### PR TITLE
feat(parquet): Add `ParquetPushDecoder::into_builder` to allow swapping projections / row filters at row group boundaries

### DIFF
--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -111,11 +111,11 @@ pub struct ArrowReaderBuilder<T> {
     /// The "input" to read parquet data from.
     ///
     /// Note in the case of the [`ParquetPushDecoderBuilder`] there is no
-    /// underlying reader; the input is instead [`PushInput`], the buffer that
+    /// underlying reader; the input is instead [`PushDecoderInput`], the buffer that
     /// caller-pushed bytes accumulate in.
     ///
     /// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
-    /// [`PushInput`]: crate::arrow::push_decoder::PushInput
+    /// [`PushDecoderInput`]: crate::arrow::push_decoder::PushDecoderInput
     pub(crate) input: T,
 
     pub(crate) metadata: Arc<ParquetMetaData>,

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -110,11 +110,12 @@ pub const DEFAULT_BATCH_SIZE: usize = 1024;
 pub struct ArrowReaderBuilder<T> {
     /// The "input" to read parquet data from.
     ///
-    /// Note in the case of the [`ParquetPushDecoderBuilder`], there
-    /// is no underlying input, which is indicated by a type parameter of [`NoInput`]
+    /// Note in the case of the [`ParquetPushDecoderBuilder`] there is no
+    /// underlying reader; the input is instead [`PushInput`], the buffer that
+    /// caller-pushed bytes accumulate in.
     ///
     /// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
-    /// [`NoInput`]: crate::arrow::push_decoder::NoInput
+    /// [`PushInput`]: crate::arrow::push_decoder::PushInput
     pub(crate) input: T,
 
     pub(crate) metadata: Arc<ParquetMetaData>,

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -600,7 +600,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
         let projected_schema = Arc::new(Schema::new(projected_fields));
 
         let decoder = ParquetPushDecoderBuilder {
-            input: NoInput,
+            input: NoInput::default(),
             metadata,
             schema,
             fields,

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -54,7 +54,7 @@ pub use metadata::*;
 mod store;
 
 use crate::DecodeResult;
-use crate::arrow::push_decoder::{NoInput, ParquetPushDecoder, ParquetPushDecoderBuilder};
+use crate::arrow::push_decoder::{ParquetPushDecoder, ParquetPushDecoderBuilder, PushInput};
 #[cfg(feature = "object_store")]
 pub use store::*;
 
@@ -600,7 +600,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
         let projected_schema = Arc::new(Schema::new(projected_fields));
 
         let decoder = ParquetPushDecoderBuilder {
-            input: NoInput::default(),
+            input: PushInput::default(),
             metadata,
             schema,
             fields,

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -54,7 +54,7 @@ pub use metadata::*;
 mod store;
 
 use crate::DecodeResult;
-use crate::arrow::push_decoder::{ParquetPushDecoder, ParquetPushDecoderBuilder, PushInput};
+use crate::arrow::push_decoder::{ParquetPushDecoder, ParquetPushDecoderBuilder, PushDecoderInput};
 #[cfg(feature = "object_store")]
 pub use store::*;
 
@@ -600,7 +600,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
         let projected_schema = Arc::new(Schema::new(projected_fields));
 
         let decoder = ParquetPushDecoderBuilder {
-            input: PushInput::default(),
+            input: PushDecoderInput::default(),
             metadata,
             schema,
             fields,

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -406,16 +406,14 @@ impl ParquetPushDecoder {
     /// Returns `Err(ParquetError::General)` when called outside a row-group
     /// boundary; check [`Self::can_swap_strategy`] first.
     ///
-    /// The decoder's [`PushBuffers`] are preserved across the swap. Bytes
-    /// that have already been fetched for columns the new strategy still
-    /// needs will not be re-requested. Bytes for columns the new strategy
-    /// no longer needs remain buffered until [`Self::clear_all_ranges`] is
-    /// called or the decoder is dropped.
+    /// The decoder's internal `PushBuffers` are preserved across the swap.
+    /// Bytes that have already been fetched for columns the new strategy
+    /// still needs will not be re-requested. Bytes for columns the new
+    /// strategy no longer needs remain buffered until
+    /// [`Self::clear_all_ranges`] is called or the decoder is dropped.
     ///
     /// Limit, offset, batch size, metadata, fields, and predicate-cache size
     /// are unchanged by a swap.
-    ///
-    /// [`PushBuffers`]: crate::util::push_buffers::PushBuffers
     pub fn swap_strategy(&mut self, swap: StrategySwap) -> Result<(), ParquetError> {
         self.state.swap_strategy(swap)
     }

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -22,18 +22,16 @@ mod reader_builder;
 mod remaining;
 
 use crate::DecodeResult;
-use crate::arrow::ProjectionMask;
 use crate::arrow::arrow_reader::{
     ArrowReaderBuilder, ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReader,
-    RowFilter, RowSelectionPolicy,
 };
 use crate::errors::ParquetError;
 use crate::file::metadata::ParquetMetaData;
 use crate::util::push_buffers::PushBuffers;
 use arrow_array::RecordBatch;
 use bytes::Bytes;
-use reader_builder::{RowBudget, RowGroupReaderBuilder};
-use remaining::RemainingRowGroups;
+use reader_builder::{RowBudget, RowGroupReaderBuilder, RowGroupReaderBuilderParts};
+use remaining::{RemainingRowGroups, RemainingRowGroupsParts};
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -111,6 +109,17 @@ use std::sync::Arc;
 ///         }
 ///     }
 /// ```
+///
+/// # Adaptive scans
+///
+/// The scan strategy is not fixed once [`build`](Self::build) is called. Drive
+/// the decoder with [`ParquetPushDecoder::try_next_reader`] — which returns
+/// once per row group, leaving a clean window between row groups — and at any
+/// such boundary call [`ParquetPushDecoder::into_builder`] to recover a
+/// builder, change any option (projection, row filter, …), and
+/// [`build`](Self::build) a fresh decoder that resumes from the next row group.
+/// This is how a query engine can promote or demote filters based on the
+/// selectivity observed in the row groups decoded so far.
 pub type ParquetPushDecoderBuilder = ArrowReaderBuilder<NoInput>;
 
 /// Type that represents "No input" for the [`ParquetPushDecoderBuilder`]
@@ -166,7 +175,7 @@ impl ParquetPushDecoderBuilder {
         let Self {
             input: NoInput,
             metadata: parquet_metadata,
-            schema: _,
+            schema,
             fields,
             batch_size,
             row_groups,
@@ -204,6 +213,7 @@ impl ParquetPushDecoderBuilder {
 
         // Initialize the decoder with the configured options
         let remaining_row_groups = RemainingRowGroups::new(
+            schema,
             parquet_metadata,
             row_groups,
             selection,
@@ -217,6 +227,56 @@ impl ParquetPushDecoderBuilder {
                 remaining_row_groups: Box::new(remaining_row_groups),
             },
         })
+    }
+}
+
+/// Reassemble a [`ParquetPushDecoderBuilder`] from the not-yet-decoded state of
+/// a [`ParquetPushDecoder`].
+///
+/// This is the inverse of [`ParquetPushDecoderBuilder::build`]: `build`
+/// destructures a builder into decoder state, this reconstructs a builder from
+/// the decoder state that remains. The reconstructed builder is configured for
+/// exactly the row groups, row selection, and offset/limit budget that have not
+/// yet been decoded, so re-`build`ing it resumes the scan where the decoder
+/// left off.
+fn builder_from_remaining(parts: RemainingRowGroupsParts) -> ParquetPushDecoderBuilder {
+    let RemainingRowGroupsParts {
+        schema,
+        row_groups,
+        selection,
+        offset,
+        limit,
+        reader_builder,
+    } = parts;
+    let RowGroupReaderBuilderParts {
+        batch_size,
+        projection,
+        metadata,
+        fields,
+        filter,
+        max_predicate_cache_size,
+        metrics,
+        row_selection_policy,
+    } = reader_builder;
+
+    ArrowReaderBuilder {
+        input: NoInput,
+        metadata,
+        schema,
+        fields,
+        batch_size,
+        // The frontier tracks remaining row groups explicitly, so the rebuilt
+        // builder always pins them (even if the original left `row_groups` as
+        // `None` meaning "all").
+        row_groups: Some(row_groups),
+        projection,
+        filter,
+        selection,
+        row_selection_policy,
+        limit,
+        offset,
+        metrics,
+        max_predicate_cache_size,
     }
 }
 
@@ -380,8 +440,8 @@ impl ParquetPushDecoder {
         self.state.clear_all_ranges();
     }
 
-    /// True iff the decoder is at a row-group boundary and a
-    /// [`Self::swap_strategy`] call would succeed.
+    /// True iff the decoder is at a row-group boundary, where
+    /// [`Self::into_builder`] can reconfigure the scan.
     ///
     /// A boundary is "between row groups": the previous row group's
     /// [`ParquetRecordBatchReader`] has been fully extracted (via
@@ -390,88 +450,68 @@ impl ParquetPushDecoder {
     /// [`Self::try_decode`] is iterating an active row group's reader this
     /// returns `false`; with [`Self::try_next_reader`] there is a clean
     /// window between two consecutive returns where this is `true`.
-    pub fn can_swap_strategy(&self) -> bool {
-        self.state.can_swap_strategy()
+    pub fn is_at_row_group_boundary(&self) -> bool {
+        self.state.is_at_row_group_boundary()
     }
 
     /// Number of row groups left to decode after the one currently in flight.
-    /// Useful as a "should I bother computing a new strategy?" signal.
+    /// Useful as a "should I bother reconfiguring the scan?" signal.
     pub fn row_groups_remaining(&self) -> usize {
         self.state.row_groups_remaining()
     }
 
-    /// Replace projection / row filter / row selection policy for subsequent
-    /// row groups.
+    /// Decompose this decoder back into a [`ParquetPushDecoderBuilder`] for the
+    /// row groups that have *not* yet been decoded.
     ///
-    /// Returns `Err(ParquetError::General)` when called outside a row-group
-    /// boundary; check [`Self::can_swap_strategy`] first.
+    /// This is the API for *adaptive* scans. Drive the decoder with
+    /// [`Self::try_next_reader`]; at any row-group boundary, call
+    /// `into_builder` to recover a builder, adjust it with the usual
+    /// [`ParquetPushDecoderBuilder`] setters, and
+    /// [`build`](ParquetPushDecoderBuilder::build) a fresh decoder that resumes
+    /// from the next row group:
     ///
-    /// The decoder's internal `PushBuffers` are preserved across the swap.
-    /// Bytes that have already been fetched for columns the new strategy
-    /// still needs will not be re-requested. Bytes for columns the new
-    /// strategy no longer needs remain buffered until
-    /// [`Self::clear_all_ranges`] is called or the decoder is dropped.
+    /// ```no_run
+    /// # use parquet::arrow::push_decoder::ParquetPushDecoder;
+    /// # use parquet::arrow::arrow_reader::RowFilter;
+    /// # fn get_decoder() -> ParquetPushDecoder { unimplemented!() }
+    /// # fn new_filter() -> RowFilter { unimplemented!() }
+    /// let mut decoder = get_decoder();
+    /// // ... drive `decoder.try_next_reader()` for a few row groups ...
+    /// if decoder.is_at_row_group_boundary() && decoder.row_groups_remaining() > 0 {
+    ///     decoder = decoder
+    ///         .into_builder()
+    ///         .unwrap()
+    ///         // any builder option can be changed here, e.g. promote a
+    ///         // filter into a row filter based on observed selectivity
+    ///         .with_row_filter(new_filter())
+    ///         .build()
+    ///         .unwrap();
+    /// }
+    /// ```
     ///
-    /// Limit, offset, batch size, metadata, fields, and predicate-cache size
-    /// are unchanged by a swap.
-    pub fn swap_strategy(&mut self, swap: StrategySwap) -> Result<(), ParquetError> {
-        self.state.swap_strategy(swap)
-    }
-}
-
-/// Description of a strategy swap to apply via
-/// [`ParquetPushDecoder::swap_strategy`].
-///
-/// Each field is `Option`-wrapped so callers only override what they intend
-/// to change. Fields left as `None` carry their previous value through the
-/// swap.
-///
-/// [`Self::filter`] is doubly-`Option`-wrapped on purpose: the outer
-/// `Option` is "do you want to change the filter?", the inner is "set or
-/// clear?". `Some(None)` clears any previously-installed filter.
-#[derive(Debug, Default)]
-#[non_exhaustive]
-pub struct StrategySwap {
-    /// New projection mask. `None` means "leave the projection alone".
-    pub projection: Option<ProjectionMask>,
-    /// New row filter. Outer `None` means "leave the filter alone";
-    /// `Some(None)` clears the filter; `Some(Some(filter))` installs a new
-    /// one.
-    pub filter: Option<Option<RowFilter>>,
-    /// New row selection policy. `None` means "leave the policy alone".
-    pub row_selection_policy: Option<RowSelectionPolicy>,
-}
-
-impl StrategySwap {
-    /// Empty swap. No fields will be modified — chain `with_*` setters to
-    /// configure.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Set a new projection mask for subsequent row groups.
-    pub fn with_projection(mut self, projection: ProjectionMask) -> Self {
-        self.projection = Some(projection);
-        self
-    }
-
-    /// Install a new row filter (or `None` to clear) for subsequent row
-    /// groups.
-    pub fn with_filter(mut self, filter: Option<RowFilter>) -> Self {
-        self.filter = Some(filter);
-        self
-    }
-
-    /// Set a new row selection policy for subsequent row groups.
-    pub fn with_row_selection_policy(mut self, policy: RowSelectionPolicy) -> Self {
-        self.row_selection_policy = Some(policy);
-        self
-    }
-
-    /// True iff every field is `None`. A no-op swap returns successfully but
-    /// has no effect.
-    pub fn is_empty(&self) -> bool {
-        self.projection.is_none() && self.filter.is_none() && self.row_selection_policy.is_none()
+    /// The returned builder pins the not-yet-decoded row groups (via
+    /// [`with_row_groups`](ArrowReaderBuilder::with_row_groups)) and carries the
+    /// not-yet-consumed row selection and offset/limit budget, so rows from
+    /// already-decoded row groups are not produced again. Every other option —
+    /// projection, row filter, row selection policy, batch size, metrics,
+    /// predicate-cache size — is left exactly as the decoder had it and can be
+    /// overridden before [`build`](ParquetPushDecoderBuilder::build).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(ParquetError::General)` when the decoder is not at a
+    /// row-group boundary (check [`Self::is_at_row_group_boundary`] first) or
+    /// has already finished. The decoder is consumed either way.
+    ///
+    /// # Buffered bytes
+    ///
+    /// Any bytes still buffered inside the decoder are dropped; the rebuilt
+    /// decoder re-requests whatever its configuration needs via
+    /// [`DecodeResult::NeedsData`]. At a row-group boundary reached through
+    /// incremental I/O the decoder has typically already freed the consumed
+    /// bytes, so in practice little or nothing is discarded.
+    pub fn into_builder(self) -> Result<ParquetPushDecoderBuilder, ParquetError> {
+        self.state.into_builder()
     }
 }
 
@@ -696,13 +736,13 @@ impl ParquetDecoderState {
         }
     }
 
-    fn can_swap_strategy(&self) -> bool {
+    fn is_at_row_group_boundary(&self) -> bool {
         match self {
             ParquetDecoderState::ReadingRowGroup {
                 remaining_row_groups,
             } => remaining_row_groups.is_at_row_group_boundary(),
             // Mid-row-group: the active reader holds an `ArrayReader` and
-            // `ReadPlan` keyed to the *current* projection/filter; swapping
+            // `ReadPlan` keyed to the *current* projection/filter; rebuilding
             // would require throwing that work away.
             ParquetDecoderState::DecodingRowGroup { .. } => false,
             ParquetDecoderState::Finished => false,
@@ -722,47 +762,31 @@ impl ParquetDecoderState {
         }
     }
 
-    fn swap_strategy(&mut self, swap: StrategySwap) -> Result<(), ParquetError> {
-        if swap.is_empty() {
-            return Ok(());
-        }
-        let remaining = match self {
+    fn into_builder(self) -> Result<ParquetPushDecoderBuilder, ParquetError> {
+        let remaining_row_groups = match self {
             ParquetDecoderState::ReadingRowGroup {
                 remaining_row_groups,
             } => remaining_row_groups,
             ParquetDecoderState::DecodingRowGroup { .. } => {
                 return Err(ParquetError::General(
-                    "swap_strategy called while a row group is being decoded; \
-                     check can_swap_strategy() first"
+                    "into_builder called while a row group is being decoded; \
+                     check is_at_row_group_boundary() first"
                         .to_string(),
                 ));
             }
             ParquetDecoderState::Finished => {
                 return Err(ParquetError::General(
-                    "swap_strategy called on a finished decoder".to_string(),
+                    "into_builder called on a finished decoder".to_string(),
                 ));
             }
         };
-        if !remaining.is_at_row_group_boundary() {
+        if !remaining_row_groups.is_at_row_group_boundary() {
             return Err(ParquetError::General(
-                "swap_strategy called mid-row-group; check can_swap_strategy() first".to_string(),
+                "into_builder called mid-row-group; check is_at_row_group_boundary() first"
+                    .to_string(),
             ));
         }
-        let StrategySwap {
-            projection,
-            filter,
-            row_selection_policy,
-        } = swap;
-        if let Some(projection) = projection {
-            remaining.set_projection(projection)?;
-        }
-        if let Some(filter) = filter {
-            remaining.set_filter(filter)?;
-        }
-        if let Some(policy) = row_selection_policy {
-            remaining.set_row_selection_policy(policy)?;
-        }
-        Ok(())
+        Ok(builder_from_remaining(remaining_row_groups.into_parts()))
     }
 }
 
@@ -1641,18 +1665,19 @@ mod test {
         expect_finished(decoder.try_decode());
     }
 
-    /// `swap_strategy` between row groups installs a new filter for the
-    /// next row group while leaving the just-decoded row group's results
-    /// untouched.
+    /// `into_builder` between row groups recovers a builder for the
+    /// not-yet-decoded row groups; rebuilding it with a new row filter
+    /// applies that filter to the subsequent row groups while leaving the
+    /// already-decoded row group's results untouched.
     ///
     /// Adaptive callers should drive the decoder with `try_next_reader`
     /// rather than `try_decode`: `try_next_reader` returns once per row
     /// group, giving the caller a clean window between two consecutive
-    /// returns to inspect stats and call `swap_strategy`. `try_decode`
+    /// returns to inspect stats and reconfigure the scan. `try_decode`
     /// barrels through row-group boundaries and is unsuitable for in-flight
     /// strategy changes.
     #[test]
-    fn test_swap_strategy_installs_filter_between_row_groups() {
+    fn test_into_builder_installs_filter_between_row_groups() {
         let metadata = test_file_parquet_metadata();
         let schema_descr = metadata.file_metadata().schema_descr_ptr();
 
@@ -1661,9 +1686,6 @@ mod test {
             .with_batch_size(1024)
             .build()
             .unwrap();
-
-        // Prefetch the entire file so we don't have to interleave I/O with
-        // the swap. PushBuffers carries the bytes through the swap.
         decoder
             .push_range(test_file_range(), TEST_FILE_DATA.clone())
             .unwrap();
@@ -1672,19 +1694,25 @@ mod test {
         let reader0 = expect_data(decoder.try_next_reader());
         let batches0: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
         let batch0 = concat_batches(&TEST_BATCH.schema(), &batches0).unwrap();
-        assert_eq!(batch0.num_rows(), 200);
         assert_eq!(batch0, TEST_BATCH.slice(0, 200));
 
-        // We're between row groups now. Swap in a filter on column "a".
-        assert!(decoder.can_swap_strategy());
+        // We're between row groups now. Rebuild with a filter on column "a".
+        assert!(decoder.is_at_row_group_boundary());
+        assert_eq!(decoder.row_groups_remaining(), 1);
         let filter =
             ArrowPredicateFn::new(ProjectionMask::columns(&schema_descr, ["a"]), |batch| {
                 gt(batch.column(0), &Int64Array::new_scalar(250))
             });
+        let mut decoder = decoder
+            .into_builder()
+            .unwrap()
+            .with_row_filter(RowFilter::new(vec![Box::new(filter)]))
+            .build()
+            .unwrap();
+        // The rebuilt decoder starts with an empty buffer (see
+        // `test_into_builder_drops_buffered_bytes`), so re-supply the data.
         decoder
-            .swap_strategy(
-                StrategySwap::new().with_filter(Some(RowFilter::new(vec![Box::new(filter)]))),
-            )
+            .push_range(test_file_range(), TEST_FILE_DATA.clone())
             .unwrap();
 
         // Reader for row group 1 — filter applied. Column "a" in RG1 has
@@ -1692,53 +1720,66 @@ mod test {
         let reader1 = expect_data(decoder.try_next_reader());
         let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
         let batch1 = concat_batches(&TEST_BATCH.schema(), &batches1).unwrap();
-        let expected1 = TEST_BATCH.slice(251, 149);
-        assert_eq!(batch1, expected1);
+        assert_eq!(batch1, TEST_BATCH.slice(251, 149));
         expect_finished(decoder.try_next_reader());
     }
 
-    /// `swap_strategy` is rejected while a row group's reader is being
-    /// drained, and accepted again the moment we cross the boundary.
+    /// `into_builder` is rejected while a row group's reader is being
+    /// drained (`DecodingRowGroup`); the error points at
+    /// `is_at_row_group_boundary`.
     #[test]
-    fn test_swap_strategy_rejected_mid_row_group() {
+    fn test_into_builder_rejected_mid_row_group() {
         let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
             .unwrap()
             .with_batch_size(50)
             .build()
             .unwrap();
-
         decoder
             .push_range(test_file_range(), TEST_FILE_DATA.clone())
             .unwrap();
 
         // After getting the first batch, we're inside `DecodingRowGroup`:
-        // an active reader is still alive. Mid-reader is not a swap point.
+        // an active reader is still alive. Mid-reader is not a boundary.
         let _ = expect_data(decoder.try_decode());
-        assert!(!decoder.can_swap_strategy());
+        assert!(!decoder.is_at_row_group_boundary());
 
-        // Trying to swap mid-row-group is an error.
-        let err = decoder
-            .swap_strategy(
-                StrategySwap::new().with_row_selection_policy(super::RowSelectionPolicy::Mask),
-            )
-            .unwrap_err();
+        let err = decoder.into_builder().unwrap_err();
         let err_msg = format!("{err}");
         assert!(
-            err_msg.contains("can_swap_strategy"),
+            err_msg.contains("is_at_row_group_boundary"),
             "unexpected error: {err_msg}"
         );
+    }
 
-        // Empty swap is a no-op even mid-row-group.
-        decoder.swap_strategy(StrategySwap::new()).unwrap();
+    /// `into_builder` is rejected once the decoder has finished.
+    #[test]
+    fn test_into_builder_rejected_on_finished_decoder() {
+        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
+            .unwrap()
+            .build()
+            .unwrap();
+        decoder
+            .push_range(test_file_range(), TEST_FILE_DATA.clone())
+            .unwrap();
+        expect_data(decoder.try_decode());
+        expect_data(decoder.try_decode());
+        expect_finished(decoder.try_decode());
+        assert!(!decoder.is_at_row_group_boundary());
+
+        let err = decoder.into_builder().unwrap_err();
+        assert!(
+            format!("{err}").contains("finished"),
+            "unexpected error: {err}"
+        );
     }
 
     /// `try_next_reader` hands the active reader off to the caller and
     /// transitions the decoder back to `ReadingRowGroup` — so the caller
-    /// can call `swap_strategy` even while still iterating the returned
+    /// can call `into_builder` even while still holding the returned
     /// reader. (The handed-off reader has no link back to the decoder's
     /// projection/filter; it has its own `ArrayReader` and `ReadPlan`.)
     #[test]
-    fn test_swap_strategy_allowed_while_iterating_handed_off_reader() {
+    fn test_into_builder_allowed_while_iterating_handed_off_reader() {
         let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
             .unwrap()
             .with_batch_size(1024)
@@ -1750,99 +1791,83 @@ mod test {
 
         let reader0 = expect_data(decoder.try_next_reader());
         // Decoder no longer owns the reader, so it considers itself
-        // "between row groups" — swap is allowed even though the caller
-        // hasn't iterated `reader0` yet.
-        assert!(decoder.can_swap_strategy());
-        // Iterating `reader0` is independent of the decoder's state.
+        // "between row groups".
+        assert!(decoder.is_at_row_group_boundary());
+        // Recovering the builder consumes the decoder but leaves `reader0`
+        // valid: iterating it is independent of the decoder's state.
+        let _builder = decoder.into_builder().unwrap();
         let batches: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
         let batch0 = concat_batches(&TEST_BATCH.schema(), &batches).unwrap();
         assert_eq!(batch0, TEST_BATCH.slice(0, 200));
     }
 
-    /// Bytes already buffered for a column survive a projection narrowing —
-    /// the next row group should not request any new data for the column
-    /// that was *already* in the projection.
+    /// `into_builder` recovers a builder for the *remaining* row groups and
+    /// carries the not-yet-consumed offset/limit budget, so a rebuilt
+    /// decoder resumes where the original left off rather than restarting.
     #[test]
-    fn test_swap_strategy_preserves_buffered_bytes() {
-        let metadata = test_file_parquet_metadata();
-        let schema_descr = metadata.file_metadata().schema_descr_ptr();
+    fn test_into_builder_resumes_remaining_budget() {
+        // limit = 250 spans both 200-row row groups: all 200 rows of RG0
+        // plus the first 50 rows of RG1.
+        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
+            .unwrap()
+            .with_batch_size(1024)
+            .with_limit(250)
+            .build()
+            .unwrap();
+        decoder
+            .push_range(test_file_range(), TEST_FILE_DATA.clone())
+            .unwrap();
 
-        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(metadata)
+        // RG0 contributes all 200 of its rows.
+        let reader0 = expect_data(decoder.try_next_reader());
+        let batches0: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
+        let batch0 = concat_batches(&TEST_BATCH.schema(), &batches0).unwrap();
+        assert_eq!(batch0, TEST_BATCH.slice(0, 200));
+
+        // Rebuild without changing anything: the remaining 50-row limit and
+        // the not-yet-decoded RG1 must carry through.
+        assert!(decoder.is_at_row_group_boundary());
+        let mut decoder = decoder.into_builder().unwrap().build().unwrap();
+        decoder
+            .push_range(test_file_range(), TEST_FILE_DATA.clone())
+            .unwrap();
+
+        let reader1 = expect_data(decoder.try_next_reader());
+        let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
+        let batch1 = concat_batches(&TEST_BATCH.schema(), &batches1).unwrap();
+        // Only the first 50 rows of RG1 (200..249) — the rest of the limit.
+        assert_eq!(batch1, TEST_BATCH.slice(200, 50));
+        expect_finished(decoder.try_next_reader());
+    }
+
+    /// `into_builder` drops the decoder's buffered bytes: the rebuilt
+    /// decoder starts with an empty buffer and re-requests whatever its
+    /// configuration needs.
+    #[test]
+    fn test_into_builder_drops_buffered_bytes() {
+        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
             .unwrap()
             .with_batch_size(1024)
             .build()
             .unwrap();
 
-        // Prefetch the whole file once.
+        // Prefetch the whole file, then drain RG0.
         decoder
             .push_range(test_file_range(), TEST_FILE_DATA.clone())
             .unwrap();
         assert_eq!(decoder.buffered_bytes(), test_file_len());
-
-        // Drain RG0 with full projection via try_next_reader.
         let reader0 = expect_data(decoder.try_next_reader());
         let _: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
+        // RG1's bytes are still staged inside the decoder.
+        assert!(decoder.buffered_bytes() > 0);
 
-        // Narrow projection to just column "a" for RG1.
-        assert!(decoder.can_swap_strategy());
-        decoder
-            .swap_strategy(
-                StrategySwap::new().with_projection(ProjectionMask::columns(&schema_descr, ["a"])),
-            )
-            .unwrap();
+        // Rebuilding via into_builder discards them.
+        let mut decoder = decoder.into_builder().unwrap().build().unwrap();
+        assert_eq!(decoder.buffered_bytes(), 0);
 
-        // Column "a" bytes for RG1 were part of the original wide
-        // projection's prefetch; we should not need additional data.
-        let reader1 = expect_data(decoder.try_next_reader());
-        let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
-        // Schema is now just "a"; RG1 has values 200..399.
-        let expected1 = TEST_BATCH.slice(200, 200).project(&[0]).unwrap();
-        let batch1 = concat_batches(&batches1[0].schema(), &batches1).unwrap();
-        assert_eq!(batch1, expected1);
-        expect_finished(decoder.try_next_reader());
-    }
-
-    /// Mirror of [`Self::test_swap_strategy_preserves_buffered_bytes`] in the
-    /// opposite direction: start with a narrow projection, drain RG0, then
-    /// widen the projection to add columns "b" and "c". Because the entire
-    /// file was prefetched, bytes for the newly-added columns are already
-    /// buffered and the next row group decodes without another `NeedsData`.
-    #[test]
-    fn test_swap_strategy_expands_projection_between_row_groups() {
-        let metadata = test_file_parquet_metadata();
-        let schema_descr = metadata.file_metadata().schema_descr_ptr();
-
-        let builder = ParquetPushDecoderBuilder::try_new_decoder(metadata)
-            .unwrap()
-            .with_batch_size(1024);
-        let mut decoder = builder
-            .with_projection(ProjectionMask::columns(&schema_descr, ["a"]))
-            .build()
-            .unwrap();
-
-        // Prefetch the whole file up front.
-        decoder
-            .push_range(test_file_range(), TEST_FILE_DATA.clone())
-            .unwrap();
-
-        // RG0 with narrow projection — just column "a".
-        let reader0 = expect_data(decoder.try_next_reader());
-        let batches0: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
-        let batch0 = concat_batches(&batches0[0].schema(), &batches0).unwrap();
-        let expected0 = TEST_BATCH.slice(0, 200).project(&[0]).unwrap();
-        assert_eq!(batch0, expected0);
-
-        // At the boundary, widen to all three columns.
-        assert!(decoder.can_swap_strategy());
-        decoder
-            .swap_strategy(
-                StrategySwap::new()
-                    .with_projection(ProjectionMask::columns(&schema_descr, ["a", "b", "c"])),
-            )
-            .unwrap();
-
-        // Bytes for "b" and "c" in RG1 were part of the prefetch, so no
-        // further data should be requested.
+        // So RG1 must be fetched again before it can be decoded.
+        let ranges = expect_needs_data(decoder.try_next_reader());
+        push_ranges_to_decoder(&mut decoder, ranges);
         let reader1 = expect_data(decoder.try_next_reader());
         let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
         let batch1 = concat_batches(&TEST_BATCH.schema(), &batches1).unwrap();
@@ -1850,15 +1875,15 @@ mod test {
         expect_finished(decoder.try_next_reader());
     }
 
-    /// Drive the decoder incrementally (no prefetch). Start with a narrow
-    /// projection, drain RG0 by satisfying its `NeedsData`, then widen the
-    /// projection to add columns "b" and "c". The post-swap `NeedsData`
-    /// for RG1 must request bytes for *all three* columns, not just the
-    /// originally-projected "a". The expected ranges are hardcoded
-    /// because `TEST_BATCH` and the writer settings are static; this
-    /// pins the layout cleanly without a parallel reference decoder.
+    /// Drive the decoder incrementally. Start with a narrow projection,
+    /// drain RG0, then `into_builder` and widen the projection to all three
+    /// columns. The rebuilt decoder's `NeedsData` for RG1 must request
+    /// bytes for *all three* columns, not just the originally-projected
+    /// "a". The expected ranges are hardcoded because `TEST_BATCH` and the
+    /// writer settings are static; this pins the layout cleanly without a
+    /// parallel reference decoder.
     #[test]
-    fn test_swap_strategy_expand_projection_requests_new_bytes() {
+    fn test_into_builder_expand_projection_requests_new_bytes() {
         let metadata = test_file_parquet_metadata();
         let schema_descr = metadata.file_metadata().schema_descr_ptr();
 
@@ -1869,33 +1894,28 @@ mod test {
             .build()
             .unwrap();
 
-        // RG0: incrementally satisfy the narrow request.
+        // RG0: incrementally satisfy the narrow request — a single
+        // contiguous range for the "a"-only projection.
         let ranges_rg0 = expect_needs_data(decoder.try_next_reader());
-        // For a narrow ("a"-only) projection, RG0 is a single contiguous range.
         assert_eq!(ranges_rg0, vec![4..1860]);
         push_ranges_to_decoder(&mut decoder, ranges_rg0);
 
         let reader0 = expect_data(decoder.try_next_reader());
         let batches0: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
         let batch0 = concat_batches(&batches0[0].schema(), &batches0).unwrap();
-        let expected0 = TEST_BATCH.slice(0, 200).project(&[0]).unwrap();
-        assert_eq!(batch0, expected0);
-        // RG0's "a" pages have been consumed; no surviving buffer.
-        assert_eq!(decoder.buffered_bytes(), 0);
+        assert_eq!(batch0, TEST_BATCH.slice(0, 200).project(&[0]).unwrap());
 
         // Widen the projection at the boundary.
-        assert!(decoder.can_swap_strategy());
-        decoder
-            .swap_strategy(
-                StrategySwap::new()
-                    .with_projection(ProjectionMask::columns(&schema_descr, ["a", "b", "c"])),
-            )
+        assert!(decoder.is_at_row_group_boundary());
+        let mut decoder = decoder
+            .into_builder()
+            .unwrap()
+            .with_projection(ProjectionMask::columns(&schema_descr, ["a", "b", "c"]))
+            .build()
             .unwrap();
 
-        // Post-swap RG1 request covers RG1's "a", "b", and "c" column
-        // chunks: ~1.8KiB each for "a" and "b", ~7.5KiB for the
-        // StringView column "c". Total 11168 bytes — far more than the
-        // 1856 bytes the narrow projection asked for in RG0.
+        // RG1 now requests "a", "b", and "c" column chunks: ~1.8KiB each
+        // for "a" and "b", ~7.5KiB for the StringView column "c".
         let ranges_rg1 = expect_needs_data(decoder.try_next_reader());
         assert_eq!(ranges_rg1, vec![11062..12918, 12918..14774, 14774..22230]);
         push_ranges_to_decoder(&mut decoder, ranges_rg1);
@@ -1907,14 +1927,13 @@ mod test {
         expect_finished(decoder.try_next_reader());
     }
 
-    /// Drive the decoder incrementally (no prefetch). Start with the full
-    /// projection, drain RG0 by satisfying its `NeedsData`, then narrow
-    /// the projection to just column "a". The post-swap `NeedsData` for
-    /// RG1 must request bytes for *only* column "a" — the same single
-    /// range a narrow projection would have asked for, not the three
-    /// ranges a wide projection would.
+    /// Mirror of [`test_into_builder_expand_projection_requests_new_bytes`]:
+    /// start with the full projection, drain RG0, then `into_builder` and
+    /// narrow the projection to just column "a". RG1's `NeedsData` must
+    /// request only the single "a" column-chunk range, not the three a
+    /// wide projection would.
     #[test]
-    fn test_swap_strategy_narrow_projection_skips_unneeded_bytes() {
+    fn test_into_builder_narrow_projection_requests_fewer_bytes() {
         let metadata = test_file_parquet_metadata();
         let schema_descr = metadata.file_metadata().schema_descr_ptr();
 
@@ -1924,7 +1943,7 @@ mod test {
             .build()
             .unwrap();
 
-        // RG0 with default (full) projection — three columns; three ranges.
+        // RG0 with the default (full) projection — three column ranges.
         let ranges_rg0 = expect_needs_data(decoder.try_next_reader());
         assert_eq!(ranges_rg0, vec![4..1860, 1860..3716, 3716..11062]);
         push_ranges_to_decoder(&mut decoder, ranges_rg0);
@@ -1933,19 +1952,17 @@ mod test {
         let batches0: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
         let batch0 = concat_batches(&TEST_BATCH.schema(), &batches0).unwrap();
         assert_eq!(batch0, TEST_BATCH.slice(0, 200));
-        assert_eq!(decoder.buffered_bytes(), 0);
 
         // Narrow the projection at the boundary.
-        assert!(decoder.can_swap_strategy());
-        decoder
-            .swap_strategy(
-                StrategySwap::new().with_projection(ProjectionMask::columns(&schema_descr, ["a"])),
-            )
+        assert!(decoder.is_at_row_group_boundary());
+        let mut decoder = decoder
+            .into_builder()
+            .unwrap()
+            .with_projection(ProjectionMask::columns(&schema_descr, ["a"]))
+            .build()
             .unwrap();
 
-        // Post-swap RG1 request asks for column "a" only — a single
-        // 1856-byte range, not the three column-chunk ranges the wide
-        // projection would have produced.
+        // RG1 now requests column "a" only — a single 1856-byte range.
         let ranges_rg1 = expect_needs_data(decoder.try_next_reader());
         assert_eq!(ranges_rg1, vec![11062..12918]);
         push_ranges_to_decoder(&mut decoder, ranges_rg1);
@@ -1953,8 +1970,7 @@ mod test {
         let reader1 = expect_data(decoder.try_next_reader());
         let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
         let batch1 = concat_batches(&batches1[0].schema(), &batches1).unwrap();
-        let expected1 = TEST_BATCH.slice(200, 200).project(&[0]).unwrap();
-        assert_eq!(batch1, expected1);
+        assert_eq!(batch1, TEST_BATCH.slice(200, 200).project(&[0]).unwrap());
         expect_finished(decoder.try_next_reader());
     }
 

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -190,35 +190,24 @@ use std::sync::Arc;
 ///     }
 /// }
 /// ```
-pub type ParquetPushDecoderBuilder = ArrowReaderBuilder<NoInput>;
+pub type ParquetPushDecoderBuilder = ArrowReaderBuilder<PushInput>;
 
-/// The `input` slot of a [`ParquetPushDecoderBuilder`].
+/// The `input` of a [`ParquetPushDecoderBuilder`].
 ///
-/// [`ArrowReaderBuilder`] is shared by the sync, async, and push decoders.
-/// The sync and async builders put a real input there — a file or async
-/// reader — to read from. The push decoder has no reader, by design: the
-/// caller pushes bytes in. So its slot instead holds the `PushBuffers` those
-/// pushed bytes accumulate in.
+/// [`ArrowReaderBuilder`] is shared by the sync, async, and push decoders, so
+/// it is generic over an `input`. The sync and async builders read from a
+/// real input — a file or an async reader. The push decoder has no reader, by
+/// design: the caller pushes bytes in. Its input is therefore the buffer
+/// those pushed bytes accumulate in.
 ///
-/// A fresh builder starts with empty buffers.
-/// [`ParquetPushDecoder::into_builder`] threads an existing decoder's buffers
+/// A fresh builder starts with an empty buffer;
+/// [`ParquetPushDecoder::into_builder`] threads an existing decoder's buffer
 /// back through so a rebuilt decoder keeps the bytes it already holds.
-///
-/// The name predates the buffer-carrying behaviour; it still reads as "no
-/// *reader* input".
-#[derive(Debug)]
-pub struct NoInput {
-    /// Bytes pushed into the decoder, awaiting decode.
+#[derive(Debug, Default)]
+pub struct PushInput {
+    /// Bytes pushed into the decoder, awaiting decode. Empty for a fresh
+    /// builder; carried over by [`ParquetPushDecoder::into_builder`].
     buffers: PushBuffers,
-}
-
-impl Default for NoInput {
-    fn default() -> Self {
-        // The file length is unused by the push decoder's buffer tracking.
-        Self {
-            buffers: PushBuffers::new(0),
-        }
-    }
 }
 
 /// Methods for building a ParquetDecoder. See the base [`ArrowReaderBuilder`] for
@@ -254,7 +243,7 @@ impl ParquetPushDecoderBuilder {
     /// See [`ArrowReaderMetadata::try_new`] for how to create the metadata from
     /// the Parquet metadata and reader options.
     pub fn new_with_metadata(arrow_reader_metadata: ArrowReaderMetadata) -> Self {
-        Self::new_builder(NoInput::default(), arrow_reader_metadata)
+        Self::new_builder(PushInput::default(), arrow_reader_metadata)
     }
 
     /// Reuse a [`PushBuffers`] when [`build`](Self::build)ing the decoder so
@@ -266,7 +255,7 @@ impl ParquetPushDecoderBuilder {
     /// [`ParquetPushDecoder::push_ranges`] instead.
     pub(crate) fn with_buffers(self, buffers: PushBuffers) -> Self {
         Self {
-            input: NoInput { buffers },
+            input: PushInput { buffers },
             ..self
         }
     }
@@ -274,7 +263,7 @@ impl ParquetPushDecoderBuilder {
     /// Create a [`ParquetPushDecoder`] with the configured options
     pub fn build(self) -> Result<ParquetPushDecoder, ParquetError> {
         let Self {
-            input: NoInput { buffers },
+            input: PushInput { buffers },
             metadata: parquet_metadata,
             schema,
             fields,
@@ -362,7 +351,7 @@ fn builder_from_remaining(parts: RemainingRowGroupsParts) -> ParquetPushDecoderB
     } = reader_builder;
 
     ArrowReaderBuilder {
-        input: NoInput::default(),
+        input: PushInput::default(),
         metadata,
         schema,
         fields,

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -1802,6 +1802,162 @@ mod test {
         expect_finished(decoder.try_next_reader());
     }
 
+    /// Mirror of [`Self::test_swap_strategy_preserves_buffered_bytes`] in the
+    /// opposite direction: start with a narrow projection, drain RG0, then
+    /// widen the projection to add columns "b" and "c". Because the entire
+    /// file was prefetched, bytes for the newly-added columns are already
+    /// buffered and the next row group decodes without another `NeedsData`.
+    #[test]
+    fn test_swap_strategy_expands_projection_between_row_groups() {
+        let metadata = test_file_parquet_metadata();
+        let schema_descr = metadata.file_metadata().schema_descr_ptr();
+
+        let builder = ParquetPushDecoderBuilder::try_new_decoder(metadata)
+            .unwrap()
+            .with_batch_size(1024);
+        let mut decoder = builder
+            .with_projection(ProjectionMask::columns(&schema_descr, ["a"]))
+            .build()
+            .unwrap();
+
+        // Prefetch the whole file up front.
+        decoder
+            .push_range(test_file_range(), TEST_FILE_DATA.clone())
+            .unwrap();
+
+        // RG0 with narrow projection — just column "a".
+        let reader0 = expect_data(decoder.try_next_reader());
+        let batches0: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
+        let batch0 = concat_batches(&batches0[0].schema(), &batches0).unwrap();
+        let expected0 = TEST_BATCH.slice(0, 200).project(&[0]).unwrap();
+        assert_eq!(batch0, expected0);
+
+        // At the boundary, widen to all three columns.
+        assert!(decoder.can_swap_strategy());
+        decoder
+            .swap_strategy(
+                StrategySwap::new()
+                    .with_projection(ProjectionMask::columns(&schema_descr, ["a", "b", "c"])),
+            )
+            .unwrap();
+
+        // Bytes for "b" and "c" in RG1 were part of the prefetch, so no
+        // further data should be requested.
+        let reader1 = expect_data(decoder.try_next_reader());
+        let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
+        let batch1 = concat_batches(&TEST_BATCH.schema(), &batches1).unwrap();
+        assert_eq!(batch1, TEST_BATCH.slice(200, 200));
+        expect_finished(decoder.try_next_reader());
+    }
+
+    /// Drive the decoder incrementally (no prefetch). Start with a narrow
+    /// projection, drain RG0 by satisfying its `NeedsData`, then widen the
+    /// projection to add columns "b" and "c". The post-swap `NeedsData`
+    /// for RG1 must request bytes for *all three* columns, not just the
+    /// originally-projected "a". The expected ranges are hardcoded
+    /// because `TEST_BATCH` and the writer settings are static; this
+    /// pins the layout cleanly without a parallel reference decoder.
+    #[test]
+    fn test_swap_strategy_expand_projection_requests_new_bytes() {
+        let metadata = test_file_parquet_metadata();
+        let schema_descr = metadata.file_metadata().schema_descr_ptr();
+
+        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(metadata)
+            .unwrap()
+            .with_batch_size(1024)
+            .with_projection(ProjectionMask::columns(&schema_descr, ["a"]))
+            .build()
+            .unwrap();
+
+        // RG0: incrementally satisfy the narrow request.
+        let ranges_rg0 = expect_needs_data(decoder.try_next_reader());
+        // For a narrow ("a"-only) projection, RG0 is a single contiguous range.
+        assert_eq!(ranges_rg0, vec![4..1860]);
+        push_ranges_to_decoder(&mut decoder, ranges_rg0);
+
+        let reader0 = expect_data(decoder.try_next_reader());
+        let batches0: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
+        let batch0 = concat_batches(&batches0[0].schema(), &batches0).unwrap();
+        let expected0 = TEST_BATCH.slice(0, 200).project(&[0]).unwrap();
+        assert_eq!(batch0, expected0);
+        // RG0's "a" pages have been consumed; no surviving buffer.
+        assert_eq!(decoder.buffered_bytes(), 0);
+
+        // Widen the projection at the boundary.
+        assert!(decoder.can_swap_strategy());
+        decoder
+            .swap_strategy(
+                StrategySwap::new()
+                    .with_projection(ProjectionMask::columns(&schema_descr, ["a", "b", "c"])),
+            )
+            .unwrap();
+
+        // Post-swap RG1 request covers RG1's "a", "b", and "c" column
+        // chunks: ~1.8KiB each for "a" and "b", ~7.5KiB for the
+        // StringView column "c". Total 11168 bytes — far more than the
+        // 1856 bytes the narrow projection asked for in RG0.
+        let ranges_rg1 = expect_needs_data(decoder.try_next_reader());
+        assert_eq!(ranges_rg1, vec![11062..12918, 12918..14774, 14774..22230]);
+        push_ranges_to_decoder(&mut decoder, ranges_rg1);
+
+        let reader1 = expect_data(decoder.try_next_reader());
+        let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
+        let batch1 = concat_batches(&TEST_BATCH.schema(), &batches1).unwrap();
+        assert_eq!(batch1, TEST_BATCH.slice(200, 200));
+        expect_finished(decoder.try_next_reader());
+    }
+
+    /// Drive the decoder incrementally (no prefetch). Start with the full
+    /// projection, drain RG0 by satisfying its `NeedsData`, then narrow
+    /// the projection to just column "a". The post-swap `NeedsData` for
+    /// RG1 must request bytes for *only* column "a" — the same single
+    /// range a narrow projection would have asked for, not the three
+    /// ranges a wide projection would.
+    #[test]
+    fn test_swap_strategy_narrow_projection_skips_unneeded_bytes() {
+        let metadata = test_file_parquet_metadata();
+        let schema_descr = metadata.file_metadata().schema_descr_ptr();
+
+        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(metadata)
+            .unwrap()
+            .with_batch_size(1024)
+            .build()
+            .unwrap();
+
+        // RG0 with default (full) projection — three columns; three ranges.
+        let ranges_rg0 = expect_needs_data(decoder.try_next_reader());
+        assert_eq!(ranges_rg0, vec![4..1860, 1860..3716, 3716..11062]);
+        push_ranges_to_decoder(&mut decoder, ranges_rg0);
+
+        let reader0 = expect_data(decoder.try_next_reader());
+        let batches0: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
+        let batch0 = concat_batches(&TEST_BATCH.schema(), &batches0).unwrap();
+        assert_eq!(batch0, TEST_BATCH.slice(0, 200));
+        assert_eq!(decoder.buffered_bytes(), 0);
+
+        // Narrow the projection at the boundary.
+        assert!(decoder.can_swap_strategy());
+        decoder
+            .swap_strategy(
+                StrategySwap::new().with_projection(ProjectionMask::columns(&schema_descr, ["a"])),
+            )
+            .unwrap();
+
+        // Post-swap RG1 request asks for column "a" only — a single
+        // 1856-byte range, not the three column-chunk ranges the wide
+        // projection would have produced.
+        let ranges_rg1 = expect_needs_data(decoder.try_next_reader());
+        assert_eq!(ranges_rg1, vec![11062..12918]);
+        push_ranges_to_decoder(&mut decoder, ranges_rg1);
+
+        let reader1 = expect_data(decoder.try_next_reader());
+        let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
+        let batch1 = concat_batches(&batches1[0].schema(), &batches1).unwrap();
+        let expected1 = TEST_BATCH.slice(200, 200).project(&[0]).unwrap();
+        assert_eq!(batch1, expected1);
+        expect_finished(decoder.try_next_reader());
+    }
+
     /// Returns a batch with 400 rows, with 3 columns: "a", "b", "c"
     ///
     /// Note c is a different types (so the data page sizes will be different)

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -27,7 +27,7 @@ use crate::arrow::arrow_reader::{
 };
 use crate::errors::ParquetError;
 use crate::file::metadata::ParquetMetaData;
-use crate::util::push_buffers::PushBuffers;
+pub use crate::util::push_buffers::PushBuffers;
 use arrow_array::RecordBatch;
 use bytes::Bytes;
 use reader_builder::{RowBudget, RowGroupReaderBuilder, RowGroupReaderBuilderParts};
@@ -190,23 +190,17 @@ use std::sync::Arc;
 ///     }
 /// }
 /// ```
-pub type ParquetPushDecoderBuilder = ArrowReaderBuilder<PushInput>;
+pub type ParquetPushDecoderBuilder = ArrowReaderBuilder<PushDecoderInput>;
 
 /// The `input` of a [`ParquetPushDecoderBuilder`].
 ///
-/// [`ArrowReaderBuilder`] is shared by the sync, async, and push decoders, so
-/// it is generic over an `input`. The sync and async builders read from a
-/// real input — a file or an async reader. The push decoder has no reader, by
-/// design: the caller pushes bytes in. Its input is therefore the buffer
-/// those pushed bytes accumulate in.
-///
-/// A fresh builder starts with an empty buffer;
-/// [`ParquetPushDecoder::into_builder`] threads an existing decoder's buffer
-/// back through so a rebuilt decoder keeps the bytes it already holds.
+/// The shared [`ArrowReaderBuilder`] is generic over an `input`. The sync and
+/// async builders read from a file or async reader; the push decoder has no
+/// reader, so its input is the [`PushBuffers`] that caller-pushed bytes
+/// accumulate in (empty for a fresh builder).
 #[derive(Debug, Default)]
-pub struct PushInput {
-    /// Bytes pushed into the decoder, awaiting decode. Empty for a fresh
-    /// builder; carried over by [`ParquetPushDecoder::into_builder`].
+pub struct PushDecoderInput {
+    /// Bytes pushed into the decoder, awaiting decode.
     buffers: PushBuffers,
 }
 
@@ -243,19 +237,14 @@ impl ParquetPushDecoderBuilder {
     /// See [`ArrowReaderMetadata::try_new`] for how to create the metadata from
     /// the Parquet metadata and reader options.
     pub fn new_with_metadata(arrow_reader_metadata: ArrowReaderMetadata) -> Self {
-        Self::new_builder(PushInput::default(), arrow_reader_metadata)
+        Self::new_builder(PushDecoderInput::default(), arrow_reader_metadata)
     }
 
-    /// Reuse a [`PushBuffers`] when [`build`](Self::build)ing the decoder so
-    /// that bytes already fetched are not requested again.
-    ///
-    /// This is how [`ParquetPushDecoder::into_builder`] carries a decoder's
-    /// buffered bytes across a rebuild. It is `pub(crate)` because
-    /// [`PushBuffers`] is an internal type; callers seed a fresh decoder with
-    /// [`ParquetPushDecoder::push_ranges`] instead.
-    pub(crate) fn with_buffers(self, buffers: PushBuffers) -> Self {
+    /// Provide a preexisting [`PushBuffers`] for the built decoder to read
+    /// from, so bytes already fetched are not requested again.
+    pub fn with_buffers(self, buffers: PushBuffers) -> Self {
         Self {
-            input: PushInput { buffers },
+            input: PushDecoderInput { buffers },
             ..self
         }
     }
@@ -263,7 +252,7 @@ impl ParquetPushDecoderBuilder {
     /// Create a [`ParquetPushDecoder`] with the configured options
     pub fn build(self) -> Result<ParquetPushDecoder, ParquetError> {
         let Self {
-            input: PushInput { buffers },
+            input: PushDecoderInput { buffers },
             metadata: parquet_metadata,
             schema,
             fields,
@@ -320,17 +309,13 @@ impl ParquetPushDecoderBuilder {
     }
 }
 
-/// Reassemble a [`ParquetPushDecoderBuilder`] from the not-yet-decoded state of
-/// a [`ParquetPushDecoder`].
-///
-/// This is the inverse of [`ParquetPushDecoderBuilder::build`]: `build`
-/// destructures a builder into decoder state, this reconstructs a builder from
-/// the decoder state that remains. The reconstructed builder is configured for
-/// exactly the row groups, row selection, and offset/limit budget that have not
-/// yet been decoded, and carries the decoder's buffered bytes, so re-`build`ing
-/// it resumes the scan where the decoder left off.
+/// Reassemble a [`ParquetPushDecoderBuilder`] from a decoder's not-yet-decoded
+/// state — the inverse of [`ParquetPushDecoderBuilder::build`]. The rebuilt
+/// builder pins the remaining row groups and carries the remaining row
+/// selection, offset/limit budget, and buffered bytes.
 fn builder_from_remaining(parts: RemainingRowGroupsParts) -> ParquetPushDecoderBuilder {
     let RemainingRowGroupsParts {
+        metadata,
         schema,
         row_groups,
         selection,
@@ -341,7 +326,6 @@ fn builder_from_remaining(parts: RemainingRowGroupsParts) -> ParquetPushDecoderB
     let RowGroupReaderBuilderParts {
         batch_size,
         projection,
-        metadata,
         fields,
         filter,
         max_predicate_cache_size,
@@ -351,7 +335,7 @@ fn builder_from_remaining(parts: RemainingRowGroupsParts) -> ParquetPushDecoderB
     } = reader_builder;
 
     ArrowReaderBuilder {
-        input: PushInput::default(),
+        input: PushDecoderInput::default(),
         metadata,
         schema,
         fields,
@@ -1764,25 +1748,14 @@ mod test {
     /// applies that filter to the subsequent row groups while leaving the
     /// already-decoded row group's results untouched.
     ///
-    /// Adaptive callers should drive the decoder with `try_next_reader`
-    /// rather than `try_decode`: `try_next_reader` returns once per row
-    /// group, giving the caller a clean window between two consecutive
-    /// returns to inspect stats and reconfigure the scan. `try_decode`
-    /// barrels through row-group boundaries and is unsuitable for in-flight
-    /// strategy changes.
+    /// See the "Adaptive scans" section of [`ParquetPushDecoderBuilder`] for
+    /// the high-level overview.
     #[test]
     fn test_into_builder_installs_filter_between_row_groups() {
-        let metadata = test_file_parquet_metadata();
-        let schema_descr = metadata.file_metadata().schema_descr_ptr();
-
-        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(metadata)
-            .unwrap()
-            .with_batch_size(1024)
-            .build()
-            .unwrap();
-        decoder
-            .push_range(test_file_range(), TEST_FILE_DATA.clone())
-            .unwrap();
+        let schema_descr = test_file_parquet_metadata()
+            .file_metadata()
+            .schema_descr_ptr();
+        let mut decoder = prefetched_decoder(1024);
 
         // Reader for row group 0 — no filter.
         let reader0 = expect_data(decoder.try_next_reader());
@@ -1820,18 +1793,11 @@ mod test {
     /// `is_at_row_group_boundary`.
     #[test]
     fn test_into_builder_rejected_mid_row_group() {
-        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
-            .unwrap()
-            .with_batch_size(50)
-            .build()
-            .unwrap();
-        decoder
-            .push_range(test_file_range(), TEST_FILE_DATA.clone())
-            .unwrap();
+        let mut decoder = prefetched_decoder(50);
 
-        // After getting the first batch, we're inside `DecodingRowGroup`:
-        // an active reader is still alive. Mid-reader is not a boundary.
-        let _ = expect_data(decoder.try_decode());
+        // Decode one batch to land mid-row-group, inside `DecodingRowGroup`
+        // with an active reader — not a boundary.
+        expect_data(decoder.try_decode());
         assert!(!decoder.is_at_row_group_boundary());
 
         let err = decoder.into_builder().unwrap_err();
@@ -1845,13 +1811,7 @@ mod test {
     /// `into_builder` is rejected once the decoder has finished.
     #[test]
     fn test_into_builder_rejected_on_finished_decoder() {
-        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
-            .unwrap()
-            .build()
-            .unwrap();
-        decoder
-            .push_range(test_file_range(), TEST_FILE_DATA.clone())
-            .unwrap();
+        let mut decoder = prefetched_decoder(1024);
         expect_data(decoder.try_decode());
         expect_data(decoder.try_decode());
         expect_finished(decoder.try_decode());
@@ -1871,14 +1831,7 @@ mod test {
     /// projection/filter; it has its own `ArrayReader` and `ReadPlan`.)
     #[test]
     fn test_into_builder_allowed_while_iterating_handed_off_reader() {
-        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
-            .unwrap()
-            .with_batch_size(1024)
-            .build()
-            .unwrap();
-        decoder
-            .push_range(test_file_range(), TEST_FILE_DATA.clone())
-            .unwrap();
+        let mut decoder = prefetched_decoder(1024);
 
         let reader0 = expect_data(decoder.try_next_reader());
         // Decoder no longer owns the reader, so it considers itself
@@ -1905,9 +1858,7 @@ mod test {
             .with_limit(250)
             .build()
             .unwrap();
-        decoder
-            .push_range(test_file_range(), TEST_FILE_DATA.clone())
-            .unwrap();
+        prefetch_test_file(&mut decoder);
 
         // RG0 contributes all 200 of its rows.
         let reader0 = expect_data(decoder.try_next_reader());
@@ -1934,17 +1885,10 @@ mod test {
     /// it already holds.
     #[test]
     fn test_into_builder_preserves_buffered_bytes() {
-        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
-            .unwrap()
-            .with_batch_size(1024)
-            .build()
-            .unwrap();
-
-        // Prefetch the whole file, then drain RG0.
-        decoder
-            .push_range(test_file_range(), TEST_FILE_DATA.clone())
-            .unwrap();
+        let mut decoder = prefetched_decoder(1024);
         assert_eq!(decoder.buffered_bytes(), test_file_len());
+
+        // Drain RG0.
         let reader0 = expect_data(decoder.try_next_reader());
         let _: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
         // RG1's bytes are still staged inside the decoder.
@@ -2167,6 +2111,25 @@ mod test {
             .map(|range| test_file_slice(range.clone()))
             .collect::<Vec<_>>();
         metadata_decoder.push_ranges(ranges, data).unwrap();
+    }
+
+    /// Push the entire test file into `decoder`.
+    fn prefetch_test_file(decoder: &mut ParquetPushDecoder) {
+        decoder
+            .push_range(test_file_range(), TEST_FILE_DATA.clone())
+            .unwrap();
+    }
+
+    /// Build a decoder over the test file with the given batch size and
+    /// prefetch the whole file into it.
+    fn prefetched_decoder(batch_size: usize) -> ParquetPushDecoder {
+        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
+            .unwrap()
+            .with_batch_size(batch_size)
+            .build()
+            .unwrap();
+        prefetch_test_file(&mut decoder);
+        decoder
     }
 
     fn push_ranges_to_decoder(decoder: &mut ParquetPushDecoder, ranges: Vec<Range<u64>>) {

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -22,8 +22,10 @@ mod reader_builder;
 mod remaining;
 
 use crate::DecodeResult;
+use crate::arrow::ProjectionMask;
 use crate::arrow::arrow_reader::{
     ArrowReaderBuilder, ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReader,
+    RowFilter, RowSelectionPolicy,
 };
 use crate::errors::ParquetError;
 use crate::file::metadata::ParquetMetaData;
@@ -377,6 +379,102 @@ impl ParquetPushDecoder {
     pub fn clear_all_ranges(&mut self) {
         self.state.clear_all_ranges();
     }
+
+    /// True iff the decoder is at a row-group boundary and a
+    /// [`Self::swap_strategy`] call would succeed.
+    ///
+    /// A boundary is "between row groups": the previous row group's
+    /// [`ParquetRecordBatchReader`] has been fully extracted (via
+    /// [`Self::try_next_reader`]) or fully drained (via [`Self::try_decode`]),
+    /// and the next row group has not yet been planned. While
+    /// [`Self::try_decode`] is iterating an active row group's reader this
+    /// returns `false`; with [`Self::try_next_reader`] there is a clean
+    /// window between two consecutive returns where this is `true`.
+    pub fn can_swap_strategy(&self) -> bool {
+        self.state.can_swap_strategy()
+    }
+
+    /// Number of row groups left to decode after the one currently in flight.
+    /// Useful as a "should I bother computing a new strategy?" signal.
+    pub fn row_groups_remaining(&self) -> usize {
+        self.state.row_groups_remaining()
+    }
+
+    /// Replace projection / row filter / row selection policy for subsequent
+    /// row groups.
+    ///
+    /// Returns `Err(ParquetError::General)` when called outside a row-group
+    /// boundary; check [`Self::can_swap_strategy`] first.
+    ///
+    /// The decoder's [`PushBuffers`] are preserved across the swap. Bytes
+    /// that have already been fetched for columns the new strategy still
+    /// needs will not be re-requested. Bytes for columns the new strategy
+    /// no longer needs remain buffered until [`Self::clear_all_ranges`] is
+    /// called or the decoder is dropped.
+    ///
+    /// Limit, offset, batch size, metadata, fields, and predicate-cache size
+    /// are unchanged by a swap.
+    ///
+    /// [`PushBuffers`]: crate::util::push_buffers::PushBuffers
+    pub fn swap_strategy(&mut self, swap: StrategySwap) -> Result<(), ParquetError> {
+        self.state.swap_strategy(swap)
+    }
+}
+
+/// Description of a strategy swap to apply via
+/// [`ParquetPushDecoder::swap_strategy`].
+///
+/// Each field is `Option`-wrapped so callers only override what they intend
+/// to change. Fields left as `None` carry their previous value through the
+/// swap.
+///
+/// [`Self::filter`] is doubly-`Option`-wrapped on purpose: the outer
+/// `Option` is "do you want to change the filter?", the inner is "set or
+/// clear?". `Some(None)` clears any previously-installed filter.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct StrategySwap {
+    /// New projection mask. `None` means "leave the projection alone".
+    pub projection: Option<ProjectionMask>,
+    /// New row filter. Outer `None` means "leave the filter alone";
+    /// `Some(None)` clears the filter; `Some(Some(filter))` installs a new
+    /// one.
+    pub filter: Option<Option<RowFilter>>,
+    /// New row selection policy. `None` means "leave the policy alone".
+    pub row_selection_policy: Option<RowSelectionPolicy>,
+}
+
+impl StrategySwap {
+    /// Empty swap. No fields will be modified — chain `with_*` setters to
+    /// configure.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set a new projection mask for subsequent row groups.
+    pub fn with_projection(mut self, projection: ProjectionMask) -> Self {
+        self.projection = Some(projection);
+        self
+    }
+
+    /// Install a new row filter (or `None` to clear) for subsequent row
+    /// groups.
+    pub fn with_filter(mut self, filter: Option<RowFilter>) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    /// Set a new row selection policy for subsequent row groups.
+    pub fn with_row_selection_policy(mut self, policy: RowSelectionPolicy) -> Self {
+        self.row_selection_policy = Some(policy);
+        self
+    }
+
+    /// True iff every field is `None`. A no-op swap returns successfully but
+    /// has no effect.
+    pub fn is_empty(&self) -> bool {
+        self.projection.is_none() && self.filter.is_none() && self.row_selection_policy.is_none()
+    }
 }
 
 /// Internal state machine for the [`ParquetPushDecoder`]
@@ -598,6 +696,75 @@ impl ParquetDecoderState {
             } => remaining_row_groups.clear_all_ranges(),
             ParquetDecoderState::Finished => {}
         }
+    }
+
+    fn can_swap_strategy(&self) -> bool {
+        match self {
+            ParquetDecoderState::ReadingRowGroup {
+                remaining_row_groups,
+            } => remaining_row_groups.is_at_row_group_boundary(),
+            // Mid-row-group: the active reader holds an `ArrayReader` and
+            // `ReadPlan` keyed to the *current* projection/filter; swapping
+            // would require throwing that work away.
+            ParquetDecoderState::DecodingRowGroup { .. } => false,
+            ParquetDecoderState::Finished => false,
+        }
+    }
+
+    fn row_groups_remaining(&self) -> usize {
+        match self {
+            ParquetDecoderState::ReadingRowGroup {
+                remaining_row_groups,
+            } => remaining_row_groups.row_groups_remaining(),
+            ParquetDecoderState::DecodingRowGroup {
+                remaining_row_groups,
+                ..
+            } => remaining_row_groups.row_groups_remaining(),
+            ParquetDecoderState::Finished => 0,
+        }
+    }
+
+    fn swap_strategy(&mut self, swap: StrategySwap) -> Result<(), ParquetError> {
+        if swap.is_empty() {
+            return Ok(());
+        }
+        let remaining = match self {
+            ParquetDecoderState::ReadingRowGroup {
+                remaining_row_groups,
+            } => remaining_row_groups,
+            ParquetDecoderState::DecodingRowGroup { .. } => {
+                return Err(ParquetError::General(
+                    "swap_strategy called while a row group is being decoded; \
+                     check can_swap_strategy() first"
+                        .to_string(),
+                ));
+            }
+            ParquetDecoderState::Finished => {
+                return Err(ParquetError::General(
+                    "swap_strategy called on a finished decoder".to_string(),
+                ));
+            }
+        };
+        if !remaining.is_at_row_group_boundary() {
+            return Err(ParquetError::General(
+                "swap_strategy called mid-row-group; check can_swap_strategy() first".to_string(),
+            ));
+        }
+        let StrategySwap {
+            projection,
+            filter,
+            row_selection_policy,
+        } = swap;
+        if let Some(projection) = projection {
+            remaining.set_projection(projection)?;
+        }
+        if let Some(filter) = filter {
+            remaining.set_filter(filter)?;
+        }
+        if let Some(policy) = row_selection_policy {
+            remaining.set_row_selection_policy(policy)?;
+        }
+        Ok(())
     }
 }
 
@@ -1474,6 +1641,167 @@ mod test {
         assert_eq!(batch1, expected1);
 
         expect_finished(decoder.try_decode());
+    }
+
+    /// `swap_strategy` between row groups installs a new filter for the
+    /// next row group while leaving the just-decoded row group's results
+    /// untouched.
+    ///
+    /// Adaptive callers should drive the decoder with `try_next_reader`
+    /// rather than `try_decode`: `try_next_reader` returns once per row
+    /// group, giving the caller a clean window between two consecutive
+    /// returns to inspect stats and call `swap_strategy`. `try_decode`
+    /// barrels through row-group boundaries and is unsuitable for in-flight
+    /// strategy changes.
+    #[test]
+    fn test_swap_strategy_installs_filter_between_row_groups() {
+        let metadata = test_file_parquet_metadata();
+        let schema_descr = metadata.file_metadata().schema_descr_ptr();
+
+        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(metadata)
+            .unwrap()
+            .with_batch_size(1024)
+            .build()
+            .unwrap();
+
+        // Prefetch the entire file so we don't have to interleave I/O with
+        // the swap. PushBuffers carries the bytes through the swap.
+        decoder
+            .push_range(test_file_range(), TEST_FILE_DATA.clone())
+            .unwrap();
+
+        // Reader for row group 0 — no filter.
+        let reader0 = expect_data(decoder.try_next_reader());
+        let batches0: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
+        let batch0 = concat_batches(&TEST_BATCH.schema(), &batches0).unwrap();
+        assert_eq!(batch0.num_rows(), 200);
+        assert_eq!(batch0, TEST_BATCH.slice(0, 200));
+
+        // We're between row groups now. Swap in a filter on column "a".
+        assert!(decoder.can_swap_strategy());
+        let filter =
+            ArrowPredicateFn::new(ProjectionMask::columns(&schema_descr, ["a"]), |batch| {
+                gt(batch.column(0), &Int64Array::new_scalar(250))
+            });
+        decoder
+            .swap_strategy(
+                StrategySwap::new().with_filter(Some(RowFilter::new(vec![Box::new(filter)]))),
+            )
+            .unwrap();
+
+        // Reader for row group 1 — filter applied. Column "a" in RG1 has
+        // values 200..399; `a > 250` keeps 251..399 = 149 rows.
+        let reader1 = expect_data(decoder.try_next_reader());
+        let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
+        let batch1 = concat_batches(&TEST_BATCH.schema(), &batches1).unwrap();
+        let expected1 = TEST_BATCH.slice(251, 149);
+        assert_eq!(batch1, expected1);
+        expect_finished(decoder.try_next_reader());
+    }
+
+    /// `swap_strategy` is rejected while a row group's reader is being
+    /// drained, and accepted again the moment we cross the boundary.
+    #[test]
+    fn test_swap_strategy_rejected_mid_row_group() {
+        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
+            .unwrap()
+            .with_batch_size(50)
+            .build()
+            .unwrap();
+
+        decoder
+            .push_range(test_file_range(), TEST_FILE_DATA.clone())
+            .unwrap();
+
+        // After getting the first batch, we're inside `DecodingRowGroup`:
+        // an active reader is still alive. Mid-reader is not a swap point.
+        let _ = expect_data(decoder.try_decode());
+        assert!(!decoder.can_swap_strategy());
+
+        // Trying to swap mid-row-group is an error.
+        let err = decoder
+            .swap_strategy(
+                StrategySwap::new().with_row_selection_policy(super::RowSelectionPolicy::Mask),
+            )
+            .unwrap_err();
+        let err_msg = format!("{err}");
+        assert!(
+            err_msg.contains("can_swap_strategy"),
+            "unexpected error: {err_msg}"
+        );
+
+        // Empty swap is a no-op even mid-row-group.
+        decoder.swap_strategy(StrategySwap::new()).unwrap();
+    }
+
+    /// `try_next_reader` hands the active reader off to the caller and
+    /// transitions the decoder back to `ReadingRowGroup` — so the caller
+    /// can call `swap_strategy` even while still iterating the returned
+    /// reader. (The handed-off reader has no link back to the decoder's
+    /// projection/filter; it has its own `ArrayReader` and `ReadPlan`.)
+    #[test]
+    fn test_swap_strategy_allowed_while_iterating_handed_off_reader() {
+        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
+            .unwrap()
+            .with_batch_size(1024)
+            .build()
+            .unwrap();
+        decoder
+            .push_range(test_file_range(), TEST_FILE_DATA.clone())
+            .unwrap();
+
+        let reader0 = expect_data(decoder.try_next_reader());
+        // Decoder no longer owns the reader, so it considers itself
+        // "between row groups" — swap is allowed even though the caller
+        // hasn't iterated `reader0` yet.
+        assert!(decoder.can_swap_strategy());
+        // Iterating `reader0` is independent of the decoder's state.
+        let batches: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
+        let batch0 = concat_batches(&TEST_BATCH.schema(), &batches).unwrap();
+        assert_eq!(batch0, TEST_BATCH.slice(0, 200));
+    }
+
+    /// Bytes already buffered for a column survive a projection narrowing —
+    /// the next row group should not request any new data for the column
+    /// that was *already* in the projection.
+    #[test]
+    fn test_swap_strategy_preserves_buffered_bytes() {
+        let metadata = test_file_parquet_metadata();
+        let schema_descr = metadata.file_metadata().schema_descr_ptr();
+
+        let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(metadata)
+            .unwrap()
+            .with_batch_size(1024)
+            .build()
+            .unwrap();
+
+        // Prefetch the whole file once.
+        decoder
+            .push_range(test_file_range(), TEST_FILE_DATA.clone())
+            .unwrap();
+        assert_eq!(decoder.buffered_bytes(), test_file_len());
+
+        // Drain RG0 with full projection via try_next_reader.
+        let reader0 = expect_data(decoder.try_next_reader());
+        let _: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
+
+        // Narrow projection to just column "a" for RG1.
+        assert!(decoder.can_swap_strategy());
+        decoder
+            .swap_strategy(
+                StrategySwap::new().with_projection(ProjectionMask::columns(&schema_descr, ["a"])),
+            )
+            .unwrap();
+
+        // Column "a" bytes for RG1 were part of the original wide
+        // projection's prefetch; we should not need additional data.
+        let reader1 = expect_data(decoder.try_next_reader());
+        let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
+        // Schema is now just "a"; RG1 has values 200..399.
+        let expected1 = TEST_BATCH.slice(200, 200).project(&[0]).unwrap();
+        let batch1 = concat_batches(&batches1[0].schema(), &batches1).unwrap();
+        assert_eq!(batch1, expected1);
+        expect_finished(decoder.try_next_reader());
     }
 
     /// Returns a batch with 400 rows, with 3 columns: "a", "b", "c"

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -122,17 +122,34 @@ use std::sync::Arc;
 /// selectivity observed in the row groups decoded so far.
 pub type ParquetPushDecoderBuilder = ArrowReaderBuilder<NoInput>;
 
-/// Type that represents "No input" for the [`ParquetPushDecoderBuilder`]
+/// The `input` slot of a [`ParquetPushDecoderBuilder`].
 ///
-/// There is no "input" for the push decoder by design (the idea is that
-/// the caller pushes data to the decoder as needed)..
+/// [`ArrowReaderBuilder`] is shared by the sync, async, and push decoders.
+/// The sync and async builders put a real input there — a file or async
+/// reader — to read from. The push decoder has no reader, by design: the
+/// caller pushes bytes in. So its slot instead holds the `PushBuffers` those
+/// pushed bytes accumulate in.
 ///
-/// However, [`ArrowReaderBuilder`] is shared with the sync and async readers,
-/// which DO have an `input`. To support reusing the same builder code for
-/// all three types of decoders, we define this `NoInput` for the push decoder to
-/// denote in the type system there is no type.
-#[derive(Debug, Clone, Copy)]
-pub struct NoInput;
+/// A fresh builder starts with empty buffers.
+/// [`ParquetPushDecoder::into_builder`] threads an existing decoder's buffers
+/// back through so a rebuilt decoder keeps the bytes it already holds.
+///
+/// The name predates the buffer-carrying behaviour; it still reads as "no
+/// *reader* input".
+#[derive(Debug)]
+pub struct NoInput {
+    /// Bytes pushed into the decoder, awaiting decode.
+    buffers: PushBuffers,
+}
+
+impl Default for NoInput {
+    fn default() -> Self {
+        // The file length is unused by the push decoder's buffer tracking.
+        Self {
+            buffers: PushBuffers::new(0),
+        }
+    }
+}
 
 /// Methods for building a ParquetDecoder. See the base [`ArrowReaderBuilder`] for
 /// more options that can be configured.
@@ -167,13 +184,27 @@ impl ParquetPushDecoderBuilder {
     /// See [`ArrowReaderMetadata::try_new`] for how to create the metadata from
     /// the Parquet metadata and reader options.
     pub fn new_with_metadata(arrow_reader_metadata: ArrowReaderMetadata) -> Self {
-        Self::new_builder(NoInput, arrow_reader_metadata)
+        Self::new_builder(NoInput::default(), arrow_reader_metadata)
+    }
+
+    /// Reuse a [`PushBuffers`] when [`build`](Self::build)ing the decoder so
+    /// that bytes already fetched are not requested again.
+    ///
+    /// This is how [`ParquetPushDecoder::into_builder`] carries a decoder's
+    /// buffered bytes across a rebuild. It is `pub(crate)` because
+    /// [`PushBuffers`] is an internal type; callers seed a fresh decoder with
+    /// [`ParquetPushDecoder::push_ranges`] instead.
+    pub(crate) fn with_buffers(self, buffers: PushBuffers) -> Self {
+        Self {
+            input: NoInput { buffers },
+            ..self
+        }
     }
 
     /// Create a [`ParquetPushDecoder`] with the configured options
     pub fn build(self) -> Result<ParquetPushDecoder, ParquetError> {
         let Self {
-            input: NoInput,
+            input: NoInput { buffers },
             metadata: parquet_metadata,
             schema,
             fields,
@@ -196,9 +227,9 @@ impl ParquetPushDecoderBuilder {
             .as_ref()
             .is_some_and(|filter| !filter.predicates.is_empty());
 
-        // Prepare to build RowGroup readers
-        let file_len = 0; // not used in push decoder
-        let buffers = PushBuffers::new(file_len);
+        // Prepare to build RowGroup readers. `buffers` carries any bytes the
+        // caller already pushed (preserved across `into_builder`); a fresh
+        // builder supplies an empty `PushBuffers`.
         let row_group_reader_builder = RowGroupReaderBuilder::new(
             batch_size,
             projection,
@@ -237,8 +268,8 @@ impl ParquetPushDecoderBuilder {
 /// destructures a builder into decoder state, this reconstructs a builder from
 /// the decoder state that remains. The reconstructed builder is configured for
 /// exactly the row groups, row selection, and offset/limit budget that have not
-/// yet been decoded, so re-`build`ing it resumes the scan where the decoder
-/// left off.
+/// yet been decoded, and carries the decoder's buffered bytes, so re-`build`ing
+/// it resumes the scan where the decoder left off.
 fn builder_from_remaining(parts: RemainingRowGroupsParts) -> ParquetPushDecoderBuilder {
     let RemainingRowGroupsParts {
         schema,
@@ -257,10 +288,11 @@ fn builder_from_remaining(parts: RemainingRowGroupsParts) -> ParquetPushDecoderB
         max_predicate_cache_size,
         metrics,
         row_selection_policy,
+        buffers,
     } = reader_builder;
 
     ArrowReaderBuilder {
-        input: NoInput,
+        input: NoInput::default(),
         metadata,
         schema,
         fields,
@@ -278,6 +310,9 @@ fn builder_from_remaining(parts: RemainingRowGroupsParts) -> ParquetPushDecoderB
         metrics,
         max_predicate_cache_size,
     }
+    // Carry the decoder's already-fetched bytes across the rebuild so the new
+    // decoder does not re-request them.
+    .with_buffers(buffers)
 }
 
 /// A push based Parquet Decoder
@@ -505,11 +540,11 @@ impl ParquetPushDecoder {
     ///
     /// # Buffered bytes
     ///
-    /// Any bytes still buffered inside the decoder are dropped; the rebuilt
-    /// decoder re-requests whatever its configuration needs via
-    /// [`DecodeResult::NeedsData`]. At a row-group boundary reached through
-    /// incremental I/O the decoder has typically already freed the consumed
-    /// bytes, so in practice little or nothing is discarded.
+    /// The decoder's buffered bytes are carried across the rebuild: bytes
+    /// already fetched for row groups the new configuration still reads are
+    /// not re-requested. Bytes the new configuration no longer needs stay
+    /// buffered until [`clear_all_ranges`](Self::clear_all_ranges) is called
+    /// or the rebuilt decoder is dropped.
     pub fn into_builder(self) -> Result<ParquetPushDecoderBuilder, ParquetError> {
         self.state.into_builder()
     }
@@ -1709,14 +1744,11 @@ mod test {
             .with_row_filter(RowFilter::new(vec![Box::new(filter)]))
             .build()
             .unwrap();
-        // The rebuilt decoder starts with an empty buffer (see
-        // `test_into_builder_drops_buffered_bytes`), so re-supply the data.
-        decoder
-            .push_range(test_file_range(), TEST_FILE_DATA.clone())
-            .unwrap();
 
-        // Reader for row group 1 — filter applied. Column "a" in RG1 has
-        // values 200..399; `a > 250` keeps 251..399 = 149 rows.
+        // Reader for row group 1 — filter applied. The rebuilt decoder kept
+        // the buffered bytes (see `test_into_builder_preserves_buffered_bytes`)
+        // so no data needs to be re-supplied. Column "a" in RG1 has values
+        // 200..399; `a > 250` keeps 251..399 = 149 rows.
         let reader1 = expect_data(decoder.try_next_reader());
         let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
         let batch1 = concat_batches(&TEST_BATCH.schema(), &batches1).unwrap();
@@ -1825,12 +1857,10 @@ mod test {
         assert_eq!(batch0, TEST_BATCH.slice(0, 200));
 
         // Rebuild without changing anything: the remaining 50-row limit and
-        // the not-yet-decoded RG1 must carry through.
+        // the not-yet-decoded RG1 must carry through (as do the buffers, so
+        // no data needs re-supplying).
         assert!(decoder.is_at_row_group_boundary());
         let mut decoder = decoder.into_builder().unwrap().build().unwrap();
-        decoder
-            .push_range(test_file_range(), TEST_FILE_DATA.clone())
-            .unwrap();
 
         let reader1 = expect_data(decoder.try_next_reader());
         let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
@@ -1840,11 +1870,11 @@ mod test {
         expect_finished(decoder.try_next_reader());
     }
 
-    /// `into_builder` drops the decoder's buffered bytes: the rebuilt
-    /// decoder starts with an empty buffer and re-requests whatever its
-    /// configuration needs.
+    /// `into_builder` carries the decoder's buffered bytes across the
+    /// rebuild: the rebuilt decoder keeps them and does not re-request data
+    /// it already holds.
     #[test]
-    fn test_into_builder_drops_buffered_bytes() {
+    fn test_into_builder_preserves_buffered_bytes() {
         let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(test_file_parquet_metadata())
             .unwrap()
             .with_batch_size(1024)
@@ -1859,15 +1889,15 @@ mod test {
         let reader0 = expect_data(decoder.try_next_reader());
         let _: Vec<_> = reader0.collect::<Result<_, _>>().unwrap();
         // RG1's bytes are still staged inside the decoder.
-        assert!(decoder.buffered_bytes() > 0);
+        let buffered = decoder.buffered_bytes();
+        assert!(buffered > 0);
 
-        // Rebuilding via into_builder discards them.
+        // Rebuilding via into_builder keeps the staged bytes.
         let mut decoder = decoder.into_builder().unwrap().build().unwrap();
-        assert_eq!(decoder.buffered_bytes(), 0);
+        assert_eq!(decoder.buffered_bytes(), buffered);
 
-        // So RG1 must be fetched again before it can be decoded.
-        let ranges = expect_needs_data(decoder.try_next_reader());
-        push_ranges_to_decoder(&mut decoder, ranges);
+        // RG1's bytes are already buffered, so it decodes without a
+        // `NeedsData` round-trip.
         let reader1 = expect_data(decoder.try_next_reader());
         let batches1: Vec<_> = reader1.collect::<Result<_, _>>().unwrap();
         let batch1 = concat_batches(&TEST_BATCH.schema(), &batches1).unwrap();

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -112,14 +112,84 @@ use std::sync::Arc;
 ///
 /// # Adaptive scans
 ///
-/// The scan strategy is not fixed once [`build`](Self::build) is called. Drive
-/// the decoder with [`ParquetPushDecoder::try_next_reader`] — which returns
-/// once per row group, leaving a clean window between row groups — and at any
-/// such boundary call [`ParquetPushDecoder::into_builder`] to recover a
-/// builder, change any option (projection, row filter, …), and
-/// [`build`](Self::build) a fresh decoder that resumes from the next row group.
-/// This is how a query engine can promote or demote filters based on the
-/// selectivity observed in the row groups decoded so far.
+/// The scan strategy is not fixed once [`build`](Self::build) is called: it
+/// can be changed *while decoding*, at row-group boundaries.
+///
+/// The important API for this is [`ParquetPushDecoder::try_next_reader`].
+/// Unlike [`try_decode`](ParquetPushDecoder::try_decode), which barrels
+/// straight through row-group boundaries, `try_next_reader` returns once per
+/// row group — leaving a clean window *between* row groups. At any such
+/// boundary, [`ParquetPushDecoder::into_builder`] hands back a
+/// `ParquetPushDecoderBuilder` for the row groups not yet decoded. Change any
+/// option on it (projection, row filter, row selection policy, …) and
+/// [`build`](Self::build) a fresh decoder that resumes from the next row
+/// group. This is how a query engine promotes or demotes filters — for
+/// example turning a row filter on or off — based on the selectivity observed
+/// in the row groups decoded so far.
+///
+/// ```
+/// # use std::ops::Range;
+/// # use std::sync::Arc;
+/// # use bytes::Bytes;
+/// # use arrow_array::record_batch;
+/// # use parquet::DecodeResult;
+/// # use parquet::arrow::ProjectionMask;
+/// # use parquet::arrow::push_decoder::ParquetPushDecoderBuilder;
+/// # use parquet::arrow::ArrowWriter;
+/// # use parquet::file::metadata::ParquetMetaDataPushDecoder;
+/// # use parquet::file::properties::WriterProperties;
+/// # let file_bytes = {
+/// #   let batch = record_batch!(
+/// #       ("a", Int32, [1, 2, 3, 4, 5, 6]),
+/// #       ("b", Int32, [6, 5, 4, 3, 2, 1])
+/// #   ).unwrap();
+/// #   // Small row groups so the test file has two of them.
+/// #   let props = WriterProperties::builder().set_max_row_group_row_count(Some(3)).build();
+/// #   let mut buffer = vec![];
+/// #   let mut writer = ArrowWriter::try_new(&mut buffer, batch.schema(), Some(props)).unwrap();
+/// #   writer.write(&batch).unwrap();
+/// #   writer.close().unwrap();
+/// #   Bytes::from(buffer)
+/// # };
+/// # let get_range = |r: &Range<u64>| file_bytes.slice(r.start as usize..r.end as usize);
+/// # let file_length = file_bytes.len() as u64;
+/// # let mut metadata_decoder = ParquetMetaDataPushDecoder::try_new(file_length).unwrap();
+/// # metadata_decoder.push_ranges(vec![0..file_length], vec![file_bytes.clone()]).unwrap();
+/// # let DecodeResult::Data(parquet_metadata) = metadata_decoder.try_decode().unwrap() else { panic!() };
+/// # let parquet_metadata = Arc::new(parquet_metadata);
+/// let mut decoder = ParquetPushDecoderBuilder::try_new_decoder(parquet_metadata)
+///     .unwrap()
+///     .build()
+///     .unwrap();
+///
+/// // Drive the decoder one row group at a time with `try_next_reader`.
+/// loop {
+///     match decoder.try_next_reader().unwrap() {
+///         DecodeResult::NeedsData(ranges) => {
+///             // Fetch and hand over the bytes the decoder asked for.
+///             let data = ranges.iter().map(|r| get_range(r)).collect();
+///             decoder.push_ranges(ranges, data).unwrap();
+///         }
+///         DecodeResult::Data(reader) => {
+///             // Decode this row group's batches.
+///             for batch in reader {
+///                 assert!(batch.unwrap().num_rows() > 0);
+///             }
+///             // We are now at a row-group boundary. Based on whatever stats
+///             // were gathered, optionally change strategy for the row groups
+///             // still to come: drop or promote a row filter, narrow or widen
+///             // the projection, etc.
+///             if decoder.is_at_row_group_boundary() && decoder.row_groups_remaining() > 0 {
+///                 let builder = decoder.into_builder().unwrap();
+///                 // e.g. column "b" turned out not to be needed.
+///                 let projection = ProjectionMask::columns(builder.parquet_schema(), ["a"]);
+///                 decoder = builder.with_projection(projection).build().unwrap();
+///             }
+///         }
+///         DecodeResult::Finished => break,
+///     }
+/// }
+/// ```
 pub type ParquetPushDecoderBuilder = ArrowReaderBuilder<NoInput>;
 
 /// The `input` slot of a [`ParquetPushDecoderBuilder`].

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -296,6 +296,63 @@ impl RowGroupReaderBuilder {
         self.buffers.push_ranges(ranges, buffers);
     }
 
+    /// True iff the inner state is `Finished`. This is the only state in
+    /// which it is safe to swap projection / filter / row selection policy
+    /// because no `RowGroupInfo`, `FilterInfo`, or in-flight `DataRequest`
+    /// is referencing the previous values.
+    pub(crate) fn is_finished(&self) -> bool {
+        matches!(self.state, Some(RowGroupDecoderState::Finished))
+    }
+
+    /// Replace the projection mask used for subsequent row groups.
+    ///
+    /// Must only be called when [`Self::is_finished`]. `PushBuffers` are
+    /// preserved; bytes already fetched for columns that survive into the
+    /// new mask are reused.
+    pub(crate) fn set_projection(
+        &mut self,
+        projection: ProjectionMask,
+    ) -> Result<(), ParquetError> {
+        if !self.is_finished() {
+            return Err(ParquetError::General(
+                "RowGroupReaderBuilder::set_projection: state must be Finished".to_string(),
+            ));
+        }
+        self.projection = projection;
+        Ok(())
+    }
+
+    /// Replace the row filter used for subsequent row groups.
+    ///
+    /// Must only be called when [`Self::is_finished`]. Pass `None` to clear
+    /// the filter, `Some(filter)` to install a new one.
+    pub(crate) fn set_filter(&mut self, filter: Option<RowFilter>) -> Result<(), ParquetError> {
+        if !self.is_finished() {
+            return Err(ParquetError::General(
+                "RowGroupReaderBuilder::set_filter: state must be Finished".to_string(),
+            ));
+        }
+        self.filter = filter;
+        Ok(())
+    }
+
+    /// Replace the row selection policy used for subsequent row groups.
+    ///
+    /// Must only be called when [`Self::is_finished`].
+    pub(crate) fn set_row_selection_policy(
+        &mut self,
+        policy: RowSelectionPolicy,
+    ) -> Result<(), ParquetError> {
+        if !self.is_finished() {
+            return Err(ParquetError::General(
+                "RowGroupReaderBuilder::set_row_selection_policy: state must be Finished"
+                    .to_string(),
+            ));
+        }
+        self.row_selection_policy = policy;
+        Ok(())
+    }
+
     /// Returns the total number of buffered bytes available
     pub fn buffered_bytes(&self) -> u64 {
         self.buffers.buffered_bytes()

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -324,6 +324,8 @@ impl RowGroupReaderBuilder {
     /// reconstructed. The runtime decode `state` is discarded; `metadata` is
     /// recovered from the frontier instead (see `RemainingRowGroups::into_parts`).
     pub(crate) fn into_parts(self) -> RowGroupReaderBuilderParts {
+        // If a new field is added to `RowGroupReaderBuilder`, it must be added here and in `RowGroupReaderBuilderParts`,
+        // or at least evaluate how it should be handled in the decomposition and reconstruction of the builder.
         let Self {
             batch_size,
             projection,

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -276,16 +276,12 @@ pub(crate) struct RowGroupReaderBuilder {
 /// The parts of a [`RowGroupReaderBuilder`] needed to rebuild it, recovered by
 /// [`RowGroupReaderBuilder::into_parts`].
 ///
-/// This is the inverse of [`RowGroupReaderBuilder::new`]: it returns the
-/// fields that originated from a [`ParquetPushDecoderBuilder`] plus the
-/// [`PushBuffers`], dropping only the runtime decode `state`.
-///
-/// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
+/// `metadata` is not included: it is a whole-file property carried alongside
+/// `schema` in `RemainingRowGroupsParts`.
 #[derive(Debug)]
 pub(crate) struct RowGroupReaderBuilderParts {
     pub batch_size: usize,
     pub projection: ProjectionMask,
-    pub metadata: Arc<ParquetMetaData>,
     pub fields: Option<Arc<ParquetField>>,
     pub filter: Option<RowFilter>,
     pub max_predicate_cache_size: usize,
@@ -324,18 +320,14 @@ impl RowGroupReaderBuilder {
         }
     }
 
-    /// Decompose into [`RowGroupReaderBuilderParts`].
-    ///
-    /// The runtime decode `state` is discarded; the configuration that came
-    /// from the [`ParquetPushDecoderBuilder`] and the buffered bytes are
-    /// returned so the builder can be reconstructed.
-    ///
-    /// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
+    /// Decompose into [`RowGroupReaderBuilderParts`] so the builder can be
+    /// reconstructed. The runtime decode `state` is discarded; `metadata` is
+    /// recovered from the frontier instead (see `RemainingRowGroups::into_parts`).
     pub(crate) fn into_parts(self) -> RowGroupReaderBuilderParts {
         let Self {
             batch_size,
             projection,
-            metadata,
+            metadata: _,
             fields,
             filter,
             max_predicate_cache_size,
@@ -347,7 +339,6 @@ impl RowGroupReaderBuilder {
         RowGroupReaderBuilderParts {
             batch_size,
             projection,
-            metadata,
             fields,
             filter,
             max_predicate_cache_size,

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -273,12 +273,12 @@ pub(crate) struct RowGroupReaderBuilder {
     buffers: PushBuffers,
 }
 
-/// The builder-configurable parts of a [`RowGroupReaderBuilder`], recovered by
+/// The parts of a [`RowGroupReaderBuilder`] needed to rebuild it, recovered by
 /// [`RowGroupReaderBuilder::into_parts`].
 ///
 /// This is the inverse of [`RowGroupReaderBuilder::new`]: it returns the
-/// fields that originated from a [`ParquetPushDecoderBuilder`], dropping the
-/// runtime decode `state` and the buffered `PushBuffers`.
+/// fields that originated from a [`ParquetPushDecoderBuilder`] plus the
+/// [`PushBuffers`], dropping only the runtime decode `state`.
 ///
 /// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
 #[derive(Debug)]
@@ -291,6 +291,9 @@ pub(crate) struct RowGroupReaderBuilderParts {
     pub max_predicate_cache_size: usize,
     pub metrics: ArrowReaderMetrics,
     pub row_selection_policy: RowSelectionPolicy,
+    /// Bytes already pushed into the decoder, carried across a rebuild so they
+    /// are not re-requested.
+    pub buffers: PushBuffers,
 }
 
 impl RowGroupReaderBuilder {
@@ -321,11 +324,11 @@ impl RowGroupReaderBuilder {
         }
     }
 
-    /// Decompose into the builder-configurable [`RowGroupReaderBuilderParts`].
+    /// Decompose into [`RowGroupReaderBuilderParts`].
     ///
-    /// The runtime decode `state` and any buffered bytes are discarded; only
-    /// the configuration that came from the [`ParquetPushDecoderBuilder`] is
-    /// returned.
+    /// The runtime decode `state` is discarded; the configuration that came
+    /// from the [`ParquetPushDecoderBuilder`] and the buffered bytes are
+    /// returned so the builder can be reconstructed.
     ///
     /// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
     pub(crate) fn into_parts(self) -> RowGroupReaderBuilderParts {
@@ -339,7 +342,7 @@ impl RowGroupReaderBuilder {
             metrics,
             row_selection_policy,
             state: _,
-            buffers: _,
+            buffers,
         } = self;
         RowGroupReaderBuilderParts {
             batch_size,
@@ -350,6 +353,7 @@ impl RowGroupReaderBuilder {
             max_predicate_cache_size,
             metrics,
             row_selection_policy,
+            buffers,
         }
     }
 

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -104,6 +104,16 @@ impl RowBudget {
         matches!(self.limit, Some(0))
     }
 
+    /// The offset still to be skipped before the next readable row group.
+    pub(crate) fn offset(self) -> Option<usize> {
+        self.offset
+    }
+
+    /// The number of output rows still permitted across the remaining row groups.
+    pub(crate) fn limit(self) -> Option<usize> {
+        self.limit
+    }
+
     /// Returns how many selected rows remain after applying this budget.
     pub(crate) fn rows_after(self, rows_before_budget: usize) -> usize {
         let rows_after_offset = rows_before_budget.saturating_sub(self.offset.unwrap_or(0));
@@ -263,6 +273,26 @@ pub(crate) struct RowGroupReaderBuilder {
     buffers: PushBuffers,
 }
 
+/// The builder-configurable parts of a [`RowGroupReaderBuilder`], recovered by
+/// [`RowGroupReaderBuilder::into_parts`].
+///
+/// This is the inverse of [`RowGroupReaderBuilder::new`]: it returns the
+/// fields that originated from a [`ParquetPushDecoderBuilder`], dropping the
+/// runtime decode `state` and the buffered `PushBuffers`.
+///
+/// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
+#[derive(Debug)]
+pub(crate) struct RowGroupReaderBuilderParts {
+    pub batch_size: usize,
+    pub projection: ProjectionMask,
+    pub metadata: Arc<ParquetMetaData>,
+    pub fields: Option<Arc<ParquetField>>,
+    pub filter: Option<RowFilter>,
+    pub max_predicate_cache_size: usize,
+    pub metrics: ArrowReaderMetrics,
+    pub row_selection_policy: RowSelectionPolicy,
+}
+
 impl RowGroupReaderBuilder {
     /// Create a new RowGroupReaderBuilder
     #[expect(clippy::too_many_arguments)]
@@ -291,66 +321,49 @@ impl RowGroupReaderBuilder {
         }
     }
 
+    /// Decompose into the builder-configurable [`RowGroupReaderBuilderParts`].
+    ///
+    /// The runtime decode `state` and any buffered bytes are discarded; only
+    /// the configuration that came from the [`ParquetPushDecoderBuilder`] is
+    /// returned.
+    ///
+    /// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
+    pub(crate) fn into_parts(self) -> RowGroupReaderBuilderParts {
+        let Self {
+            batch_size,
+            projection,
+            metadata,
+            fields,
+            filter,
+            max_predicate_cache_size,
+            metrics,
+            row_selection_policy,
+            state: _,
+            buffers: _,
+        } = self;
+        RowGroupReaderBuilderParts {
+            batch_size,
+            projection,
+            metadata,
+            fields,
+            filter,
+            max_predicate_cache_size,
+            metrics,
+            row_selection_policy,
+        }
+    }
+
     /// Push new data buffers that can be used to satisfy pending requests
     pub fn push_data(&mut self, ranges: Vec<Range<u64>>, buffers: Vec<Bytes>) {
         self.buffers.push_ranges(ranges, buffers);
     }
 
     /// True iff the inner state is `Finished`. This is the only state in
-    /// which it is safe to swap projection / filter / row selection policy
+    /// which it is safe to decompose the builder via [`Self::into_parts`],
     /// because no `RowGroupInfo`, `FilterInfo`, or in-flight `DataRequest`
-    /// is referencing the previous values.
+    /// is referencing the row-group-scoped decode state.
     pub(crate) fn is_finished(&self) -> bool {
         matches!(self.state, Some(RowGroupDecoderState::Finished))
-    }
-
-    /// Replace the projection mask used for subsequent row groups.
-    ///
-    /// Must only be called when [`Self::is_finished`]. `PushBuffers` are
-    /// preserved; bytes already fetched for columns that survive into the
-    /// new mask are reused.
-    pub(crate) fn set_projection(
-        &mut self,
-        projection: ProjectionMask,
-    ) -> Result<(), ParquetError> {
-        if !self.is_finished() {
-            return Err(ParquetError::General(
-                "RowGroupReaderBuilder::set_projection: state must be Finished".to_string(),
-            ));
-        }
-        self.projection = projection;
-        Ok(())
-    }
-
-    /// Replace the row filter used for subsequent row groups.
-    ///
-    /// Must only be called when [`Self::is_finished`]. Pass `None` to clear
-    /// the filter, `Some(filter)` to install a new one.
-    pub(crate) fn set_filter(&mut self, filter: Option<RowFilter>) -> Result<(), ParquetError> {
-        if !self.is_finished() {
-            return Err(ParquetError::General(
-                "RowGroupReaderBuilder::set_filter: state must be Finished".to_string(),
-            ));
-        }
-        self.filter = filter;
-        Ok(())
-    }
-
-    /// Replace the row selection policy used for subsequent row groups.
-    ///
-    /// Must only be called when [`Self::is_finished`].
-    pub(crate) fn set_row_selection_policy(
-        &mut self,
-        policy: RowSelectionPolicy,
-    ) -> Result<(), ParquetError> {
-        if !self.is_finished() {
-            return Err(ParquetError::General(
-                "RowGroupReaderBuilder::set_row_selection_policy: state must be Finished"
-                    .to_string(),
-            ));
-        }
-        self.row_selection_policy = policy;
-        Ok(())
     }
 
     /// Returns the total number of buffered bytes available

--- a/parquet/src/arrow/push_decoder/remaining.rs
+++ b/parquet/src/arrow/push_decoder/remaining.rs
@@ -186,12 +186,9 @@ impl RowGroupFrontier {
 /// work item. [`RowGroupReaderBuilder`] owns decoding for the active row group.
 #[derive(Debug)]
 pub(crate) struct RemainingRowGroups {
-    /// The arrow schema of the decoded output.
-    ///
-    /// Carried only so [`Self::into_parts`] can hand it back to a rebuilt
-    /// [`ParquetPushDecoderBuilder`]; it is not consulted while decoding.
-    ///
-    /// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
+    /// The arrow schema of the decoded output. Carried only so
+    /// [`Self::into_parts`] can hand it to a rebuilt builder; unused while
+    /// decoding.
     schema: SchemaRef,
 
     /// Cross-row-group scan state for queued work.
@@ -201,18 +198,15 @@ pub(crate) struct RemainingRowGroups {
     row_group_reader_builder: RowGroupReaderBuilder,
 }
 
-/// The builder-configurable state recovered from a [`RemainingRowGroups`] by
-/// [`RemainingRowGroups::into_parts`].
-///
-/// The fields describe the row groups that have *not* yet been decoded, so a
-/// [`ParquetPushDecoderBuilder`] reconstructed from them resumes exactly where
-/// the decoder left off.
-///
-/// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
+/// The state recovered from a [`RemainingRowGroups`] by
+/// [`RemainingRowGroups::into_parts`], describing the row groups *not* yet
+/// decoded so a builder reconstructed from it resumes where the decoder left off.
 #[derive(Debug)]
 pub(crate) struct RemainingRowGroupsParts {
     /// The arrow schema of the decoded output.
     pub schema: SchemaRef,
+    /// The Parquet file metadata.
+    pub metadata: Arc<ParquetMetaData>,
     /// Row groups not yet handed to the reader builder.
     pub row_groups: Vec<usize>,
     /// The not-yet-consumed slice of the global row selection.
@@ -252,16 +246,16 @@ impl RemainingRowGroups {
     ///
     /// Must be called at a row-group boundary (see
     /// [`Self::is_at_row_group_boundary`]). The inner reader builder's runtime
-    /// decode state is discarded; its buffered bytes are carried through in
-    /// [`RemainingRowGroupsParts::reader_builder`].
+    /// decode state is discarded; its buffered bytes are carried through.
     pub(crate) fn into_parts(self) -> RemainingRowGroupsParts {
         let Self {
             schema,
             frontier,
             row_group_reader_builder,
         } = self;
+        // `has_predicates` is recomputed by `build()` from the filter.
         let RowGroupFrontier {
-            parquet_metadata: _,
+            parquet_metadata,
             row_groups,
             selection,
             budget,
@@ -269,6 +263,7 @@ impl RemainingRowGroups {
         } = frontier;
         RemainingRowGroupsParts {
             schema,
+            metadata: parquet_metadata,
             row_groups: Vec::from(row_groups),
             selection,
             offset: budget.offset(),

--- a/parquet/src/arrow/push_decoder/remaining.rs
+++ b/parquet/src/arrow/push_decoder/remaining.rs
@@ -248,11 +248,12 @@ impl RemainingRowGroups {
         }
     }
 
-    /// Decompose into the builder-configurable [`RemainingRowGroupsParts`].
+    /// Decompose into [`RemainingRowGroupsParts`].
     ///
     /// Must be called at a row-group boundary (see
-    /// [`Self::is_at_row_group_boundary`]); the inner reader builder's runtime
-    /// decode state and buffered bytes are discarded.
+    /// [`Self::is_at_row_group_boundary`]). The inner reader builder's runtime
+    /// decode state is discarded; its buffered bytes are carried through in
+    /// [`RemainingRowGroupsParts::reader_builder`].
     pub(crate) fn into_parts(self) -> RemainingRowGroupsParts {
         let Self {
             schema,

--- a/parquet/src/arrow/push_decoder/remaining.rs
+++ b/parquet/src/arrow/push_decoder/remaining.rs
@@ -16,15 +16,13 @@
 // under the License.
 
 use crate::DecodeResult;
-use crate::arrow::ProjectionMask;
-use crate::arrow::arrow_reader::{
-    ParquetRecordBatchReader, RowFilter, RowSelection, RowSelectionPolicy,
-};
+use crate::arrow::arrow_reader::{ParquetRecordBatchReader, RowSelection};
 use crate::arrow::push_decoder::reader_builder::{
-    RowBudget, RowGroupBuildResult, RowGroupReaderBuilder,
+    RowBudget, RowGroupBuildResult, RowGroupReaderBuilder, RowGroupReaderBuilderParts,
 };
 use crate::errors::ParquetError;
 use crate::file::metadata::ParquetMetaData;
+use arrow_schema::SchemaRef;
 use bytes::Bytes;
 use std::collections::VecDeque;
 use std::ops::Range;
@@ -188,6 +186,14 @@ impl RowGroupFrontier {
 /// work item. [`RowGroupReaderBuilder`] owns decoding for the active row group.
 #[derive(Debug)]
 pub(crate) struct RemainingRowGroups {
+    /// The arrow schema of the decoded output.
+    ///
+    /// Carried only so [`Self::into_parts`] can hand it back to a rebuilt
+    /// [`ParquetPushDecoderBuilder`]; it is not consulted while decoding.
+    ///
+    /// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
+    schema: SchemaRef,
+
     /// Cross-row-group scan state for queued work.
     frontier: RowGroupFrontier,
 
@@ -195,8 +201,33 @@ pub(crate) struct RemainingRowGroups {
     row_group_reader_builder: RowGroupReaderBuilder,
 }
 
+/// The builder-configurable state recovered from a [`RemainingRowGroups`] by
+/// [`RemainingRowGroups::into_parts`].
+///
+/// The fields describe the row groups that have *not* yet been decoded, so a
+/// [`ParquetPushDecoderBuilder`] reconstructed from them resumes exactly where
+/// the decoder left off.
+///
+/// [`ParquetPushDecoderBuilder`]: crate::arrow::push_decoder::ParquetPushDecoderBuilder
+#[derive(Debug)]
+pub(crate) struct RemainingRowGroupsParts {
+    /// The arrow schema of the decoded output.
+    pub schema: SchemaRef,
+    /// Row groups not yet handed to the reader builder.
+    pub row_groups: Vec<usize>,
+    /// The not-yet-consumed slice of the global row selection.
+    pub selection: Option<RowSelection>,
+    /// Offset still to be skipped before the next readable row group.
+    pub offset: Option<usize>,
+    /// Output rows still permitted across the remaining row groups.
+    pub limit: Option<usize>,
+    /// Builder-configurable parts of the inner row-group reader builder.
+    pub reader_builder: RowGroupReaderBuilderParts,
+}
+
 impl RemainingRowGroups {
     pub fn new(
+        schema: SchemaRef,
         parquet_metadata: Arc<ParquetMetaData>,
         row_groups: Vec<usize>,
         selection: Option<RowSelection>,
@@ -205,6 +236,7 @@ impl RemainingRowGroups {
         row_group_reader_builder: RowGroupReaderBuilder,
     ) -> Self {
         Self {
+            schema,
             frontier: RowGroupFrontier::new(
                 parquet_metadata,
                 row_groups,
@@ -213,6 +245,34 @@ impl RemainingRowGroups {
                 has_predicates,
             ),
             row_group_reader_builder,
+        }
+    }
+
+    /// Decompose into the builder-configurable [`RemainingRowGroupsParts`].
+    ///
+    /// Must be called at a row-group boundary (see
+    /// [`Self::is_at_row_group_boundary`]); the inner reader builder's runtime
+    /// decode state and buffered bytes are discarded.
+    pub(crate) fn into_parts(self) -> RemainingRowGroupsParts {
+        let Self {
+            schema,
+            frontier,
+            row_group_reader_builder,
+        } = self;
+        let RowGroupFrontier {
+            parquet_metadata: _,
+            row_groups,
+            selection,
+            budget,
+            has_predicates: _,
+        } = frontier;
+        RemainingRowGroupsParts {
+            schema,
+            row_groups: Vec::from(row_groups),
+            selection,
+            offset: budget.offset(),
+            limit: budget.limit(),
+            reader_builder: row_group_reader_builder.into_parts(),
         }
     }
 
@@ -241,28 +301,6 @@ impl RemainingRowGroups {
     /// being decoded).
     pub fn row_groups_remaining(&self) -> usize {
         self.frontier.row_groups.len()
-    }
-
-    /// Replace the projection. Must be called when
-    /// [`Self::is_at_row_group_boundary`].
-    pub fn set_projection(&mut self, projection: ProjectionMask) -> Result<(), ParquetError> {
-        self.row_group_reader_builder.set_projection(projection)
-    }
-
-    /// Replace the row filter. Must be called when
-    /// [`Self::is_at_row_group_boundary`].
-    pub fn set_filter(&mut self, filter: Option<RowFilter>) -> Result<(), ParquetError> {
-        self.row_group_reader_builder.set_filter(filter)
-    }
-
-    /// Replace the row selection policy. Must be called when
-    /// [`Self::is_at_row_group_boundary`].
-    pub fn set_row_selection_policy(
-        &mut self,
-        policy: RowSelectionPolicy,
-    ) -> Result<(), ParquetError> {
-        self.row_group_reader_builder
-            .set_row_selection_policy(policy)
     }
 
     /// returns [`ParquetRecordBatchReader`] suitable for reading the next

--- a/parquet/src/arrow/push_decoder/remaining.rs
+++ b/parquet/src/arrow/push_decoder/remaining.rs
@@ -16,7 +16,10 @@
 // under the License.
 
 use crate::DecodeResult;
-use crate::arrow::arrow_reader::{ParquetRecordBatchReader, RowSelection};
+use crate::arrow::ProjectionMask;
+use crate::arrow::arrow_reader::{
+    ParquetRecordBatchReader, RowFilter, RowSelection, RowSelectionPolicy,
+};
 use crate::arrow::push_decoder::reader_builder::{
     RowBudget, RowGroupBuildResult, RowGroupReaderBuilder,
 };
@@ -226,6 +229,40 @@ impl RemainingRowGroups {
     /// Clear any staged ranges currently buffered for future decode work
     pub fn clear_all_ranges(&mut self) {
         self.row_group_reader_builder.clear_all_ranges();
+    }
+
+    /// True iff the inner row-group reader is between row groups (state
+    /// `Finished`). Forward to [`RowGroupReaderBuilder::is_finished`].
+    pub fn is_at_row_group_boundary(&self) -> bool {
+        self.row_group_reader_builder.is_finished()
+    }
+
+    /// Number of row groups remaining (not including the one currently
+    /// being decoded).
+    pub fn row_groups_remaining(&self) -> usize {
+        self.frontier.row_groups.len()
+    }
+
+    /// Replace the projection. Must be called when
+    /// [`Self::is_at_row_group_boundary`].
+    pub fn set_projection(&mut self, projection: ProjectionMask) -> Result<(), ParquetError> {
+        self.row_group_reader_builder.set_projection(projection)
+    }
+
+    /// Replace the row filter. Must be called when
+    /// [`Self::is_at_row_group_boundary`].
+    pub fn set_filter(&mut self, filter: Option<RowFilter>) -> Result<(), ParquetError> {
+        self.row_group_reader_builder.set_filter(filter)
+    }
+
+    /// Replace the row selection policy. Must be called when
+    /// [`Self::is_at_row_group_boundary`].
+    pub fn set_row_selection_policy(
+        &mut self,
+        policy: RowSelectionPolicy,
+    ) -> Result<(), ParquetError> {
+        self.row_group_reader_builder
+            .set_row_selection_policy(policy)
     }
 
     /// returns [`ParquetRecordBatchReader`] suitable for reading the next

--- a/parquet/src/util/push_buffers.rs
+++ b/parquet/src/util/push_buffers.rs
@@ -38,7 +38,7 @@ use std::ops::Range;
 ///
 /// Thus, the implementation defers to the caller to coalesce subsequent requests
 /// if desired.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct PushBuffers {
     /// the virtual "offset" of this buffers (added to any request)
     offset: u64,
@@ -75,7 +75,11 @@ impl Display for PushBuffers {
 }
 
 impl PushBuffers {
-    /// Create a new Buffers instance with the given file length
+    /// Create a new, empty `PushBuffers` for a file of the given length.
+    ///
+    /// Use [`PushBuffers::default`] when the file length is unknown or
+    /// irrelevant (e.g. the push decoder, which tracks ranges by absolute
+    /// offset and never consults `file_len`).
     pub fn new(file_len: u64) -> Self {
         Self {
             offset: 0,

--- a/parquet/src/util/push_buffers.rs
+++ b/parquet/src/util/push_buffers.rs
@@ -21,9 +21,12 @@ use bytes::Bytes;
 use std::fmt::Display;
 use std::ops::Range;
 
-/// Holds multiple buffers of data
+/// Holds multiple non-contiguous, caller-provided buffers of file data.
 ///
-/// This is the in-memory buffer for the ParquetDecoder and ParquetMetadataDecoders
+/// This is the in-memory buffer used by the push-based Parquet decoders
+/// (`ParquetPushDecoder` and `ParquetMetaDataPushDecoder`). It can be
+/// constructed up front and handed to a builder so the decoder reuses bytes
+/// that have already been fetched.
 ///
 /// Features:
 /// 1. Zero copy
@@ -39,7 +42,7 @@ use std::ops::Range;
 /// Thus, the implementation defers to the caller to coalesce subsequent requests
 /// if desired.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct PushBuffers {
+pub struct PushBuffers {
     /// the virtual "offset" of this buffers (added to any request)
     offset: u64,
     /// The total length of the file being decoded
@@ -113,7 +116,7 @@ impl PushBuffers {
     }
 
     /// Returns true if the Buffers contains data for the given range
-    pub fn has_range(&self, range: &Range<u64>) -> bool {
+    pub(crate) fn has_range(&self, range: &Range<u64>) -> bool {
         self.ranges
             .iter()
             .any(|r| r.start <= range.start && r.end >= range.end)
@@ -124,25 +127,25 @@ impl PushBuffers {
     }
 
     /// return the file length of the Parquet file being read
-    pub fn file_len(&self) -> u64 {
+    pub(crate) fn file_len(&self) -> u64 {
         self.file_len
     }
 
     /// Specify a new offset
-    pub fn with_offset(mut self, offset: u64) -> Self {
+    fn with_offset(mut self, offset: u64) -> Self {
         self.offset = offset;
         self
     }
 
     /// Return the total of all buffered ranges
     #[cfg(feature = "arrow")]
-    pub fn buffered_bytes(&self) -> u64 {
+    pub(crate) fn buffered_bytes(&self) -> u64 {
         self.ranges.iter().map(|r| r.end - r.start).sum()
     }
 
     /// Clear any range and corresponding buffer that is exactly in the ranges_to_clear
     #[cfg(feature = "arrow")]
-    pub fn clear_ranges(&mut self, ranges_to_clear: &[Range<u64>]) {
+    pub(crate) fn clear_ranges(&mut self, ranges_to_clear: &[Range<u64>]) {
         let mut new_ranges = Vec::new();
         let mut new_buffers = Vec::new();
 
@@ -160,7 +163,7 @@ impl PushBuffers {
     }
 
     /// Clear all buffered ranges and their corresponding data
-    pub fn clear_all_ranges(&mut self) {
+    pub(crate) fn clear_all_ranges(&mut self) {
         self.ranges.clear();
         self.buffers.clear();
     }


### PR DESCRIPTION
This is the decoder piece of the work presented at the NYC DataFusion meetup.

The idea is that we'll be able to adaptively promote and demote filters into row filters based on runtime selectivity stats.