### PR TITLE
[Not for merge] Make `ConvertedType` optional in the Parquet schema

### DIFF
--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -21,7 +21,7 @@ use crate::arrow::buffer::offset_buffer::OffsetBuffer;
 use crate::arrow::decoder::{DeltaByteArrayDecoder, DictIndexDecoder};
 use crate::arrow::record_reader::GenericRecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;
-use crate::basic::{ConvertedType, Encoding};
+use crate::basic::{ConvertedType, Encoding, LogicalType};
 use crate::column::page::PageIterator;
 use crate::column::reader::decoder::ColumnValueDecoder;
 use crate::data_type::Int32Type;
@@ -181,7 +181,8 @@ impl<I: OffsetSizeTrait> ColumnValueDecoder for ByteArrayColumnValueDecoder<I> {
     type Buffer = OffsetBuffer<I>;
 
     fn new(desc: &ColumnDescPtr) -> Self {
-        let validate_utf8 = desc.converted_type() == ConvertedType::UTF8;
+        let validate_utf8 = desc.logical_type_ref() == Some(&LogicalType::String)
+            || desc.converted_type() == Some(ConvertedType::UTF8);
         Self {
             dict: None,
             decoder: None,

--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -235,9 +235,9 @@ where
     type Buffer = DictionaryBuffer<K, V>;
 
     fn new(col: &ColumnDescPtr) -> Self {
-        let validate_utf8 = col.converted_type() == ConvertedType::UTF8;
+        let validate_utf8 = col.converted_type() == Some(ConvertedType::UTF8);
 
-        let value_type = match (V::IS_LARGE, col.converted_type() == ConvertedType::UTF8) {
+        let value_type = match (V::IS_LARGE, col.converted_type() == Some(ConvertedType::UTF8)) {
             (true, true) => ArrowType::LargeUtf8,
             (true, false) => ArrowType::LargeBinary,
             (false, true) => ArrowType::Utf8,

--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -237,7 +237,10 @@ where
     fn new(col: &ColumnDescPtr) -> Self {
         let validate_utf8 = col.converted_type() == Some(ConvertedType::UTF8);
 
-        let value_type = match (V::IS_LARGE, col.converted_type() == Some(ConvertedType::UTF8)) {
+        let value_type = match (
+            V::IS_LARGE,
+            col.converted_type() == Some(ConvertedType::UTF8),
+        ) {
             (true, true) => ArrowType::LargeUtf8,
             (true, false) => ArrowType::LargeBinary,
             (false, true) => ArrowType::Utf8,

--- a/parquet/src/arrow/array_reader/byte_view_array.rs
+++ b/parquet/src/arrow/array_reader/byte_view_array.rs
@@ -20,7 +20,7 @@ use crate::arrow::buffer::view_buffer::ViewBuffer;
 use crate::arrow::decoder::{DeltaByteArrayDecoder, DictIndexDecoder};
 use crate::arrow::record_reader::GenericRecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;
-use crate::basic::{ConvertedType, Encoding};
+use crate::basic::{ConvertedType, Encoding, LogicalType};
 use crate::column::page::PageIterator;
 use crate::column::reader::decoder::ColumnValueDecoder;
 use crate::data_type::Int32Type;
@@ -141,7 +141,8 @@ impl ColumnValueDecoder for ByteViewArrayColumnValueDecoder {
     type Buffer = ViewBuffer;
 
     fn new(desc: &ColumnDescPtr) -> Self {
-        let validate_utf8 = desc.converted_type() == ConvertedType::UTF8;
+        let validate_utf8 = desc.logical_type_ref() == Some(&LogicalType::String)
+            || desc.converted_type() == Some(ConvertedType::UTF8);
         Self {
             dict: None,
             decoder: None,

--- a/parquet/src/arrow/array_reader/test_util.rs
+++ b/parquet/src/arrow/array_reader/test_util.rs
@@ -29,7 +29,7 @@ use crate::schema::types::{ColumnDescPtr, ColumnDescriptor, ColumnPath, Type};
 /// Returns a descriptor for a UTF-8 column
 pub fn utf8_column() -> ColumnDescPtr {
     let t = Type::primitive_type_builder("col", PhysicalType::BYTE_ARRAY)
-        .with_converted_type(ConvertedType::UTF8)
+        .with_converted_type(Some(ConvertedType::UTF8))
         .build()
         .unwrap();
 

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -1834,14 +1834,14 @@ pub(crate) mod tests {
     fn test_primitive_single_column_reader_test() {
         run_single_column_reader_tests::<BoolType, _, BoolType>(
             2,
-            ConvertedType::NONE,
+            None,
             None,
             |vals| Arc::new(BooleanArray::from_iter(vals.iter().cloned())),
             &[Encoding::PLAIN, Encoding::RLE, Encoding::RLE_DICTIONARY],
         );
         run_single_column_reader_tests::<Int32Type, _, Int32Type>(
             2,
-            ConvertedType::NONE,
+            None,
             None,
             |vals| Arc::new(Int32Array::from_iter(vals.iter().cloned())),
             &[
@@ -1853,7 +1853,7 @@ pub(crate) mod tests {
         );
         run_single_column_reader_tests::<Int64Type, _, Int64Type>(
             2,
-            ConvertedType::NONE,
+            None,
             None,
             |vals| Arc::new(Int64Array::from_iter(vals.iter().cloned())),
             &[
@@ -1865,7 +1865,7 @@ pub(crate) mod tests {
         );
         run_single_column_reader_tests::<FloatType, _, FloatType>(
             2,
-            ConvertedType::NONE,
+            None,
             None,
             |vals| Arc::new(Float32Array::from_iter(vals.iter().cloned())),
             &[Encoding::PLAIN, Encoding::BYTE_STREAM_SPLIT],
@@ -1876,7 +1876,7 @@ pub(crate) mod tests {
     fn test_unsigned_primitive_single_column_reader_test() {
         run_single_column_reader_tests::<Int32Type, _, Int32Type>(
             2,
-            ConvertedType::UINT_32,
+            Some(ConvertedType::UINT_32),
             Some(ArrowDataType::UInt32),
             |vals| {
                 Arc::new(UInt32Array::from_iter(
@@ -1891,7 +1891,7 @@ pub(crate) mod tests {
         );
         run_single_column_reader_tests::<Int64Type, _, Int64Type>(
             2,
-            ConvertedType::UINT_64,
+            Some(ConvertedType::UINT_64),
             Some(ArrowDataType::UInt64),
             |vals| {
                 Arc::new(UInt64Array::from_iter(
@@ -2199,7 +2199,7 @@ pub(crate) mod tests {
     fn test_fixed_length_binary_column_reader() {
         run_single_column_reader_tests::<FixedLenByteArrayType, _, RandFixedLenGen>(
             20,
-            ConvertedType::NONE,
+            None,
             None,
             |vals| {
                 let mut builder = FixedSizeBinaryBuilder::with_capacity(vals.len(), 20);
@@ -2219,7 +2219,7 @@ pub(crate) mod tests {
     fn test_interval_day_time_column_reader() {
         run_single_column_reader_tests::<FixedLenByteArrayType, _, RandFixedLenGen>(
             12,
-            ConvertedType::INTERVAL,
+            Some(ConvertedType::INTERVAL),
             None,
             |vals| {
                 Arc::new(
@@ -2306,7 +2306,7 @@ pub(crate) mod tests {
         resolutions.iter().for_each(|(arrow_type, converter)| {
             run_single_column_reader_tests::<Int96Type, _, Int96Type>(
                 2,
-                ConvertedType::NONE,
+                None,
                 arrow_type.clone(),
                 converter,
                 encodings,
@@ -2439,7 +2439,7 @@ pub(crate) mod tests {
 
         run_single_column_reader_tests::<ByteArrayType, _, RandUtf8Gen>(
             2,
-            ConvertedType::NONE,
+            None,
             None,
             |vals| {
                 Arc::new(BinaryArray::from_iter(
@@ -2451,7 +2451,7 @@ pub(crate) mod tests {
 
         run_single_column_reader_tests::<ByteArrayType, _, RandUtf8Gen>(
             2,
-            ConvertedType::UTF8,
+            Some(ConvertedType::UTF8),
             None,
             string_converter::<i32>,
             encodings,
@@ -2459,7 +2459,7 @@ pub(crate) mod tests {
 
         run_single_column_reader_tests::<ByteArrayType, _, RandUtf8Gen>(
             2,
-            ConvertedType::UTF8,
+            Some(ConvertedType::UTF8),
             Some(ArrowDataType::Utf8),
             string_converter::<i32>,
             encodings,
@@ -2467,7 +2467,7 @@ pub(crate) mod tests {
 
         run_single_column_reader_tests::<ByteArrayType, _, RandUtf8Gen>(
             2,
-            ConvertedType::UTF8,
+            Some(ConvertedType::UTF8),
             Some(ArrowDataType::LargeUtf8),
             string_converter::<i64>,
             encodings,
@@ -2486,7 +2486,7 @@ pub(crate) mod tests {
                 single_column_reader_test::<ByteArrayType, _, RandUtf8Gen>(
                     opts,
                     2,
-                    ConvertedType::UTF8,
+                    Some(ConvertedType::UTF8),
                     Some(data_type.clone()),
                     move |vals| {
                         let vals = string_converter::<i32>(vals);
@@ -2511,7 +2511,7 @@ pub(crate) mod tests {
 
             run_single_column_reader_tests::<ByteArrayType, _, RandUtf8Gen>(
                 2,
-                ConvertedType::UTF8,
+                Some(ConvertedType::UTF8),
                 Some(data_type.clone()),
                 move |vals| {
                     let vals = string_converter::<i32>(vals);
@@ -2527,7 +2527,7 @@ pub(crate) mod tests {
 
             run_single_column_reader_tests::<ByteArrayType, _, RandUtf8Gen>(
                 2,
-                ConvertedType::UTF8,
+                Some(ConvertedType::UTF8),
                 Some(data_type.clone()),
                 move |vals| {
                     let vals = string_converter::<i64>(vals);
@@ -3162,7 +3162,7 @@ pub(crate) mod tests {
     /// value generator
     fn run_single_column_reader_tests<T, F, G>(
         rand_max: i32,
-        converted_type: ConvertedType,
+        converted_type: Option<ConvertedType>,
         arrow_type: Option<ArrowDataType>,
         converter: F,
         encodings: &[Encoding],
@@ -3312,7 +3312,7 @@ pub(crate) mod tests {
     fn single_column_reader_test<T, F, G>(
         opts: TestOptions,
         rand_max: i32,
-        converted_type: ConvertedType,
+        converted_type: Option<ConvertedType>,
         arrow_type: Option<ArrowDataType>,
         converter: F,
     ) where
@@ -3322,7 +3322,7 @@ pub(crate) mod tests {
     {
         // Print out options to facilitate debugging failures on CI
         println!(
-            "Running type {:?} single_column_reader_test ConvertedType::{}/ArrowType::{:?} with Options: {:?}",
+            "Running type {:?} single_column_reader_test ConvertedType::{:?}/ArrowType::{:?} with Options: {:?}",
             T::get_physical_type(),
             converted_type,
             arrow_type,
@@ -3812,7 +3812,7 @@ pub(crate) mod tests {
         let fields = vec![Arc::new(
             Type::primitive_type_builder("leaf", PhysicalType::BYTE_ARRAY)
                 .with_repetition(Repetition::OPTIONAL)
-                .with_converted_type(ConvertedType::UTF8)
+                .with_converted_type(Some(ConvertedType::UTF8))
                 .build()
                 .unwrap(),
         )];

--- a/parquet/src/arrow/schema/complex.rs
+++ b/parquet/src/arrow/schema/complex.rs
@@ -670,12 +670,16 @@ impl Visitor {
         if cur_type.is_primitive() {
             self.visit_primitive(cur_type, context)
         } else {
-            match cur_type.get_basic_info().converted_type() {
-                ConvertedType::LIST => self.visit_list(cur_type, context),
-                ConvertedType::MAP | ConvertedType::MAP_KEY_VALUE => {
-                    self.visit_map(cur_type, context)
+            if let Some(converted_type) = cur_type.get_basic_info().converted_type() {
+                match converted_type {
+                    ConvertedType::LIST => self.visit_list(cur_type, context),
+                    ConvertedType::MAP | ConvertedType::MAP_KEY_VALUE => {
+                        self.visit_map(cur_type, context)
+                    }
+                    _ => self.visit_struct(cur_type, context),
                 }
-                _ => self.visit_struct(cur_type, context),
+            } else {
+                self.visit_struct(cur_type, context)
             }
         }
     }

--- a/parquet/src/arrow/schema/complex.rs
+++ b/parquet/src/arrow/schema/complex.rs
@@ -670,16 +670,12 @@ impl Visitor {
         if cur_type.is_primitive() {
             self.visit_primitive(cur_type, context)
         } else {
-            if let Some(converted_type) = cur_type.get_basic_info().converted_type() {
-                match converted_type {
-                    ConvertedType::LIST => self.visit_list(cur_type, context),
-                    ConvertedType::MAP | ConvertedType::MAP_KEY_VALUE => {
-                        self.visit_map(cur_type, context)
-                    }
-                    _ => self.visit_struct(cur_type, context),
+            match cur_type.get_basic_info().converted_type() {
+                Some(ConvertedType::LIST) => self.visit_list(cur_type, context),
+                Some(ConvertedType::MAP) | Some(ConvertedType::MAP_KEY_VALUE) => {
+                    self.visit_map(cur_type, context)
                 }
-            } else {
-                self.visit_struct(cur_type, context)
+                _ => self.visit_struct(cur_type, context),
             }
         }
     }

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -703,7 +703,7 @@ fn arrow_to_parquet_type(field: &Field, coerce_types: bool) -> Result<Type> {
             .build(),
         DataType::Interval(_) => {
             Type::primitive_type_builder(name, PhysicalType::FIXED_LEN_BYTE_ARRAY)
-                .with_converted_type(ConvertedType::INTERVAL)
+                .with_converted_type(Some(ConvertedType::INTERVAL))
                 .with_repetition(repetition)
                 .with_id(id)
                 .with_length(12)

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -379,7 +379,7 @@ pub fn add_encoded_arrow_schema_to_metadata(schema: &Schema, props: &mut WriterP
 ///         ),
 ///         Arc::new(
 ///          Type::primitive_type_builder("b", basic::Type::INT32)
-///           .with_converted_type(basic::ConvertedType::DATE)
+///           .with_converted_type(Some(basic::ConvertedType::DATE))
 ///           .with_logical_type(Some(basic::LogicalType::Date))
 ///           .build().unwrap()
 ///         ),

--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -170,7 +170,7 @@ fn decimal_256_type(scale: i32, precision: i32) -> Result<DataType> {
 
 fn from_int32(info: &BasicTypeInfo, scale: i32, precision: i32) -> Result<DataType> {
     match (info.logical_type_ref(), info.converted_type()) {
-        (None, ConvertedType::NONE) => Ok(DataType::Int32),
+        (None, None) => Ok(DataType::Int32),
         (
             Some(
                 ref t @ LogicalType::Integer {
@@ -199,17 +199,17 @@ fn from_int32(info: &BasicTypeInfo, scale: i32, precision: i32) -> Result<DataTy
                 unit
             )),
         },
-        (None, ConvertedType::UINT_8) => Ok(DataType::UInt8),
-        (None, ConvertedType::UINT_16) => Ok(DataType::UInt16),
-        (None, ConvertedType::UINT_32) => Ok(DataType::UInt32),
-        (None, ConvertedType::INT_8) => Ok(DataType::Int8),
-        (None, ConvertedType::INT_16) => Ok(DataType::Int16),
-        (None, ConvertedType::INT_32) => Ok(DataType::Int32),
-        (None, ConvertedType::DATE) => Ok(DataType::Date32),
-        (None, ConvertedType::TIME_MILLIS) => Ok(DataType::Time32(TimeUnit::Millisecond)),
-        (None, ConvertedType::DECIMAL) => decimal_128_type(scale, precision),
+        (None, Some(ConvertedType::UINT_8)) => Ok(DataType::UInt8),
+        (None, Some(ConvertedType::UINT_16)) => Ok(DataType::UInt16),
+        (None, Some(ConvertedType::UINT_32)) => Ok(DataType::UInt32),
+        (None, Some(ConvertedType::INT_8)) => Ok(DataType::Int8),
+        (None, Some(ConvertedType::INT_16)) => Ok(DataType::Int16),
+        (None, Some(ConvertedType::INT_32)) => Ok(DataType::Int32),
+        (None, Some(ConvertedType::DATE)) => Ok(DataType::Date32),
+        (None, Some(ConvertedType::TIME_MILLIS)) => Ok(DataType::Time32(TimeUnit::Millisecond)),
+        (None, Some(ConvertedType::DECIMAL)) => decimal_128_type(scale, precision),
         (logical, converted) => Err(arrow_err!(
-            "Unable to convert parquet INT32 logical type {:?} or converted type {}",
+            "Unable to convert parquet INT32 logical type {:?} or converted type {:?}",
             logical,
             converted
         )),
@@ -218,7 +218,7 @@ fn from_int32(info: &BasicTypeInfo, scale: i32, precision: i32) -> Result<DataTy
 
 fn from_int64(info: &BasicTypeInfo, scale: i32, precision: i32) -> Result<DataType> {
     match (info.logical_type_ref(), info.converted_type()) {
-        (None, ConvertedType::NONE) => Ok(DataType::Int64),
+        (None, None) => Ok(DataType::Int64),
         (
             Some(LogicalType::Integer {
                 bit_width: 64,
@@ -254,23 +254,23 @@ fn from_int64(info: &BasicTypeInfo, scale: i32, precision: i32) -> Result<DataTy
                 None
             },
         )),
-        (None, ConvertedType::INT_64) => Ok(DataType::Int64),
-        (None, ConvertedType::UINT_64) => Ok(DataType::UInt64),
-        (None, ConvertedType::TIME_MICROS) => Ok(DataType::Time64(TimeUnit::Microsecond)),
-        (None, ConvertedType::TIMESTAMP_MILLIS) => Ok(DataType::Timestamp(
+        (None, Some(ConvertedType::INT_64)) => Ok(DataType::Int64),
+        (None, Some(ConvertedType::UINT_64)) => Ok(DataType::UInt64),
+        (None, Some(ConvertedType::TIME_MICROS)) => Ok(DataType::Time64(TimeUnit::Microsecond)),
+        (None, Some(ConvertedType::TIMESTAMP_MILLIS)) => Ok(DataType::Timestamp(
             TimeUnit::Millisecond,
             Some("UTC".into()),
         )),
-        (None, ConvertedType::TIMESTAMP_MICROS) => Ok(DataType::Timestamp(
+        (None, Some(ConvertedType::TIMESTAMP_MICROS)) => Ok(DataType::Timestamp(
             TimeUnit::Microsecond,
             Some("UTC".into()),
         )),
         (Some(LogicalType::Decimal { scale, precision }), _) => {
             decimal_128_type(*scale, *precision)
         }
-        (None, ConvertedType::DECIMAL) => decimal_128_type(scale, precision),
+        (None, Some(ConvertedType::DECIMAL)) => decimal_128_type(scale, precision),
         (logical, converted) => Err(arrow_err!(
-            "Unable to convert parquet INT64 logical type {:?} or converted type {}",
+            "Unable to convert parquet INT64 logical type {:?} or converted type {:?}",
             logical,
             converted
         )),
@@ -286,11 +286,11 @@ fn from_byte_array(info: &BasicTypeInfo, precision: i32, scale: i32) -> Result<D
         (Some(LogicalType::Geometry { .. }), _) => Ok(DataType::Binary),
         (Some(LogicalType::Geography { .. }), _) => Ok(DataType::Binary),
         (Some(LogicalType::_Unknown { .. }), _) => Ok(DataType::Binary),
-        (None, ConvertedType::NONE) => Ok(DataType::Binary),
-        (None, ConvertedType::JSON) => Ok(DataType::Utf8),
-        (None, ConvertedType::BSON) => Ok(DataType::Binary),
-        (None, ConvertedType::ENUM) => Ok(DataType::Binary),
-        (None, ConvertedType::UTF8) => Ok(DataType::Utf8),
+        (None, None) => Ok(DataType::Binary),
+        (None, Some(ConvertedType::JSON)) => Ok(DataType::Utf8),
+        (None, Some(ConvertedType::BSON)) => Ok(DataType::Binary),
+        (None, Some(ConvertedType::ENUM)) => Ok(DataType::Binary),
+        (None, Some(ConvertedType::UTF8)) => Ok(DataType::Utf8),
         (
             Some(LogicalType::Decimal {
                 scale: s,
@@ -298,9 +298,9 @@ fn from_byte_array(info: &BasicTypeInfo, precision: i32, scale: i32) -> Result<D
             }),
             _,
         ) => decimal_type(*s, *p),
-        (None, ConvertedType::DECIMAL) => decimal_type(scale, precision),
+        (None, Some(ConvertedType::DECIMAL)) => decimal_type(scale, precision),
         (logical, converted) => Err(arrow_err!(
-            "Unable to convert parquet BYTE_ARRAY logical type {:?} or converted type {}",
+            "Unable to convert parquet BYTE_ARRAY logical type {:?} or converted type {:?}",
             logical,
             converted
         )),
@@ -322,14 +322,14 @@ fn from_fixed_len_byte_array(
                 decimal_256_type(*scale, *precision)
             }
         }
-        (None, ConvertedType::DECIMAL) => {
+        (None, Some(ConvertedType::DECIMAL)) => {
             if type_length <= 16 {
                 decimal_128_type(scale, precision)
             } else {
                 decimal_256_type(scale, precision)
             }
         }
-        (None, ConvertedType::INTERVAL) => {
+        (None, Some(ConvertedType::INTERVAL)) => {
             // There is currently no reliable way of determining which IntervalUnit
             // to return. Thus without the original Arrow schema, the results
             // would be incorrect if all 12 bytes of the interval are populated

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -62,8 +62,6 @@ enum Type {
 // ----------------------------------------------------------------------
 // Mirrors thrift enum `ConvertedType`
 
-// TODO(ets): Adding the `NONE` variant to this enum is a bit awkward. We should
-// look into removing it and using `Option<ConvertedType>` instead.
 thrift_enum!(
 /// Common types (converted types) used by frameworks when using Parquet.
 ///
@@ -73,9 +71,6 @@ thrift_enum!(
 /// This struct was renamed from `LogicalType` in version 4.0.0.
 /// If targeting Parquet format 2.4.0 or above, please use [LogicalType] instead.
 enum ConvertedType {
-  /// Not defined in the spec, used internally to indicate no type conversion
-  NONE = -1;
-
   /// A BYTE_ARRAY actually contains UTF8 encoded chars.
   UTF8 = 0;
 
@@ -1207,7 +1202,7 @@ impl ColumnOrder {
     )]
     pub fn get_sort_order(
         logical_type: Option<LogicalType>,
-        converted_type: ConvertedType,
+        converted_type: Option<ConvertedType>,
         physical_type: Type,
     ) -> SortOrder {
         Self::sort_order_for_type(logical_type.as_ref(), converted_type, physical_type)
@@ -1216,7 +1211,7 @@ impl ColumnOrder {
     /// Returns sort order for a physical/logical type.
     pub fn sort_order_for_type(
         logical_type: Option<&LogicalType>,
-        converted_type: ConvertedType,
+        converted_type: Option<ConvertedType>,
         physical_type: Type,
     ) -> SortOrder {
         match logical_type {
@@ -1246,42 +1241,47 @@ impl ColumnOrder {
         }
     }
 
-    fn get_converted_sort_order(converted_type: ConvertedType, physical_type: Type) -> SortOrder {
-        match converted_type {
-            // Unsigned byte-wise comparison.
-            ConvertedType::UTF8
-            | ConvertedType::JSON
-            | ConvertedType::BSON
-            | ConvertedType::ENUM => SortOrder::UNSIGNED,
+    fn get_converted_sort_order(
+        converted_type: Option<ConvertedType>,
+        physical_type: Type,
+    ) -> SortOrder {
+        if let Some(converted_type) = converted_type {
+            match converted_type {
+                // Unsigned byte-wise comparison.
+                ConvertedType::UTF8
+                | ConvertedType::JSON
+                | ConvertedType::BSON
+                | ConvertedType::ENUM => SortOrder::UNSIGNED,
 
-            ConvertedType::INT_8
-            | ConvertedType::INT_16
-            | ConvertedType::INT_32
-            | ConvertedType::INT_64 => SortOrder::SIGNED,
+                ConvertedType::INT_8
+                | ConvertedType::INT_16
+                | ConvertedType::INT_32
+                | ConvertedType::INT_64 => SortOrder::SIGNED,
 
-            ConvertedType::UINT_8
-            | ConvertedType::UINT_16
-            | ConvertedType::UINT_32
-            | ConvertedType::UINT_64 => SortOrder::UNSIGNED,
+                ConvertedType::UINT_8
+                | ConvertedType::UINT_16
+                | ConvertedType::UINT_32
+                | ConvertedType::UINT_64 => SortOrder::UNSIGNED,
 
-            // Signed comparison of the represented value.
-            ConvertedType::DECIMAL => SortOrder::SIGNED,
+                // Signed comparison of the represented value.
+                ConvertedType::DECIMAL => SortOrder::SIGNED,
 
-            ConvertedType::DATE => SortOrder::SIGNED,
+                ConvertedType::DATE => SortOrder::SIGNED,
 
-            ConvertedType::TIME_MILLIS
-            | ConvertedType::TIME_MICROS
-            | ConvertedType::TIMESTAMP_MILLIS
-            | ConvertedType::TIMESTAMP_MICROS => SortOrder::SIGNED,
+                ConvertedType::TIME_MILLIS
+                | ConvertedType::TIME_MICROS
+                | ConvertedType::TIMESTAMP_MILLIS
+                | ConvertedType::TIMESTAMP_MICROS => SortOrder::SIGNED,
 
-            ConvertedType::INTERVAL => SortOrder::UNDEFINED,
+                ConvertedType::INTERVAL => SortOrder::UNDEFINED,
 
-            ConvertedType::LIST | ConvertedType::MAP | ConvertedType::MAP_KEY_VALUE => {
-                SortOrder::UNDEFINED
+                ConvertedType::LIST | ConvertedType::MAP | ConvertedType::MAP_KEY_VALUE => {
+                    SortOrder::UNDEFINED
+                }
             }
-
+        } else {
             // Fall back to physical type.
-            ConvertedType::NONE => Self::get_default_sort_order(physical_type),
+            Self::get_default_sort_order(physical_type)
         }
     }
 
@@ -1381,60 +1381,55 @@ impl fmt::Display for ColumnOrder {
 // ----------------------------------------------------------------------
 // LogicalType <=> ConvertedType conversion
 
-// Note: To prevent type loss when converting from ConvertedType to LogicalType,
-// the conversion from ConvertedType -> LogicalType is not implemented.
-// Such type loss includes:
-// - Not knowing the decimal scale and precision of ConvertedType
-// - Time and timestamp nanosecond precision, that is not supported in ConvertedType.
-
-impl From<Option<LogicalType>> for ConvertedType {
-    fn from(value: Option<LogicalType>) -> Self {
-        match value {
-            Some(value) => match value {
-                LogicalType::String => ConvertedType::UTF8,
-                LogicalType::Map => ConvertedType::MAP,
-                LogicalType::List => ConvertedType::LIST,
-                LogicalType::Enum => ConvertedType::ENUM,
-                LogicalType::Decimal { .. } => ConvertedType::DECIMAL,
-                LogicalType::Date => ConvertedType::DATE,
-                LogicalType::Time { unit, .. } => match unit {
-                    TimeUnit::MILLIS => ConvertedType::TIME_MILLIS,
-                    TimeUnit::MICROS => ConvertedType::TIME_MICROS,
-                    TimeUnit::NANOS => ConvertedType::NONE,
-                },
-                LogicalType::Timestamp { unit, .. } => match unit {
-                    TimeUnit::MILLIS => ConvertedType::TIMESTAMP_MILLIS,
-                    TimeUnit::MICROS => ConvertedType::TIMESTAMP_MICROS,
-                    TimeUnit::NANOS => ConvertedType::NONE,
-                },
-                LogicalType::Integer {
-                    bit_width,
-                    is_signed,
-                } => match (bit_width, is_signed) {
-                    (8, true) => ConvertedType::INT_8,
-                    (16, true) => ConvertedType::INT_16,
-                    (32, true) => ConvertedType::INT_32,
-                    (64, true) => ConvertedType::INT_64,
-                    (8, false) => ConvertedType::UINT_8,
-                    (16, false) => ConvertedType::UINT_16,
-                    (32, false) => ConvertedType::UINT_32,
-                    (64, false) => ConvertedType::UINT_64,
-                    (bit_width, is_signed) => panic!(
-                        "Integer type bit_width={bit_width}, signed={is_signed} is not supported"
-                    ),
-                },
-                LogicalType::Json => ConvertedType::JSON,
-                LogicalType::Bson => ConvertedType::BSON,
-                LogicalType::Uuid
-                | LogicalType::Float16
-                | LogicalType::Variant { .. }
-                | LogicalType::Geometry { .. }
-                | LogicalType::Geography { .. }
-                | LogicalType::_Unknown { .. }
-                | LogicalType::Unknown => ConvertedType::NONE,
+/// Convert a [`LogicalType`] to the appropriate [`ConvertedType`].
+///
+/// Returns `None` if there is no defined conversion.
+///
+/// Note: To prevent type loss when converting from `ConvertedType` to `LogicalType`,
+/// the conversion from `ConvertedType` -> `LogicalType` is not implemented.
+/// Such type loss includes:
+/// - Not knowing the decimal scale and precision of `ConvertedType`
+/// - Time and timestamp nanosecond precision, that is not supported in `ConvertedType`.
+pub fn converted_type_for_logical(value: Option<LogicalType>) -> Option<ConvertedType> {
+    match value {
+        Some(value) => match value {
+            LogicalType::String => Some(ConvertedType::UTF8),
+            LogicalType::Map => Some(ConvertedType::MAP),
+            LogicalType::List => Some(ConvertedType::LIST),
+            LogicalType::Enum => Some(ConvertedType::ENUM),
+            LogicalType::Decimal { .. } => Some(ConvertedType::DECIMAL),
+            LogicalType::Date => Some(ConvertedType::DATE),
+            LogicalType::Time { unit, .. } => match unit {
+                TimeUnit::MILLIS => Some(ConvertedType::TIME_MILLIS),
+                TimeUnit::MICROS => Some(ConvertedType::TIME_MICROS),
+                TimeUnit::NANOS => None,
             },
-            None => ConvertedType::NONE,
-        }
+            LogicalType::Timestamp { unit, .. } => match unit {
+                TimeUnit::MILLIS => Some(ConvertedType::TIMESTAMP_MILLIS),
+                TimeUnit::MICROS => Some(ConvertedType::TIMESTAMP_MICROS),
+                TimeUnit::NANOS => None,
+            },
+            LogicalType::Integer {
+                bit_width,
+                is_signed,
+            } => match (bit_width, is_signed) {
+                (8, true) => Some(ConvertedType::INT_8),
+                (16, true) => Some(ConvertedType::INT_16),
+                (32, true) => Some(ConvertedType::INT_32),
+                (64, true) => Some(ConvertedType::INT_64),
+                (8, false) => Some(ConvertedType::UINT_8),
+                (16, false) => Some(ConvertedType::UINT_16),
+                (32, false) => Some(ConvertedType::UINT_32),
+                (64, false) => Some(ConvertedType::UINT_64),
+                (bit_width, is_signed) => panic!(
+                    "Integer type bit_width={bit_width}, signed={is_signed} is not supported"
+                ),
+            },
+            LogicalType::Json => Some(ConvertedType::JSON),
+            LogicalType::Bson => Some(ConvertedType::BSON),
+            _ => None,
+        },
+        None => None,
     }
 }
 
@@ -1477,7 +1472,6 @@ impl str::FromStr for ConvertedType {
 
     fn from_str(s: &str) -> Result<Self> {
         match s {
-            "NONE" => Ok(ConvertedType::NONE),
             "UTF8" => Ok(ConvertedType::UTF8),
             "MAP" => Ok(ConvertedType::MAP),
             "MAP_KEY_VALUE" => Ok(ConvertedType::MAP_KEY_VALUE),
@@ -1858,163 +1852,154 @@ mod tests {
     #[test]
     fn test_logical_to_converted_type() {
         let logical_none: Option<LogicalType> = None;
-        assert_eq!(ConvertedType::from(logical_none), ConvertedType::NONE);
+        assert_eq!(converted_type_for_logical(logical_none), None);
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Decimal {
+            converted_type_for_logical(Some(LogicalType::Decimal {
                 precision: 20,
                 scale: 5
             })),
-            ConvertedType::DECIMAL
+            Some(ConvertedType::DECIMAL)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Bson)),
-            ConvertedType::BSON
+            converted_type_for_logical(Some(LogicalType::Bson)),
+            Some(ConvertedType::BSON)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Json)),
-            ConvertedType::JSON
+            converted_type_for_logical(Some(LogicalType::Json)),
+            Some(ConvertedType::JSON)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::String)),
-            ConvertedType::UTF8
+            converted_type_for_logical(Some(LogicalType::String)),
+            Some(ConvertedType::UTF8)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Date)),
-            ConvertedType::DATE
+            converted_type_for_logical(Some(LogicalType::Date)),
+            Some(ConvertedType::DATE)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Time {
+            converted_type_for_logical(Some(LogicalType::Time {
                 unit: TimeUnit::MILLIS,
                 is_adjusted_to_u_t_c: true,
             })),
-            ConvertedType::TIME_MILLIS
+            Some(ConvertedType::TIME_MILLIS)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Time {
+            converted_type_for_logical(Some(LogicalType::Time {
                 unit: TimeUnit::MICROS,
                 is_adjusted_to_u_t_c: true,
             })),
-            ConvertedType::TIME_MICROS
+            Some(ConvertedType::TIME_MICROS)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Time {
+            converted_type_for_logical(Some(LogicalType::Time {
                 unit: TimeUnit::NANOS,
                 is_adjusted_to_u_t_c: false,
             })),
-            ConvertedType::NONE
+            None
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Timestamp {
+            converted_type_for_logical(Some(LogicalType::Timestamp {
                 unit: TimeUnit::MILLIS,
                 is_adjusted_to_u_t_c: true,
             })),
-            ConvertedType::TIMESTAMP_MILLIS
+            Some(ConvertedType::TIMESTAMP_MILLIS)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Timestamp {
+            converted_type_for_logical(Some(LogicalType::Timestamp {
                 unit: TimeUnit::MICROS,
                 is_adjusted_to_u_t_c: false,
             })),
-            ConvertedType::TIMESTAMP_MICROS
+            Some(ConvertedType::TIMESTAMP_MICROS)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Timestamp {
+            converted_type_for_logical(Some(LogicalType::Timestamp {
                 unit: TimeUnit::NANOS,
                 is_adjusted_to_u_t_c: false,
             })),
-            ConvertedType::NONE
+            None
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(LogicalType::Integer {
                 bit_width: 8,
                 is_signed: false
             })),
-            ConvertedType::UINT_8
+            Some(ConvertedType::UINT_8)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(LogicalType::Integer {
                 bit_width: 8,
                 is_signed: true
             })),
-            ConvertedType::INT_8
+            Some(ConvertedType::INT_8)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(LogicalType::Integer {
                 bit_width: 16,
                 is_signed: false
             })),
-            ConvertedType::UINT_16
+            Some(ConvertedType::UINT_16)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(LogicalType::Integer {
                 bit_width: 16,
                 is_signed: true
             })),
-            ConvertedType::INT_16
+            Some(ConvertedType::INT_16)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(LogicalType::Integer {
                 bit_width: 32,
                 is_signed: false
             })),
-            ConvertedType::UINT_32
+            Some(ConvertedType::UINT_32)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(LogicalType::Integer {
                 bit_width: 32,
                 is_signed: true
             })),
-            ConvertedType::INT_32
+            Some(ConvertedType::INT_32)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(LogicalType::Integer {
                 bit_width: 64,
                 is_signed: false
             })),
-            ConvertedType::UINT_64
+            Some(ConvertedType::UINT_64)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(LogicalType::Integer {
                 bit_width: 64,
                 is_signed: true
             })),
-            ConvertedType::INT_64
+            Some(ConvertedType::INT_64)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::List)),
-            ConvertedType::LIST
+            converted_type_for_logical(Some(LogicalType::List)),
+            Some(ConvertedType::LIST)
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Map)),
-            ConvertedType::MAP
+            converted_type_for_logical(Some(LogicalType::Map)),
+            Some(ConvertedType::MAP)
+        );
+        assert_eq!(converted_type_for_logical(Some(LogicalType::Uuid)), None);
+        assert_eq!(
+            converted_type_for_logical(Some(LogicalType::Enum)),
+            Some(ConvertedType::ENUM)
+        );
+        assert_eq!(converted_type_for_logical(Some(LogicalType::Float16)), None);
+        assert_eq!(
+            converted_type_for_logical(Some(LogicalType::Geometry { crs: None })),
+            None
         );
         assert_eq!(
-            ConvertedType::from(Some(LogicalType::Uuid)),
-            ConvertedType::NONE
-        );
-        assert_eq!(
-            ConvertedType::from(Some(LogicalType::Enum)),
-            ConvertedType::ENUM
-        );
-        assert_eq!(
-            ConvertedType::from(Some(LogicalType::Float16)),
-            ConvertedType::NONE
-        );
-        assert_eq!(
-            ConvertedType::from(Some(LogicalType::Geometry { crs: None })),
-            ConvertedType::NONE
-        );
-        assert_eq!(
-            ConvertedType::from(Some(LogicalType::Geography {
+            converted_type_for_logical(Some(LogicalType::Geography {
                 crs: None,
                 algorithm: Some(EdgeInterpolationAlgorithm::default()),
             })),
-            ConvertedType::NONE
+            None
         );
-        assert_eq!(
-            ConvertedType::from(Some(LogicalType::Unknown)),
-            ConvertedType::NONE
-        );
+        assert_eq!(converted_type_for_logical(Some(LogicalType::Unknown)), None);
     }
 
     #[test]
@@ -2381,7 +2366,7 @@ mod tests {
         fn check_sort_order(types: Vec<ConvertedType>, expected_order: SortOrder) {
             for tpe in types {
                 assert_eq!(
-                    ColumnOrder::get_sort_order(None, tpe, Type::BYTE_ARRAY),
+                    ColumnOrder::get_sort_order(None, Some(tpe), Type::BYTE_ARRAY),
                     expected_order
                 );
             }
@@ -2426,7 +2411,10 @@ mod tests {
 
         // Check None logical type
         // This should return a sort order for byte array type.
-        check_sort_order(vec![ConvertedType::NONE], SortOrder::UNSIGNED);
+        assert_eq!(
+            ColumnOrder::get_sort_order(None, None, Type::BYTE_ARRAY),
+            SortOrder::UNSIGNED
+        );
     }
 
     #[test]

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -1390,7 +1390,7 @@ impl fmt::Display for ColumnOrder {
 /// Such type loss includes:
 /// - Not knowing the decimal scale and precision of `ConvertedType`
 /// - Time and timestamp nanosecond precision, that is not supported in `ConvertedType`.
-pub fn converted_type_for_logical(value: Option<LogicalType>) -> Option<ConvertedType> {
+pub fn converted_type_for_logical(value: Option<&LogicalType>) -> Option<ConvertedType> {
     match value {
         Some(value) => match value {
             LogicalType::String => Some(ConvertedType::UTF8),
@@ -1851,155 +1851,161 @@ mod tests {
 
     #[test]
     fn test_logical_to_converted_type() {
-        let logical_none: Option<LogicalType> = None;
+        let logical_none: Option<&LogicalType> = None;
         assert_eq!(converted_type_for_logical(logical_none), None);
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Decimal {
+            converted_type_for_logical(Some(&LogicalType::Decimal {
                 precision: 20,
                 scale: 5
             })),
             Some(ConvertedType::DECIMAL)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Bson)),
+            converted_type_for_logical(Some(&LogicalType::Bson)),
             Some(ConvertedType::BSON)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Json)),
+            converted_type_for_logical(Some(&LogicalType::Json)),
             Some(ConvertedType::JSON)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::String)),
+            converted_type_for_logical(Some(&LogicalType::String)),
             Some(ConvertedType::UTF8)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Date)),
+            converted_type_for_logical(Some(&LogicalType::Date)),
             Some(ConvertedType::DATE)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Time {
+            converted_type_for_logical(Some(&LogicalType::Time {
                 unit: TimeUnit::MILLIS,
                 is_adjusted_to_u_t_c: true,
             })),
             Some(ConvertedType::TIME_MILLIS)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Time {
+            converted_type_for_logical(Some(&LogicalType::Time {
                 unit: TimeUnit::MICROS,
                 is_adjusted_to_u_t_c: true,
             })),
             Some(ConvertedType::TIME_MICROS)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Time {
+            converted_type_for_logical(Some(&LogicalType::Time {
                 unit: TimeUnit::NANOS,
                 is_adjusted_to_u_t_c: false,
             })),
             None
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Timestamp {
+            converted_type_for_logical(Some(&LogicalType::Timestamp {
                 unit: TimeUnit::MILLIS,
                 is_adjusted_to_u_t_c: true,
             })),
             Some(ConvertedType::TIMESTAMP_MILLIS)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Timestamp {
+            converted_type_for_logical(Some(&LogicalType::Timestamp {
                 unit: TimeUnit::MICROS,
                 is_adjusted_to_u_t_c: false,
             })),
             Some(ConvertedType::TIMESTAMP_MICROS)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Timestamp {
+            converted_type_for_logical(Some(&LogicalType::Timestamp {
                 unit: TimeUnit::NANOS,
                 is_adjusted_to_u_t_c: false,
             })),
             None
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(&LogicalType::Integer {
                 bit_width: 8,
                 is_signed: false
             })),
             Some(ConvertedType::UINT_8)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(&LogicalType::Integer {
                 bit_width: 8,
                 is_signed: true
             })),
             Some(ConvertedType::INT_8)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(&LogicalType::Integer {
                 bit_width: 16,
                 is_signed: false
             })),
             Some(ConvertedType::UINT_16)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(&LogicalType::Integer {
                 bit_width: 16,
                 is_signed: true
             })),
             Some(ConvertedType::INT_16)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(&LogicalType::Integer {
                 bit_width: 32,
                 is_signed: false
             })),
             Some(ConvertedType::UINT_32)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(&LogicalType::Integer {
                 bit_width: 32,
                 is_signed: true
             })),
             Some(ConvertedType::INT_32)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(&LogicalType::Integer {
                 bit_width: 64,
                 is_signed: false
             })),
             Some(ConvertedType::UINT_64)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Integer {
+            converted_type_for_logical(Some(&LogicalType::Integer {
                 bit_width: 64,
                 is_signed: true
             })),
             Some(ConvertedType::INT_64)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::List)),
+            converted_type_for_logical(Some(&LogicalType::List)),
             Some(ConvertedType::LIST)
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Map)),
+            converted_type_for_logical(Some(&LogicalType::Map)),
             Some(ConvertedType::MAP)
         );
-        assert_eq!(converted_type_for_logical(Some(LogicalType::Uuid)), None);
+        assert_eq!(converted_type_for_logical(Some(&LogicalType::Uuid)), None);
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Enum)),
+            converted_type_for_logical(Some(&LogicalType::Enum)),
             Some(ConvertedType::ENUM)
         );
-        assert_eq!(converted_type_for_logical(Some(LogicalType::Float16)), None);
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Geometry { crs: None })),
+            converted_type_for_logical(Some(&LogicalType::Float16)),
             None
         );
         assert_eq!(
-            converted_type_for_logical(Some(LogicalType::Geography {
+            converted_type_for_logical(Some(&LogicalType::Geometry { crs: None })),
+            None
+        );
+        assert_eq!(
+            converted_type_for_logical(Some(&LogicalType::Geography {
                 crs: None,
                 algorithm: Some(EdgeInterpolationAlgorithm::default()),
             })),
             None
         );
-        assert_eq!(converted_type_for_logical(Some(LogicalType::Unknown)), None);
+        assert_eq!(
+            converted_type_for_logical(Some(&LogicalType::Unknown)),
+            None
+        );
     }
 
     #[test]

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -1644,7 +1644,6 @@ mod tests {
 
     #[test]
     fn test_display_converted_type() {
-        assert_eq!(ConvertedType::NONE.to_string(), "NONE");
         assert_eq!(ConvertedType::UTF8.to_string(), "UTF8");
         assert_eq!(ConvertedType::MAP.to_string(), "MAP");
         assert_eq!(ConvertedType::MAP_KEY_VALUE.to_string(), "MAP_KEY_VALUE");
@@ -1679,13 +1678,6 @@ mod tests {
 
     #[test]
     fn test_from_string_into_converted_type() {
-        assert_eq!(
-            ConvertedType::NONE
-                .to_string()
-                .parse::<ConvertedType>()
-                .unwrap(),
-            ConvertedType::NONE
-        );
         assert_eq!(
             ConvertedType::UTF8
                 .to_string()
@@ -2269,7 +2261,7 @@ mod tests {
         fn check_sort_order(types: Vec<LogicalType>, expected_order: SortOrder) {
             for tpe in types {
                 assert_eq!(
-                    ColumnOrder::get_sort_order(Some(tpe), ConvertedType::NONE, Type::BYTE_ARRAY),
+                    ColumnOrder::get_sort_order(Some(tpe), None, Type::BYTE_ARRAY),
                     expected_order
                 );
             }

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -1110,7 +1110,7 @@ mod tests {
     fn get_test_int32_type() -> SchemaType {
         SchemaType::primitive_type_builder("a", PhysicalType::INT32)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::INT_32)
+            .with_converted_type(Some(ConvertedType::INT_32))
             .with_length(-1)
             .build()
             .expect("build() should be OK")
@@ -1120,7 +1120,7 @@ mod tests {
     fn get_test_int64_type() -> SchemaType {
         SchemaType::primitive_type_builder("a", PhysicalType::INT64)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::INT_64)
+            .with_converted_type(Some(ConvertedType::INT_64))
             .with_length(-1)
             .build()
             .expect("build() should be OK")

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -154,7 +154,7 @@ impl<T: DataType> ColumnValueEncoderImpl<T> {
     fn write_slice(&mut self, slice: &[T::T]) -> Result<()> {
         if self.statistics_enabled != EnabledStatistics::None
             // INTERVAL, Geometry, and Geography have undefined sort order, so don't write min/max stats for them
-            && self.descr.converted_type() != ConvertedType::INTERVAL
+            && self.descr.converted_type() != Some(ConvertedType::INTERVAL)
         {
             if let Some(accumulator) = self.geo_stats_accumulator.as_deref_mut() {
                 update_geo_stats_accumulator(accumulator, slice.iter());

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -1530,16 +1530,16 @@ fn compare_greater<T: ParquetValueType>(descr: &ColumnDescriptor, a: &T, b: &T) 
                 return compare_greater_unsigned_int(a, b);
             }
 
-            if let Some(converted_type) = descr.converted_type() {
-                match converted_type {
+            if descr.converted_type().is_some_and(|ct| {
+                matches!(
+                    ct,
                     ConvertedType::UINT_8
-                    | ConvertedType::UINT_16
-                    | ConvertedType::UINT_32
-                    | ConvertedType::UINT_64 => {
-                        return compare_greater_unsigned_int(a, b);
-                    }
-                    _ => {}
-                };
+                        | ConvertedType::UINT_16
+                        | ConvertedType::UINT_32
+                        | ConvertedType::UINT_64
+                )
+            }) {
+                return compare_greater_unsigned_int(a, b);
             }
         }
         Type::FIXED_LEN_BYTE_ARRAY | Type::BYTE_ARRAY => {

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -1012,7 +1012,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     /// Returns `true` if this column's logical type is a UTF-8 string.
     fn is_utf8(&self) -> bool {
         self.get_descriptor().logical_type_ref() == Some(&LogicalType::String)
-            || self.get_descriptor().converted_type() == ConvertedType::UTF8
+            || self.get_descriptor().converted_type() == Some(ConvertedType::UTF8)
     }
 
     /// Truncates a binary statistic to at most `truncation_length` bytes.
@@ -1530,21 +1530,23 @@ fn compare_greater<T: ParquetValueType>(descr: &ColumnDescriptor, a: &T, b: &T) 
                 return compare_greater_unsigned_int(a, b);
             }
 
-            match descr.converted_type() {
-                ConvertedType::UINT_8
-                | ConvertedType::UINT_16
-                | ConvertedType::UINT_32
-                | ConvertedType::UINT_64 => {
-                    return compare_greater_unsigned_int(a, b);
-                }
-                _ => {}
-            };
+            if let Some(converted_type) = descr.converted_type() {
+                match converted_type {
+                    ConvertedType::UINT_8
+                    | ConvertedType::UINT_16
+                    | ConvertedType::UINT_32
+                    | ConvertedType::UINT_64 => {
+                        return compare_greater_unsigned_int(a, b);
+                    }
+                    _ => {}
+                };
+            }
         }
         Type::FIXED_LEN_BYTE_ARRAY | Type::BYTE_ARRAY => {
             if let Some(LogicalType::Decimal { .. }) = descr.logical_type_ref() {
                 return compare_greater_byte_array_decimals(a.as_bytes(), b.as_bytes());
             }
-            if let ConvertedType::DECIMAL = descr.converted_type() {
+            if let Some(ConvertedType::DECIMAL) = descr.converted_type() {
                 return compare_greater_byte_array_decimals(a.as_bytes(), b.as_bytes());
             }
             if let Some(LogicalType::Float16) = descr.logical_type_ref() {
@@ -4508,7 +4510,7 @@ mod tests {
         let tpe =
             SchemaType::primitive_type_builder("col", FixedLenByteArrayType::get_physical_type())
                 .with_length(12)
-                .with_converted_type(ConvertedType::INTERVAL)
+                .with_converted_type(Some(ConvertedType::INTERVAL))
                 .build()
                 .unwrap();
         ColumnDescriptor::new(Arc::new(tpe), 0, 0, path)
@@ -4536,7 +4538,7 @@ mod tests {
     ) -> ColumnDescriptor {
         let path = ColumnPath::from("col");
         let tpe = SchemaType::primitive_type_builder("col", T::get_physical_type())
-            .with_converted_type(ConvertedType::UINT_32)
+            .with_converted_type(Some(ConvertedType::UINT_32))
             .build()
             .unwrap();
         ColumnDescriptor::new(Arc::new(tpe), max_def_level, max_rep_level, path)

--- a/parquet/src/file/metadata/thrift/mod.rs
+++ b/parquet/src/file/metadata/thrift/mod.rs
@@ -1510,10 +1510,7 @@ fn write_schema_helper<W: Write>(
                 repetition_type: Some(basic_info.repetition()),
                 name: basic_info.name(),
                 num_children: None,
-                converted_type: match basic_info.converted_type() {
-                    ConvertedType::NONE => None,
-                    other => Some(other),
-                },
+                converted_type: basic_info.converted_type(),
                 scale: if *scale >= 0 { Some(*scale) } else { None },
                 precision: if *precision >= 0 {
                     Some(*precision)
@@ -1542,10 +1539,7 @@ fn write_schema_helper<W: Write>(
                 repetition_type: repetition,
                 name: basic_info.name(),
                 num_children: Some(fields.len().try_into()?),
-                converted_type: match basic_info.converted_type() {
-                    ConvertedType::NONE => None,
-                    other => Some(other),
-                },
+                converted_type: basic_info.converted_type(),
                 scale: None,
                 precision: None,
                 field_id: if basic_info.has_id() {

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1051,7 +1051,8 @@ mod tests {
     #[cfg(feature = "arrow")]
     use crate::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use crate::basic::{
-        ColumnOrder, Compression, ConvertedType, Encoding, LogicalType, Repetition, SortOrder, Type,
+        ColumnOrder, Compression, ConvertedType, Encoding, LogicalType, Repetition, SortOrder,
+        Type, converted_type_for_logical,
     };
     use crate::column::page::{Page, PageReader};
     use crate::column::reader::get_typed_column_reader;
@@ -1287,7 +1288,7 @@ mod tests {
         let field = Arc::new(
             types::Type::primitive_type_builder("col1", Type::INT32)
                 .with_logical_type(field_logical_type.clone())
-                .with_converted_type(field_logical_type.into())
+                .with_converted_type(converted_type_for_logical(field_logical_type.as_ref()))
                 .build()
                 .unwrap(),
         );

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1181,7 +1181,7 @@ mod tests {
                     ),
                     Arc::new(
                         types::Type::primitive_type_builder("col2", Type::FIXED_LEN_BYTE_ARRAY)
-                            .with_converted_type(ConvertedType::INTERVAL)
+                            .with_converted_type(Some(ConvertedType::INTERVAL))
                             .with_length(12)
                             .build()
                             .unwrap(),

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -36,7 +36,7 @@ use serde_json::Value;
 macro_rules! nyi {
     ($column_descr:ident, $value:ident) => {{
         unimplemented!(
-            "Conversion for physical type {}, converted type {}, value {:?}",
+            "Conversion for physical type {}, converted type {:?}, value {:?}",
             $column_descr.physical_type(),
             $column_descr.converted_type(),
             $value
@@ -672,15 +672,15 @@ impl Field {
     #[inline]
     pub fn convert_int32(descr: &ColumnDescPtr, value: i32) -> Self {
         match descr.converted_type() {
-            ConvertedType::INT_8 => Field::Byte(value as i8),
-            ConvertedType::INT_16 => Field::Short(value as i16),
-            ConvertedType::INT_32 | ConvertedType::NONE => Field::Int(value),
-            ConvertedType::UINT_8 => Field::UByte(value as u8),
-            ConvertedType::UINT_16 => Field::UShort(value as u16),
-            ConvertedType::UINT_32 => Field::UInt(value as u32),
-            ConvertedType::DATE => Field::Date(value),
-            ConvertedType::TIME_MILLIS => Field::TimeMillis(value),
-            ConvertedType::DECIMAL => Field::Decimal(Decimal::from_i32(
+            Some(ConvertedType::INT_8) => Field::Byte(value as i8),
+            Some(ConvertedType::INT_16) => Field::Short(value as i16),
+            Some(ConvertedType::INT_32) | None => Field::Int(value),
+            Some(ConvertedType::UINT_8) => Field::UByte(value as u8),
+            Some(ConvertedType::UINT_16) => Field::UShort(value as u16),
+            Some(ConvertedType::UINT_32) => Field::UInt(value as u32),
+            Some(ConvertedType::DATE) => Field::Date(value),
+            Some(ConvertedType::TIME_MILLIS) => Field::TimeMillis(value),
+            Some(ConvertedType::DECIMAL) => Field::Decimal(Decimal::from_i32(
                 value,
                 descr.type_precision(),
                 descr.type_scale(),
@@ -693,12 +693,12 @@ impl Field {
     #[inline]
     pub fn convert_int64(descr: &ColumnDescPtr, value: i64) -> Self {
         match descr.converted_type() {
-            ConvertedType::INT_64 | ConvertedType::NONE => Field::Long(value),
-            ConvertedType::UINT_64 => Field::ULong(value as u64),
-            ConvertedType::TIME_MICROS => Field::TimeMicros(value),
-            ConvertedType::TIMESTAMP_MILLIS => Field::TimestampMillis(value),
-            ConvertedType::TIMESTAMP_MICROS => Field::TimestampMicros(value),
-            ConvertedType::DECIMAL => Field::Decimal(Decimal::from_i64(
+            Some(ConvertedType::INT_64) | None => Field::Long(value),
+            Some(ConvertedType::UINT_64) => Field::ULong(value as u64),
+            Some(ConvertedType::TIME_MICROS) => Field::TimeMicros(value),
+            Some(ConvertedType::TIMESTAMP_MILLIS) => Field::TimestampMillis(value),
+            Some(ConvertedType::TIMESTAMP_MICROS) => Field::TimestampMicros(value),
+            Some(ConvertedType::DECIMAL) => Field::Decimal(Decimal::from_i64(
                 value,
                 descr.type_precision(),
                 descr.type_scale(),
@@ -732,7 +732,9 @@ impl Field {
     pub fn convert_byte_array(descr: &ColumnDescPtr, value: ByteArray) -> Result<Self> {
         let field = match descr.physical_type() {
             PhysicalType::BYTE_ARRAY => match descr.converted_type() {
-                ConvertedType::UTF8 | ConvertedType::ENUM | ConvertedType::JSON => {
+                Some(ConvertedType::UTF8)
+                | Some(ConvertedType::ENUM)
+                | Some(ConvertedType::JSON) => {
                     let value = String::from_utf8(value.data().to_vec()).map_err(|e| {
                         general_err!(
                             "Error reading BYTE_ARRAY as String. Bytes: {:?} Error: {:?}",
@@ -742,8 +744,8 @@ impl Field {
                     })?;
                     Field::Str(value)
                 }
-                ConvertedType::BSON | ConvertedType::NONE => Field::Bytes(value),
-                ConvertedType::DECIMAL => Field::Decimal(Decimal::from_bytes(
+                Some(ConvertedType::BSON) | None => Field::Bytes(value),
+                Some(ConvertedType::DECIMAL) => Field::Decimal(Decimal::from_bytes(
                     value,
                     descr.type_precision(),
                     descr.type_scale(),
@@ -751,12 +753,12 @@ impl Field {
                 _ => nyi!(descr, value),
             },
             PhysicalType::FIXED_LEN_BYTE_ARRAY => match descr.converted_type() {
-                ConvertedType::DECIMAL => Field::Decimal(Decimal::from_bytes(
+                Some(ConvertedType::DECIMAL) => Field::Decimal(Decimal::from_bytes(
                     value,
                     descr.type_precision(),
                     descr.type_scale(),
                 )),
-                ConvertedType::NONE if descr.logical_type_ref() == Some(&LogicalType::Float16) => {
+                None if descr.logical_type_ref() == Some(&LogicalType::Float16) => {
                     if value.len() != 2 {
                         return Err(general_err!(
                             "Error reading FIXED_LEN_BYTE_ARRAY as FLOAT16. Length must be 2, got {}",
@@ -766,7 +768,7 @@ impl Field {
                     let bytes = [value.data()[0], value.data()[1]];
                     Field::Float16(f16::from_le_bytes(bytes))
                 }
-                ConvertedType::NONE => Field::Bytes(value),
+                None => Field::Bytes(value),
                 _ => nyi!(descr, value),
             },
             _ => nyi!(descr, value),
@@ -1048,7 +1050,7 @@ mod tests {
     #[test]
     fn test_row_convert_bool() {
         // BOOLEAN value does not depend on logical type
-        let descr = make_column_descr![PhysicalType::BOOLEAN, ConvertedType::NONE];
+        let descr = make_column_descr![PhysicalType::BOOLEAN, None];
 
         let row = Field::convert_bool(&descr, true);
         assert_eq!(row, Field::Bool(true));
@@ -1059,74 +1061,74 @@ mod tests {
 
     #[test]
     fn test_row_convert_int32() {
-        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::INT_8];
+        let descr = make_column_descr![PhysicalType::INT32, Some(ConvertedType::INT_8)];
         let row = Field::convert_int32(&descr, 111);
         assert_eq!(row, Field::Byte(111));
 
-        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::INT_16];
+        let descr = make_column_descr![PhysicalType::INT32, Some(ConvertedType::INT_16)];
         let row = Field::convert_int32(&descr, 222);
         assert_eq!(row, Field::Short(222));
 
-        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::INT_32];
+        let descr = make_column_descr![PhysicalType::INT32, Some(ConvertedType::INT_32)];
         let row = Field::convert_int32(&descr, 333);
         assert_eq!(row, Field::Int(333));
 
-        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::UINT_8];
+        let descr = make_column_descr![PhysicalType::INT32, Some(ConvertedType::UINT_8)];
         let row = Field::convert_int32(&descr, -1);
         assert_eq!(row, Field::UByte(255));
 
-        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::UINT_16];
+        let descr = make_column_descr![PhysicalType::INT32, Some(ConvertedType::UINT_16)];
         let row = Field::convert_int32(&descr, 256);
         assert_eq!(row, Field::UShort(256));
 
-        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::UINT_32];
+        let descr = make_column_descr![PhysicalType::INT32, Some(ConvertedType::UINT_32)];
         let row = Field::convert_int32(&descr, 1234);
         assert_eq!(row, Field::UInt(1234));
 
-        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::NONE];
+        let descr = make_column_descr![PhysicalType::INT32, None];
         let row = Field::convert_int32(&descr, 444);
         assert_eq!(row, Field::Int(444));
 
-        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::DATE];
+        let descr = make_column_descr![PhysicalType::INT32, Some(ConvertedType::DATE)];
         let row = Field::convert_int32(&descr, 14611);
         assert_eq!(row, Field::Date(14611));
 
-        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::TIME_MILLIS];
+        let descr = make_column_descr![PhysicalType::INT32, Some(ConvertedType::TIME_MILLIS)];
         let row = Field::convert_int32(&descr, 14611);
         assert_eq!(row, Field::TimeMillis(14611));
 
-        let descr = make_column_descr![PhysicalType::INT32, ConvertedType::DECIMAL, 0, 8, 2];
+        let descr = make_column_descr![PhysicalType::INT32, Some(ConvertedType::DECIMAL), 0, 8, 2];
         let row = Field::convert_int32(&descr, 444);
         assert_eq!(row, Field::Decimal(Decimal::from_i32(444, 8, 2)));
     }
 
     #[test]
     fn test_row_convert_int64() {
-        let descr = make_column_descr![PhysicalType::INT64, ConvertedType::INT_64];
+        let descr = make_column_descr![PhysicalType::INT64, Some(ConvertedType::INT_64)];
         let row = Field::convert_int64(&descr, 1111);
         assert_eq!(row, Field::Long(1111));
 
-        let descr = make_column_descr![PhysicalType::INT64, ConvertedType::UINT_64];
+        let descr = make_column_descr![PhysicalType::INT64, Some(ConvertedType::UINT_64)];
         let row = Field::convert_int64(&descr, 78239823);
         assert_eq!(row, Field::ULong(78239823));
 
-        let descr = make_column_descr![PhysicalType::INT64, ConvertedType::TIMESTAMP_MILLIS];
+        let descr = make_column_descr![PhysicalType::INT64, Some(ConvertedType::TIMESTAMP_MILLIS)];
         let row = Field::convert_int64(&descr, 1541186529153);
         assert_eq!(row, Field::TimestampMillis(1541186529153));
 
-        let descr = make_column_descr![PhysicalType::INT64, ConvertedType::TIMESTAMP_MICROS];
+        let descr = make_column_descr![PhysicalType::INT64, Some(ConvertedType::TIMESTAMP_MICROS)];
         let row = Field::convert_int64(&descr, 1541186529153123);
         assert_eq!(row, Field::TimestampMicros(1541186529153123));
 
-        let descr = make_column_descr![PhysicalType::INT64, ConvertedType::TIME_MICROS];
+        let descr = make_column_descr![PhysicalType::INT64, Some(ConvertedType::TIME_MICROS)];
         let row = Field::convert_int64(&descr, 47445123456);
         assert_eq!(row, Field::TimeMicros(47445123456));
 
-        let descr = make_column_descr![PhysicalType::INT64, ConvertedType::NONE];
+        let descr = make_column_descr![PhysicalType::INT64, None];
         let row = Field::convert_int64(&descr, 2222);
         assert_eq!(row, Field::Long(2222));
 
-        let descr = make_column_descr![PhysicalType::INT64, ConvertedType::DECIMAL, 0, 8, 2];
+        let descr = make_column_descr![PhysicalType::INT64, Some(ConvertedType::DECIMAL), 0, 8, 2];
         let row = Field::convert_int64(&descr, 3333);
         assert_eq!(row, Field::Decimal(Decimal::from_i64(3333, 8, 2)));
     }
@@ -1164,37 +1166,43 @@ mod tests {
     #[test]
     fn test_row_convert_byte_array() {
         // UTF8
-        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, ConvertedType::UTF8];
+        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, Some(ConvertedType::UTF8)];
         let value = ByteArray::from(vec![b'A', b'B', b'C', b'D']);
         let row = Field::convert_byte_array(&descr, value);
         assert_eq!(row.unwrap(), Field::Str("ABCD".to_string()));
 
         // ENUM
-        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, ConvertedType::ENUM];
+        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, Some(ConvertedType::ENUM)];
         let value = ByteArray::from(vec![b'1', b'2', b'3']);
         let row = Field::convert_byte_array(&descr, value);
         assert_eq!(row.unwrap(), Field::Str("123".to_string()));
 
         // JSON
-        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, ConvertedType::JSON];
+        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, Some(ConvertedType::JSON)];
         let value = ByteArray::from(vec![b'{', b'"', b'a', b'"', b':', b'1', b'}']);
         let row = Field::convert_byte_array(&descr, value);
         assert_eq!(row.unwrap(), Field::Str("{\"a\":1}".to_string()));
 
         // NONE
-        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, ConvertedType::NONE];
+        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, None];
         let value = ByteArray::from(vec![1, 2, 3, 4, 5]);
         let row = Field::convert_byte_array(&descr, value.clone());
         assert_eq!(row.unwrap(), Field::Bytes(value));
 
         // BSON
-        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, ConvertedType::BSON];
+        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, Some(ConvertedType::BSON)];
         let value = ByteArray::from(vec![1, 2, 3, 4, 5]);
         let row = Field::convert_byte_array(&descr, value.clone());
         assert_eq!(row.unwrap(), Field::Bytes(value));
 
         // DECIMAL
-        let descr = make_column_descr![PhysicalType::BYTE_ARRAY, ConvertedType::DECIMAL, 0, 8, 2];
+        let descr = make_column_descr![
+            PhysicalType::BYTE_ARRAY,
+            Some(ConvertedType::DECIMAL),
+            0,
+            8,
+            2
+        ];
         let value = ByteArray::from(vec![207, 200]);
         let row = Field::convert_byte_array(&descr, value.clone());
         assert_eq!(
@@ -1205,7 +1213,7 @@ mod tests {
         // DECIMAL (FIXED_LEN_BYTE_ARRAY)
         let descr = make_column_descr![
             PhysicalType::FIXED_LEN_BYTE_ARRAY,
-            ConvertedType::DECIMAL,
+            Some(ConvertedType::DECIMAL),
             8,
             17,
             5

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -1136,7 +1136,7 @@ mod tests {
     #[test]
     fn test_row_convert_int96() {
         // INT96 value does not depend on logical type
-        let descr = make_column_descr![PhysicalType::INT96, ConvertedType::NONE];
+        let descr = make_column_descr![PhysicalType::INT96, None];
 
         let value = Int96::from(vec![0, 0, 2454923]);
         let row = Field::convert_int96(&descr, value);
@@ -1150,7 +1150,7 @@ mod tests {
     #[test]
     fn test_row_convert_float() {
         // FLOAT value does not depend on logical type
-        let descr = make_column_descr![PhysicalType::FLOAT, ConvertedType::NONE];
+        let descr = make_column_descr![PhysicalType::FLOAT, None];
         let row = Field::convert_float(&descr, 2.31);
         assert_eq!(row, Field::Float(2.31));
     }
@@ -1158,7 +1158,7 @@ mod tests {
     #[test]
     fn test_row_convert_double() {
         // DOUBLE value does not depend on logical type
-        let descr = make_column_descr![PhysicalType::DOUBLE, ConvertedType::NONE];
+        let descr = make_column_descr![PhysicalType::DOUBLE, None];
         let row = Field::convert_double(&descr, 1.56);
         assert_eq!(row, Field::Double(1.56));
     }
@@ -1244,13 +1244,7 @@ mod tests {
         assert_eq!(row.unwrap(), Field::Float16(f16::PI));
 
         // NONE (FIXED_LEN_BYTE_ARRAY)
-        let descr = make_column_descr![
-            PhysicalType::FIXED_LEN_BYTE_ARRAY,
-            ConvertedType::NONE,
-            6,
-            0,
-            0
-        ];
+        let descr = make_column_descr![PhysicalType::FIXED_LEN_BYTE_ARRAY, None, 6, 0, 0];
         let value = ByteArray::from(vec![1, 2, 3, 4, 5, 6]);
         let row = Field::convert_byte_array(&descr, value.clone());
         assert_eq!(row.unwrap(), Field::Bytes(value));

--- a/parquet/src/record/reader.rs
+++ b/parquet/src/record/reader.rs
@@ -152,7 +152,7 @@ impl TreeBuilder {
         } else {
             match field.get_basic_info().converted_type() {
                 // List types
-                ConvertedType::LIST => {
+                Some(ConvertedType::LIST) => {
                     assert_eq!(field.get_fields().len(), 1, "Invalid list type {field:?}");
 
                     let repeated_field = field.get_fields()[0].clone();
@@ -204,7 +204,7 @@ impl TreeBuilder {
                     }
                 }
                 // Map types (key-value pairs)
-                ConvertedType::MAP | ConvertedType::MAP_KEY_VALUE => {
+                Some(ConvertedType::MAP) | Some(ConvertedType::MAP_KEY_VALUE) => {
                     assert_eq!(field.get_fields().len(), 1, "Invalid map type: {field:?}");
                     assert!(
                         !field.get_fields()[0].is_primitive(),

--- a/parquet/src/schema/mod.rs
+++ b/parquet/src/schema/mod.rs
@@ -48,7 +48,7 @@
 //! // }
 //!
 //! let field_a = Type::primitive_type_builder("a", PhysicalType::BYTE_ARRAY)
-//!     .with_converted_type(ConvertedType::UTF8)
+//!     .with_converted_type(Some(ConvertedType::UTF8))
 //!     .with_repetition(Repetition::OPTIONAL)
 //!     .build()
 //!     .unwrap();

--- a/parquet/src/schema/parser.rs
+++ b/parquet/src/schema/parser.rs
@@ -44,7 +44,10 @@
 
 use std::sync::Arc;
 
-use crate::basic::{ConvertedType, LogicalType, Repetition, TimeUnit, Type as PhysicalType};
+use crate::basic::{
+    ConvertedType, LogicalType, Repetition, TimeUnit, Type as PhysicalType,
+    converted_type_for_logical,
+};
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::{Type, TypePtr};
 
@@ -255,17 +258,18 @@ impl Parser<'_> {
                     let upper = v.to_uppercase();
                     let logical = upper.parse::<LogicalType>();
                     match logical {
-                        Ok(logical) => {
-                            Ok((Some(logical.clone()), ConvertedType::from(Some(logical))))
-                        }
-                        Err(_) => Ok((None, upper.parse::<ConvertedType>()?)),
+                        Ok(logical) => Ok((
+                            Some(logical.clone()),
+                            converted_type_for_logical(Some(&logical)),
+                        )),
+                        Err(_) => Ok((None, Some(upper.parse::<ConvertedType>()?))),
                     }
                 })?;
             assert_token(self.tokenizer.next(), ")")?;
             tpe
         } else {
             self.tokenizer.backtrack();
-            (None, ConvertedType::NONE)
+            (None, None)
         };
 
         // Parse optional id
@@ -322,10 +326,11 @@ impl Parser<'_> {
                     let upper = v.to_uppercase();
                     let logical = upper.parse::<LogicalType>();
                     match logical {
-                        Ok(logical) => {
-                            Ok((Some(logical.clone()), ConvertedType::from(Some(logical))))
-                        }
-                        Err(_) => Ok((None, upper.parse::<ConvertedType>()?)),
+                        Ok(logical) => Ok((
+                            Some(logical.clone()),
+                            converted_type_for_logical(Some(&logical)),
+                        )),
+                        Err(_) => Ok((None, Some(upper.parse::<ConvertedType>()?))),
                     }
                 })?;
 
@@ -354,7 +359,7 @@ impl Parser<'_> {
                                 scale = 0
                             }
                             logical = Some(LogicalType::Decimal { scale, precision });
-                            converted = ConvertedType::from(logical.clone());
+                            converted = converted_type_for_logical(logical.as_ref());
                         }
                     }
                     LogicalType::Time { .. } => {
@@ -375,7 +380,7 @@ impl Parser<'_> {
                                     is_adjusted_to_u_t_c,
                                     unit,
                                 });
-                                converted = ConvertedType::from(logical.clone());
+                                converted = converted_type_for_logical(logical.as_ref());
                             } else {
                                 // Invalid token for unit
                                 self.tokenizer.backtrack();
@@ -400,7 +405,7 @@ impl Parser<'_> {
                                     is_adjusted_to_u_t_c,
                                     unit,
                                 });
-                                converted = ConvertedType::from(logical.clone());
+                                converted = converted_type_for_logical(logical.as_ref());
                             } else {
                                 // Invalid token for unit
                                 self.tokenizer.backtrack();
@@ -450,7 +455,7 @@ impl Parser<'_> {
                                     bit_width,
                                     is_signed,
                                 });
-                                converted = ConvertedType::from(logical.clone());
+                                converted = converted_type_for_logical(logical.as_ref());
                             } else {
                                 // Invalid token for unit
                                 self.tokenizer.backtrack();
@@ -459,7 +464,7 @@ impl Parser<'_> {
                     }
                     _ => {}
                 }
-            } else if converted == ConvertedType::DECIMAL {
+            } else if converted == Some(ConvertedType::DECIMAL) {
                 if let Some("(") = self.tokenizer.next() {
                     // Parse precision
                     precision = parse_i32(
@@ -491,7 +496,7 @@ impl Parser<'_> {
             (logical, converted, precision, scale)
         } else {
             self.tokenizer.backtrack();
-            (None, ConvertedType::NONE, -1, -1)
+            (None, None, -1, -1)
         };
 
         // Parse optional id
@@ -837,7 +842,7 @@ mod tests {
                             precision: 9,
                             scale: 3,
                         }))
-                        .with_converted_type(ConvertedType::DECIMAL)
+                        .with_converted_type(Some(ConvertedType::DECIMAL))
                         .with_length(5)
                         .with_precision(9)
                         .with_scale(3)
@@ -850,7 +855,7 @@ mod tests {
                             precision: 38,
                             scale: 18,
                         }))
-                        .with_converted_type(ConvertedType::DECIMAL)
+                        .with_converted_type(Some(ConvertedType::DECIMAL))
                         .with_length(16)
                         .with_precision(38)
                         .with_scale(18)
@@ -900,11 +905,11 @@ mod tests {
                             Type::group_type_builder("a1")
                                 .with_repetition(Repetition::OPTIONAL)
                                 .with_logical_type(Some(LogicalType::List))
-                                .with_converted_type(ConvertedType::LIST)
+                                .with_converted_type(Some(ConvertedType::LIST))
                                 .with_fields(vec![Arc::new(
                                     Type::primitive_type_builder("a2", PhysicalType::BYTE_ARRAY)
                                         .with_repetition(Repetition::REPEATED)
-                                        .with_converted_type(ConvertedType::UTF8)
+                                        .with_converted_type(Some(ConvertedType::UTF8))
                                         .build()
                                         .unwrap(),
                                 )])
@@ -915,7 +920,7 @@ mod tests {
                             Type::group_type_builder("b1")
                                 .with_repetition(Repetition::OPTIONAL)
                                 .with_logical_type(Some(LogicalType::List))
-                                .with_converted_type(ConvertedType::LIST)
+                                .with_converted_type(Some(ConvertedType::LIST))
                                 .with_fields(vec![Arc::new(
                                     Type::group_type_builder("b2")
                                         .with_repetition(Repetition::REPEATED)
@@ -971,14 +976,14 @@ mod tests {
             Arc::new(
                 Type::primitive_type_builder("_1", PhysicalType::INT32)
                     .with_repetition(Repetition::REQUIRED)
-                    .with_converted_type(ConvertedType::INT_8)
+                    .with_converted_type(Some(ConvertedType::INT_8))
                     .build()
                     .unwrap(),
             ),
             Arc::new(
                 Type::primitive_type_builder("_2", PhysicalType::INT32)
                     .with_repetition(Repetition::REQUIRED)
-                    .with_converted_type(ConvertedType::INT_16)
+                    .with_converted_type(Some(ConvertedType::INT_16))
                     .build()
                     .unwrap(),
             ),
@@ -997,13 +1002,13 @@ mod tests {
             Arc::new(
                 Type::primitive_type_builder("_5", PhysicalType::INT32)
                     .with_logical_type(Some(LogicalType::Date))
-                    .with_converted_type(ConvertedType::DATE)
+                    .with_converted_type(Some(ConvertedType::DATE))
                     .build()
                     .unwrap(),
             ),
             Arc::new(
                 Type::primitive_type_builder("_6", PhysicalType::BYTE_ARRAY)
-                    .with_converted_type(ConvertedType::UTF8)
+                    .with_converted_type(Some(ConvertedType::UTF8))
                     .build()
                     .unwrap(),
             ),

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -1114,7 +1114,7 @@ mod tests {
 
         let b2 = Type::group_type_builder("b2")
             .with_repetition(Repetition::REPEATED)
-            .with_converted_type(ConvertedType::NONE)
+            .with_converted_type(None)
             .with_fields(vec![Arc::new(b3), Arc::new(b4)])
             .build()
             .unwrap();

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -101,7 +101,7 @@ pub fn print_file_metadata(out: &mut dyn io::Write, file_metadata: &FileMetaData
 ///
 /// let field_a = Type::primitive_type_builder("a", PhysicalType::BYTE_ARRAY)
 ///     .with_id(Some(42))
-///     .with_converted_type(ConvertedType::UTF8)
+///     .with_converted_type(Some(ConvertedType::UTF8))
 ///     .build()
 ///     .unwrap();
 ///

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -278,7 +278,7 @@ fn print_timeunit(unit: &TimeUnit) -> &str {
 #[inline]
 fn print_logical_and_converted(
     logical_type: Option<&LogicalType>,
-    converted_type: ConvertedType,
+    converted_type: Option<ConvertedType>,
     precision: i32,
     scale: i32,
 ) -> String {
@@ -342,23 +342,25 @@ fn print_logical_and_converted(
         None => {
             // Also print converted type if it is available
             match converted_type {
-                ConvertedType::NONE => String::new(),
-                decimal @ ConvertedType::DECIMAL => {
-                    // For decimal type we should print precision and scale if they
-                    // are > 0, e.g. DECIMAL(9,2) -
-                    // DECIMAL(9) - DECIMAL
-                    let precision_scale = match (precision, scale) {
-                        (p, s) if p > 0 && s > 0 => {
-                            format!("({p},{s})")
-                        }
-                        (p, 0) if p > 0 => format!("({p})"),
-                        _ => String::new(),
-                    };
-                    format!("{decimal}{precision_scale}")
-                }
-                other_converted_type => {
-                    format!("{other_converted_type}")
-                }
+                None => String::new(),
+                Some(converted_type) => match converted_type {
+                    decimal @ ConvertedType::DECIMAL => {
+                        // For decimal type we should print precision and scale if they
+                        // are > 0, e.g. DECIMAL(9,2) -
+                        // DECIMAL(9) - DECIMAL
+                        let precision_scale = match (precision, scale) {
+                            (p, s) if p > 0 && s > 0 => {
+                                format!("({p},{s})")
+                            }
+                            (p, 0) if p > 0 => format!("({p})"),
+                            _ => String::new(),
+                        };
+                        format!("{decimal}{precision_scale}")
+                    }
+                    other_converted_type => {
+                        format!("{other_converted_type}")
+                    }
+                },
             }
         }
     }
@@ -478,7 +480,7 @@ mod tests {
             (
                 Type::primitive_type_builder("field", PhysicalType::INT32)
                     .with_repetition(Repetition::REQUIRED)
-                    .with_converted_type(ConvertedType::INT_32)
+                    .with_converted_type(Some(ConvertedType::INT_32))
                     .build()
                     .unwrap(),
                 "REQUIRED INT32 field (INT_32);",
@@ -486,7 +488,7 @@ mod tests {
             (
                 Type::primitive_type_builder("field", PhysicalType::INT32)
                     .with_repetition(Repetition::REQUIRED)
-                    .with_converted_type(ConvertedType::INT_32)
+                    .with_converted_type(Some(ConvertedType::INT_32))
                     .with_id(Some(42))
                     .build()
                     .unwrap(),
@@ -524,7 +526,7 @@ mod tests {
         id: Option<i32>,
         physical_type: PhysicalType,
         logical_type: Option<LogicalType>,
-        converted_type: ConvertedType,
+        converted_type: Option<ConvertedType>,
         repetition: Repetition,
     ) -> Result<Type> {
         Type::primitive_type_builder(name, physical_type)
@@ -547,7 +549,7 @@ mod tests {
                         bit_width: 32,
                         is_signed: true,
                     }),
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -562,7 +564,7 @@ mod tests {
                         bit_width: 8,
                         is_signed: false,
                     }),
-                    ConvertedType::NONE,
+                    None,
                     Repetition::OPTIONAL,
                 )
                 .unwrap(),
@@ -577,7 +579,7 @@ mod tests {
                         bit_width: 16,
                         is_signed: true,
                     }),
-                    ConvertedType::INT_16,
+                    Some(ConvertedType::INT_16),
                     Repetition::REPEATED,
                 )
                 .unwrap(),
@@ -592,7 +594,7 @@ mod tests {
                         bit_width: 16,
                         is_signed: true,
                     }),
-                    ConvertedType::INT_16,
+                    Some(ConvertedType::INT_16),
                     Repetition::REPEATED,
                 )
                 .unwrap(),
@@ -604,7 +606,7 @@ mod tests {
                     None,
                     PhysicalType::INT64,
                     None,
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REPEATED,
                 )
                 .unwrap(),
@@ -616,7 +618,7 @@ mod tests {
                     None,
                     PhysicalType::FLOAT,
                     None,
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -628,7 +630,7 @@ mod tests {
                     None,
                     PhysicalType::BOOLEAN,
                     None,
-                    ConvertedType::NONE,
+                    None,
                     Repetition::OPTIONAL,
                 )
                 .unwrap(),
@@ -640,7 +642,7 @@ mod tests {
                     Some(42),
                     PhysicalType::BOOLEAN,
                     None,
-                    ConvertedType::NONE,
+                    None,
                     Repetition::OPTIONAL,
                 )
                 .unwrap(),
@@ -655,7 +657,7 @@ mod tests {
                         is_adjusted_to_u_t_c: true,
                         unit: TimeUnit::MILLIS,
                     }),
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -667,7 +669,7 @@ mod tests {
                     None,
                     PhysicalType::INT32,
                     Some(LogicalType::Date),
-                    ConvertedType::NONE,
+                    None,
                     Repetition::OPTIONAL,
                 )
                 .unwrap(),
@@ -682,7 +684,7 @@ mod tests {
                         unit: TimeUnit::MILLIS,
                         is_adjusted_to_u_t_c: false,
                     }),
-                    ConvertedType::TIME_MILLIS,
+                    Some(ConvertedType::TIME_MILLIS),
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -697,7 +699,7 @@ mod tests {
                         unit: TimeUnit::MILLIS,
                         is_adjusted_to_u_t_c: false,
                     }),
-                    ConvertedType::TIME_MILLIS,
+                    Some(ConvertedType::TIME_MILLIS),
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -709,7 +711,7 @@ mod tests {
                     None,
                     PhysicalType::BYTE_ARRAY,
                     None,
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -721,7 +723,7 @@ mod tests {
                     Some(42),
                     PhysicalType::BYTE_ARRAY,
                     None,
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -733,7 +735,7 @@ mod tests {
                     None,
                     PhysicalType::BYTE_ARRAY,
                     None,
-                    ConvertedType::UTF8,
+                    Some(ConvertedType::UTF8),
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -745,7 +747,7 @@ mod tests {
                     None,
                     PhysicalType::BYTE_ARRAY,
                     Some(LogicalType::Json),
-                    ConvertedType::JSON,
+                    Some(ConvertedType::JSON),
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -757,7 +759,7 @@ mod tests {
                     None,
                     PhysicalType::BYTE_ARRAY,
                     Some(LogicalType::Bson),
-                    ConvertedType::BSON,
+                    Some(ConvertedType::BSON),
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -769,7 +771,7 @@ mod tests {
                     None,
                     PhysicalType::BYTE_ARRAY,
                     Some(LogicalType::String),
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -781,7 +783,7 @@ mod tests {
                     Some(42),
                     PhysicalType::BYTE_ARRAY,
                     Some(LogicalType::String),
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -793,7 +795,7 @@ mod tests {
                     None,
                     PhysicalType::BYTE_ARRAY,
                     Some(LogicalType::Geometry { crs: None }),
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -807,7 +809,7 @@ mod tests {
                     Some(LogicalType::Geometry {
                         crs: Some("non-missing CRS".to_string()),
                     }),
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -822,7 +824,7 @@ mod tests {
                         crs: None,
                         algorithm: Some(EdgeInterpolationAlgorithm::default()),
                     }),
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -837,7 +839,7 @@ mod tests {
                         crs: Some("non-missing CRS".to_string()),
                         algorithm: Some(EdgeInterpolationAlgorithm::default()),
                     }),
-                    ConvertedType::NONE,
+                    None,
                     Repetition::REQUIRED,
                 )
                 .unwrap(),
@@ -869,7 +871,7 @@ mod tests {
             (
                 Type::primitive_type_builder("field", PhysicalType::FIXED_LEN_BYTE_ARRAY)
                     .with_logical_type(None)
-                    .with_converted_type(ConvertedType::INTERVAL)
+                    .with_converted_type(Some(ConvertedType::INTERVAL))
                     .with_length(12)
                     .with_repetition(Repetition::REQUIRED)
                     .build()
@@ -901,7 +903,7 @@ mod tests {
             ),
             (
                 Type::primitive_type_builder("decimal", PhysicalType::FIXED_LEN_BYTE_ARRAY)
-                    .with_converted_type(ConvertedType::DECIMAL)
+                    .with_converted_type(Some(ConvertedType::DECIMAL))
                     .with_precision(19)
                     .with_scale(4)
                     .with_length(decimal_length_from_precision(19))
@@ -938,7 +940,7 @@ mod tests {
             let mut p = Printer::new(&mut s);
             let field_a = Type::primitive_type_builder("a", PhysicalType::BYTE_ARRAY)
                 .with_id(Some(42))
-                .with_converted_type(ConvertedType::UTF8)
+                .with_converted_type(Some(ConvertedType::UTF8))
                 .build()
                 .unwrap();
 
@@ -985,17 +987,17 @@ mod tests {
             let mut p = Printer::new(&mut s);
             let f1 = Type::primitive_type_builder("f1", PhysicalType::INT32)
                 .with_repetition(Repetition::REQUIRED)
-                .with_converted_type(ConvertedType::INT_32)
+                .with_converted_type(Some(ConvertedType::INT_32))
                 .build();
             let f2 = Type::primitive_type_builder("f2", PhysicalType::BYTE_ARRAY)
-                .with_converted_type(ConvertedType::UTF8)
+                .with_converted_type(Some(ConvertedType::UTF8))
                 .build();
             let f3 = Type::primitive_type_builder("f3", PhysicalType::BYTE_ARRAY)
                 .with_logical_type(Some(LogicalType::String))
                 .build();
             let f4 = Type::primitive_type_builder("f4", PhysicalType::FIXED_LEN_BYTE_ARRAY)
                 .with_repetition(Repetition::REPEATED)
-                .with_converted_type(ConvertedType::INTERVAL)
+                .with_converted_type(Some(ConvertedType::INTERVAL))
                 .with_length(12)
                 .build();
 
@@ -1035,11 +1037,11 @@ mod tests {
             let mut p = Printer::new(&mut s);
             let f1 = Type::primitive_type_builder("f1", PhysicalType::INT32)
                 .with_repetition(Repetition::REQUIRED)
-                .with_converted_type(ConvertedType::INT_32)
+                .with_converted_type(Some(ConvertedType::INT_32))
                 .with_id(Some(0))
                 .build();
             let f2 = Type::primitive_type_builder("f2", PhysicalType::BYTE_ARRAY)
-                .with_converted_type(ConvertedType::UTF8)
+                .with_converted_type(Some(ConvertedType::UTF8))
                 .with_id(Some(1))
                 .build();
             let f3 = Type::primitive_type_builder("f3", PhysicalType::BYTE_ARRAY)
@@ -1048,7 +1050,7 @@ mod tests {
                 .build();
             let f4 = Type::primitive_type_builder("f4", PhysicalType::FIXED_LEN_BYTE_ARRAY)
                 .with_repetition(Repetition::REPEATED)
-                .with_converted_type(ConvertedType::INTERVAL)
+                .with_converted_type(Some(ConvertedType::INTERVAL))
                 .with_length(12)
                 .with_id(Some(2))
                 .build();
@@ -1088,14 +1090,14 @@ mod tests {
     fn test_print_and_parse_primitive() {
         let a2 = Type::primitive_type_builder("a2", PhysicalType::BYTE_ARRAY)
             .with_repetition(Repetition::REPEATED)
-            .with_converted_type(ConvertedType::UTF8)
+            .with_converted_type(Some(ConvertedType::UTF8))
             .build()
             .unwrap();
 
         let a1 = Type::group_type_builder("a1")
             .with_repetition(Repetition::OPTIONAL)
             .with_logical_type(Some(LogicalType::List))
-            .with_converted_type(ConvertedType::LIST)
+            .with_converted_type(Some(ConvertedType::LIST))
             .with_fields(vec![Arc::new(a2)])
             .build()
             .unwrap();
@@ -1120,7 +1122,7 @@ mod tests {
         let b1 = Type::group_type_builder("b1")
             .with_repetition(Repetition::OPTIONAL)
             .with_logical_type(Some(LogicalType::List))
-            .with_converted_type(ConvertedType::LIST)
+            .with_converted_type(Some(ConvertedType::LIST))
             .with_fields(vec![Arc::new(b2)])
             .build()
             .unwrap();
@@ -1143,13 +1145,13 @@ mod tests {
     fn test_print_and_parse_nested() {
         let f1 = Type::primitive_type_builder("f1", PhysicalType::INT32)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::INT_32)
+            .with_converted_type(Some(ConvertedType::INT_32))
             .build()
             .unwrap();
 
         let f2 = Type::primitive_type_builder("f2", PhysicalType::BYTE_ARRAY)
             .with_repetition(Repetition::OPTIONAL)
-            .with_converted_type(ConvertedType::UTF8)
+            .with_converted_type(Some(ConvertedType::UTF8))
             .build()
             .unwrap();
 
@@ -1161,7 +1163,7 @@ mod tests {
 
         let f3 = Type::primitive_type_builder("f3", PhysicalType::FIXED_LEN_BYTE_ARRAY)
             .with_repetition(Repetition::REPEATED)
-            .with_converted_type(ConvertedType::INTERVAL)
+            .with_converted_type(Some(ConvertedType::INTERVAL))
             .with_length(12)
             .build()
             .unwrap();
@@ -1182,7 +1184,7 @@ mod tests {
                 precision: 9,
                 scale: 2,
             }))
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_precision(9)
             .with_scale(2)
             .build()
@@ -1194,7 +1196,7 @@ mod tests {
                 precision: 9,
                 scale: 0,
             }))
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_precision(9)
             .with_scale(0)
             .build()

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -25,6 +25,7 @@ use crate::file::metadata::thrift::SchemaElement;
 
 use crate::basic::{
     ColumnOrder, ConvertedType, LogicalType, Repetition, SortOrder, TimeUnit, Type as PhysicalType,
+    converted_type_for_logical,
 };
 use crate::errors::{ParquetError, Result};
 
@@ -214,7 +215,7 @@ impl Type {
             if let Some(logical_type) = basic_info.logical_type_ref() {
                 return logical_type == &LogicalType::List;
             }
-            return basic_info.converted_type() == ConvertedType::LIST;
+            return basic_info.converted_type() == Some(ConvertedType::LIST);
         }
         false
     }
@@ -238,7 +239,7 @@ pub struct PrimitiveTypeBuilder<'a> {
     name: &'a str,
     repetition: Repetition,
     physical_type: PhysicalType,
-    converted_type: ConvertedType,
+    converted_type: Option<ConvertedType>,
     logical_type: Option<LogicalType>,
     length: i32,
     precision: i32,
@@ -253,7 +254,7 @@ impl<'a> PrimitiveTypeBuilder<'a> {
             name,
             repetition: Repetition::OPTIONAL,
             physical_type,
-            converted_type: ConvertedType::NONE,
+            converted_type: None,
             logical_type: None,
             length: -1,
             precision: -1,
@@ -268,7 +269,7 @@ impl<'a> PrimitiveTypeBuilder<'a> {
     }
 
     /// Sets [`ConvertedType`] for this field and returns itself.
-    pub fn with_converted_type(self, converted_type: ConvertedType) -> Self {
+    pub fn with_converted_type(self, converted_type: Option<ConvertedType>) -> Self {
         Self {
             converted_type,
             ..self
@@ -312,15 +313,7 @@ impl<'a> PrimitiveTypeBuilder<'a> {
 
     /// Creates a new `PrimitiveType` instance from the collected attributes.
     /// Returns `Err` in case of any building conditions are not met.
-    pub fn build(self) -> Result<Type> {
-        let mut basic_info = BasicTypeInfo {
-            name: String::from(self.name),
-            repetition: Some(self.repetition),
-            converted_type: self.converted_type,
-            logical_type: self.logical_type.clone(),
-            id: self.id,
-        };
-
+    pub fn build(mut self) -> Result<Type> {
         // Check length before logical type, since it is used for logical type validation.
         if self.physical_type == PhysicalType::FIXED_LEN_BYTE_ARRAY && self.length < 0 {
             return Err(general_err!(
@@ -333,10 +326,10 @@ impl<'a> PrimitiveTypeBuilder<'a> {
         if let Some(logical_type) = &self.logical_type {
             // If a converted type is populated, check that it is consistent with
             // its logical type
-            if self.converted_type != ConvertedType::NONE {
-                if ConvertedType::from(self.logical_type.clone()) != self.converted_type {
+            if self.converted_type.is_some() {
+                if converted_type_for_logical(self.logical_type.as_ref()) != self.converted_type {
                     return Err(general_err!(
-                        "Logical type {:?} is incompatible with converted type {} for field '{}'",
+                        "Logical type {:?} is incompatible with converted type {:?} for field '{}'",
                         logical_type,
                         self.converted_type,
                         self.name
@@ -344,7 +337,7 @@ impl<'a> PrimitiveTypeBuilder<'a> {
                 }
             } else {
                 // Populate the converted type for backwards compatibility
-                basic_info.converted_type = self.logical_type.clone().into();
+                self.converted_type = converted_type_for_logical(self.logical_type.as_ref());
             }
             // Check that logical type and physical type are compatible
             match (logical_type, self.physical_type) {
@@ -431,73 +424,83 @@ impl<'a> PrimitiveTypeBuilder<'a> {
             }
         }
 
-        match self.converted_type {
-            ConvertedType::NONE => {}
-            ConvertedType::UTF8 | ConvertedType::BSON | ConvertedType::JSON => {
-                if self.physical_type != PhysicalType::BYTE_ARRAY {
+        if let Some(converted_type) = self.converted_type {
+            match converted_type {
+                ConvertedType::UTF8 | ConvertedType::BSON | ConvertedType::JSON => {
+                    if self.physical_type != PhysicalType::BYTE_ARRAY {
+                        return Err(general_err!(
+                            "{} cannot annotate field '{}' because it is not a BYTE_ARRAY field",
+                            converted_type,
+                            self.name
+                        ));
+                    }
+                }
+                ConvertedType::DECIMAL => {
+                    self.check_decimal_precision_scale()?;
+                }
+                ConvertedType::DATE
+                | ConvertedType::TIME_MILLIS
+                | ConvertedType::UINT_8
+                | ConvertedType::UINT_16
+                | ConvertedType::UINT_32
+                | ConvertedType::INT_8
+                | ConvertedType::INT_16
+                | ConvertedType::INT_32 => {
+                    if self.physical_type != PhysicalType::INT32 {
+                        return Err(general_err!(
+                            "{} cannot annotate field '{}' because it is not a INT32 field",
+                            converted_type,
+                            self.name
+                        ));
+                    }
+                }
+                ConvertedType::TIME_MICROS
+                | ConvertedType::TIMESTAMP_MILLIS
+                | ConvertedType::TIMESTAMP_MICROS
+                | ConvertedType::UINT_64
+                | ConvertedType::INT_64 => {
+                    if self.physical_type != PhysicalType::INT64 {
+                        return Err(general_err!(
+                            "{} cannot annotate field '{}' because it is not a INT64 field",
+                            converted_type,
+                            self.name
+                        ));
+                    }
+                }
+                ConvertedType::INTERVAL => {
+                    if self.physical_type != PhysicalType::FIXED_LEN_BYTE_ARRAY || self.length != 12
+                    {
+                        return Err(general_err!(
+                            "INTERVAL cannot annotate field '{}' because it is not a FIXED_LEN_BYTE_ARRAY(12) field",
+                            self.name
+                        ));
+                    }
+                }
+                ConvertedType::ENUM => {
+                    if self.physical_type != PhysicalType::BYTE_ARRAY {
+                        return Err(general_err!(
+                            "ENUM cannot annotate field '{}' because it is not a BYTE_ARRAY field",
+                            self.name
+                        ));
+                    }
+                }
+                _ => {
                     return Err(general_err!(
-                        "{} cannot annotate field '{}' because it is not a BYTE_ARRAY field",
-                        self.converted_type,
+                        "{} cannot be applied to primitive field '{}'",
+                        converted_type,
                         self.name
                     ));
                 }
-            }
-            ConvertedType::DECIMAL => {
-                self.check_decimal_precision_scale()?;
-            }
-            ConvertedType::DATE
-            | ConvertedType::TIME_MILLIS
-            | ConvertedType::UINT_8
-            | ConvertedType::UINT_16
-            | ConvertedType::UINT_32
-            | ConvertedType::INT_8
-            | ConvertedType::INT_16
-            | ConvertedType::INT_32 => {
-                if self.physical_type != PhysicalType::INT32 {
-                    return Err(general_err!(
-                        "{} cannot annotate field '{}' because it is not a INT32 field",
-                        self.converted_type,
-                        self.name
-                    ));
-                }
-            }
-            ConvertedType::TIME_MICROS
-            | ConvertedType::TIMESTAMP_MILLIS
-            | ConvertedType::TIMESTAMP_MICROS
-            | ConvertedType::UINT_64
-            | ConvertedType::INT_64 => {
-                if self.physical_type != PhysicalType::INT64 {
-                    return Err(general_err!(
-                        "{} cannot annotate field '{}' because it is not a INT64 field",
-                        self.converted_type,
-                        self.name
-                    ));
-                }
-            }
-            ConvertedType::INTERVAL => {
-                if self.physical_type != PhysicalType::FIXED_LEN_BYTE_ARRAY || self.length != 12 {
-                    return Err(general_err!(
-                        "INTERVAL cannot annotate field '{}' because it is not a FIXED_LEN_BYTE_ARRAY(12) field",
-                        self.name
-                    ));
-                }
-            }
-            ConvertedType::ENUM => {
-                if self.physical_type != PhysicalType::BYTE_ARRAY {
-                    return Err(general_err!(
-                        "ENUM cannot annotate field '{}' because it is not a BYTE_ARRAY field",
-                        self.name
-                    ));
-                }
-            }
-            _ => {
-                return Err(general_err!(
-                    "{} cannot be applied to primitive field '{}'",
-                    self.converted_type,
-                    self.name
-                ));
             }
         }
+
+        let basic_info = BasicTypeInfo {
+            name: String::from(self.name),
+            repetition: Some(self.repetition),
+            converted_type: self.converted_type,
+            logical_type: self.logical_type,
+            id: self.id,
+        };
 
         Ok(Type::PrimitiveType {
             basic_info,
@@ -592,7 +595,7 @@ impl<'a> PrimitiveTypeBuilder<'a> {
 pub struct GroupTypeBuilder<'a> {
     name: &'a str,
     repetition: Option<Repetition>,
-    converted_type: ConvertedType,
+    converted_type: Option<ConvertedType>,
     logical_type: Option<LogicalType>,
     fields: Vec<TypePtr>,
     id: Option<i32>,
@@ -604,7 +607,7 @@ impl<'a> GroupTypeBuilder<'a> {
         Self {
             name,
             repetition: None,
-            converted_type: ConvertedType::NONE,
+            converted_type: None,
             logical_type: None,
             fields: Vec::new(),
             id: None,
@@ -618,7 +621,7 @@ impl<'a> GroupTypeBuilder<'a> {
     }
 
     /// Sets [`ConvertedType`] for this field and returns itself.
-    pub fn with_converted_type(self, converted_type: ConvertedType) -> Self {
+    pub fn with_converted_type(self, converted_type: Option<ConvertedType>) -> Self {
         Self {
             converted_type,
             ..self
@@ -650,12 +653,13 @@ impl<'a> GroupTypeBuilder<'a> {
             name: String::from(self.name),
             repetition: self.repetition,
             converted_type: self.converted_type,
-            logical_type: self.logical_type.clone(),
+            logical_type: self.logical_type,
             id: self.id,
         };
         // Populate the converted type if only the logical type is populated
-        if self.logical_type.is_some() && self.converted_type == ConvertedType::NONE {
-            basic_info.converted_type = self.logical_type.into();
+        if basic_info.logical_type.is_some() && basic_info.converted_type.is_none() {
+            basic_info.converted_type =
+                converted_type_for_logical(basic_info.logical_type.as_ref());
         }
         Ok(Type::GroupType {
             basic_info,
@@ -670,7 +674,7 @@ impl<'a> GroupTypeBuilder<'a> {
 pub struct BasicTypeInfo {
     name: String,
     repetition: Option<Repetition>,
-    converted_type: ConvertedType,
+    converted_type: Option<ConvertedType>,
     logical_type: Option<LogicalType>,
     id: Option<i32>,
 }
@@ -701,8 +705,8 @@ impl BasicTypeInfo {
         self.repetition.unwrap()
     }
 
-    /// Returns [`ConvertedType`] value for the type.
-    pub fn converted_type(&self) -> ConvertedType {
+    /// Returns the [`ConvertedType`] value for the type.
+    pub fn converted_type(&self) -> Option<ConvertedType> {
         self.converted_type
     }
 
@@ -935,7 +939,7 @@ impl ColumnDescriptor {
     }
 
     /// Returns [`ConvertedType`] for this column.
-    pub fn converted_type(&self) -> ConvertedType {
+    pub fn converted_type(&self) -> Option<ConvertedType> {
         self.primitive_type.get_basic_info().converted_type()
     }
 
@@ -1344,7 +1348,7 @@ fn schema_from_array_helper<'a>(
         return Ok((index + 1, Arc::new(builder.build().unwrap())));
     }
 
-    let converted_type = element.converted_type.unwrap_or(ConvertedType::NONE);
+    let converted_type = element.converted_type;
 
     // LogicalType is prefered to ConvertedType, but both may be present.
     let logical_type = element.logical_type;
@@ -1469,7 +1473,7 @@ mod tests {
                     is_signed: true
                 })
             );
-            assert_eq!(basic_info.converted_type(), ConvertedType::INT_32);
+            assert_eq!(basic_info.converted_type(), Some(ConvertedType::INT_32));
             assert_eq!(basic_info.id(), 0);
             match tp {
                 Type::PrimitiveType { physical_type, .. } => {
@@ -1498,7 +1502,7 @@ mod tests {
         // Test illegal inputs with converted type
         result = Type::primitive_type_builder("foo", PhysicalType::INT64)
             .with_repetition(Repetition::REPEATED)
-            .with_converted_type(ConvertedType::BSON)
+            .with_converted_type(Some(ConvertedType::BSON))
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
@@ -1510,7 +1514,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT96)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_precision(-1)
             .with_scale(-1)
             .build();
@@ -1541,7 +1545,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_precision(-1)
             .with_scale(-1)
             .build();
@@ -1555,7 +1559,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_precision(0)
             .with_scale(-1)
             .build();
@@ -1569,7 +1573,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_precision(1)
             .with_scale(-1)
             .build();
@@ -1580,7 +1584,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_precision(1)
             .with_scale(2)
             .build();
@@ -1595,7 +1599,7 @@ mod tests {
         // It is OK if precision == scale
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_precision(1)
             .with_scale(1)
             .build();
@@ -1603,7 +1607,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT32)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_precision(18)
             .with_scale(2)
             .build();
@@ -1617,7 +1621,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT64)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_precision(32)
             .with_scale(2)
             .build();
@@ -1631,7 +1635,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::FIXED_LEN_BYTE_ARRAY)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_length(5)
             .with_precision(12)
             .with_scale(2)
@@ -1646,7 +1650,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT64)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::UINT_8)
+            .with_converted_type(Some(ConvertedType::UINT_8))
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
@@ -1658,7 +1662,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT32)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::TIME_MICROS)
+            .with_converted_type(Some(ConvertedType::TIME_MICROS))
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
@@ -1670,7 +1674,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::INTERVAL)
+            .with_converted_type(Some(ConvertedType::INTERVAL))
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
@@ -1682,7 +1686,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::FIXED_LEN_BYTE_ARRAY)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::INTERVAL)
+            .with_converted_type(Some(ConvertedType::INTERVAL))
             .with_length(1)
             .build();
         assert!(result.is_err());
@@ -1695,7 +1699,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT32)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::ENUM)
+            .with_converted_type(Some(ConvertedType::ENUM))
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
@@ -1707,7 +1711,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT32)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::MAP)
+            .with_converted_type(Some(ConvertedType::MAP))
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
@@ -1719,7 +1723,7 @@ mod tests {
 
         result = Type::primitive_type_builder("foo", PhysicalType::FIXED_LEN_BYTE_ARRAY)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::DECIMAL)
+            .with_converted_type(Some(ConvertedType::DECIMAL))
             .with_length(-1)
             .build();
         assert!(result.is_err());
@@ -1789,12 +1793,12 @@ mod tests {
     #[test]
     fn test_group_type() {
         let f1 = Type::primitive_type_builder("f1", PhysicalType::INT32)
-            .with_converted_type(ConvertedType::INT_32)
+            .with_converted_type(Some(ConvertedType::INT_32))
             .with_id(Some(0))
             .build();
         assert!(f1.is_ok());
         let f2 = Type::primitive_type_builder("f2", PhysicalType::BYTE_ARRAY)
-            .with_converted_type(ConvertedType::UTF8)
+            .with_converted_type(Some(ConvertedType::UTF8))
             .with_id(Some(1))
             .build();
         assert!(f2.is_ok());
@@ -1815,7 +1819,7 @@ mod tests {
         assert!(!tp.is_primitive());
         assert_eq!(basic_info.repetition(), Repetition::REPEATED);
         assert_eq!(basic_info.logical_type_ref(), Some(&LogicalType::List));
-        assert_eq!(basic_info.converted_type(), ConvertedType::LIST);
+        assert_eq!(basic_info.converted_type(), Some(ConvertedType::LIST));
         assert_eq!(basic_info.id(), 1);
         assert_eq!(tp.get_fields().len(), 2);
         assert_eq!(tp.get_fields()[0].name(), "f1");
@@ -1834,13 +1838,13 @@ mod tests {
 
     fn test_column_descriptor_helper() -> Result<()> {
         let tp = Type::primitive_type_builder("name", PhysicalType::BYTE_ARRAY)
-            .with_converted_type(ConvertedType::UTF8)
+            .with_converted_type(Some(ConvertedType::UTF8))
             .build()?;
 
         let descr = ColumnDescriptor::new(Arc::new(tp), 4, 1, ColumnPath::from("name"));
 
         assert_eq!(descr.path(), &ColumnPath::from("name"));
-        assert_eq!(descr.converted_type(), ConvertedType::UTF8);
+        assert_eq!(descr.converted_type(), Some(ConvertedType::UTF8));
         assert_eq!(descr.physical_type(), PhysicalType::BYTE_ARRAY);
         assert_eq!(descr.max_def_level(), 4);
         assert_eq!(descr.max_rep_level(), 1);
@@ -1868,32 +1872,32 @@ mod tests {
 
         let inta = Type::primitive_type_builder("a", PhysicalType::INT32)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::INT_32)
+            .with_converted_type(Some(ConvertedType::INT_32))
             .build()?;
         fields.push(Arc::new(inta));
         let intb = Type::primitive_type_builder("b", PhysicalType::INT64)
-            .with_converted_type(ConvertedType::INT_64)
+            .with_converted_type(Some(ConvertedType::INT_64))
             .build()?;
         fields.push(Arc::new(intb));
         let intc = Type::primitive_type_builder("c", PhysicalType::BYTE_ARRAY)
             .with_repetition(Repetition::REPEATED)
-            .with_converted_type(ConvertedType::UTF8)
+            .with_converted_type(Some(ConvertedType::UTF8))
             .build()?;
         fields.push(Arc::new(intc));
 
         // 3-level list encoding
         let item1 = Type::primitive_type_builder("item1", PhysicalType::INT64)
             .with_repetition(Repetition::REQUIRED)
-            .with_converted_type(ConvertedType::INT_64)
+            .with_converted_type(Some(ConvertedType::INT_64))
             .build()?;
         let item2 = Type::primitive_type_builder("item2", PhysicalType::BOOLEAN).build()?;
         let item3 = Type::primitive_type_builder("item3", PhysicalType::INT32)
             .with_repetition(Repetition::REPEATED)
-            .with_converted_type(ConvertedType::INT_32)
+            .with_converted_type(Some(ConvertedType::INT_32))
             .build()?;
         let list = Type::group_type_builder("records")
             .with_repetition(Repetition::REPEATED)
-            .with_converted_type(ConvertedType::LIST)
+            .with_converted_type(Some(ConvertedType::LIST))
             .with_fields(vec![Arc::new(item1), Arc::new(item2), Arc::new(item3)])
             .build()?;
         let bag = Type::group_type_builder("bag")
@@ -2128,11 +2132,11 @@ mod tests {
 
         // OK: different logical type does not affect check_contains
         let f1 = Type::primitive_type_builder("f", PhysicalType::INT32)
-            .with_converted_type(ConvertedType::UINT_8)
+            .with_converted_type(Some(ConvertedType::UINT_8))
             .build()
             .unwrap();
         let f2 = Type::primitive_type_builder("f", PhysicalType::INT32)
-            .with_converted_type(ConvertedType::UINT_16)
+            .with_converted_type(Some(ConvertedType::UINT_16))
             .build()
             .unwrap();
         assert!(f1.check_contains(&f2));

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -1030,7 +1030,7 @@ impl ColumnDescriptor {
 ///         ),
 ///         Arc::new(
 ///          Type::primitive_type_builder("b", basic::Type::INT32)
-///           .with_converted_type(basic::ConvertedType::DATE)
+///           .with_converted_type(Some(basic::ConvertedType::DATE))
 ///           .with_logical_type(Some(basic::LogicalType::Date))
 ///           .build().unwrap()
 ///         ),

--- a/parquet/src/schema/visitor.rs
+++ b/parquet/src/schema/visitor.rs
@@ -105,12 +105,16 @@ pub trait TypeVisitor<R, C> {
         if cur_type.is_primitive() {
             self.visit_primitive(cur_type, context)
         } else {
-            match cur_type.get_basic_info().converted_type() {
-                ConvertedType::LIST => self.visit_list(cur_type, context),
-                ConvertedType::MAP | ConvertedType::MAP_KEY_VALUE => {
-                    self.visit_map(cur_type, context)
+            if let Some(converted_type) = cur_type.get_basic_info().converted_type() {
+                match converted_type {
+                    ConvertedType::LIST => self.visit_list(cur_type, context),
+                    ConvertedType::MAP | ConvertedType::MAP_KEY_VALUE => {
+                        self.visit_map(cur_type, context)
+                    }
+                    _ => self.visit_struct(cur_type, context),
                 }
-                _ => self.visit_struct(cur_type, context),
+            } else {
+                self.visit_struct(cur_type, context)
             }
         }
     }

--- a/parquet/src/schema/visitor.rs
+++ b/parquet/src/schema/visitor.rs
@@ -105,16 +105,12 @@ pub trait TypeVisitor<R, C> {
         if cur_type.is_primitive() {
             self.visit_primitive(cur_type, context)
         } else {
-            if let Some(converted_type) = cur_type.get_basic_info().converted_type() {
-                match converted_type {
-                    ConvertedType::LIST => self.visit_list(cur_type, context),
-                    ConvertedType::MAP | ConvertedType::MAP_KEY_VALUE => {
-                        self.visit_map(cur_type, context)
-                    }
-                    _ => self.visit_struct(cur_type, context),
+            match cur_type.get_basic_info().converted_type() {
+                Some(ConvertedType::LIST) => self.visit_list(cur_type, context),
+                Some(ConvertedType::MAP) | Some(ConvertedType::MAP_KEY_VALUE) => {
+                    self.visit_map(cur_type, context)
                 }
-            } else {
-                self.visit_struct(cur_type, context)
+                _ => self.visit_struct(cur_type, context),
             }
         }
     }

--- a/parquet_derive/src/parquet_field.rs
+++ b/parquet_derive/src/parquet_field.rs
@@ -743,7 +743,9 @@ impl Type {
         let last_part = self.last_part();
 
         match last_part.trim() {
-            "NaiveDateTime" => Some(quote! { ::parquet::basic::ConvertedType::TIMESTAMP_MILLIS }),
+            "NaiveDateTime" => {
+                Some(quote! { Some(::parquet::basic::ConvertedType::TIMESTAMP_MILLIS) })
+            }
             _ => None,
         }
     }

--- a/parquet_derive/src/parquet_field.rs
+++ b/parquet_derive/src/parquet_field.rs
@@ -1486,7 +1486,7 @@ mod test {
         let converted_type = time.ty.converted_type();
         assert_eq!(
             converted_type.unwrap().to_string(),
-            quote! { ::parquet::basic::ConvertedType::TIMESTAMP_MILLIS }.to_string()
+            quote! { Some(::parquet::basic::ConvertedType::TIMESTAMP_MILLIS) }.to_string()
         );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #NNN.

# Rationale for this change

Test of making converted type an optional field (as it is in the Parquet spec).

# What changes are included in this PR?
Convert `converted_type` in the `BasicTypeInfo` to an `Option<ConvertedType>`, remove the `ConvertedType::NONE` variant (which is not in the spec).

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
