### PR TITLE
Allow UTC & +00:00 to be written in parquet writer

### DIFF
--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -722,6 +722,13 @@ impl DataType {
                         })
                     })
             }
+            // Timestamps with matching unit whose timezones are both recognized UTC
+            // aliases are considered equivalent.
+            (DataType::Timestamp(a_unit, Some(a_tz)), DataType::Timestamp(b_unit, Some(b_tz)))
+                if a_unit == b_unit && a_tz != b_tz =>
+            {
+                is_utc_alias(a_tz) && is_utc_alias(b_tz)
+            }
             _ => self == other,
         }
     }
@@ -872,6 +879,16 @@ impl DataType {
     pub fn new_fixed_size_list(data_type: DataType, size: i32, nullable: bool) -> Self {
         DataType::FixedSizeList(Arc::new(Field::new_list_field(data_type, nullable)), size)
     }
+}
+
+/// Returns true when `tz` is one of the recognized UTC timezone aliases.
+///
+/// Producers of arrow batches use a variety of strings to denote UTC: `"UTC"`,
+/// `"+00:00"` and `"Z"` are all common and semantically
+/// identical. Treating these as interchangeable lets writers accept batches from
+/// upstream systems that disagree on the canonical spelling.
+pub fn is_utc_alias(tz: &str) -> bool {
+    matches!(tz, "UTC" | "+00:00" | "Z")
 }
 
 /// The maximum precision for [DataType::Decimal32] values

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -1307,4 +1307,101 @@ mod tests {
         )
         ");
     }
+
+    #[test]
+    fn test_is_utc_alias() {
+        assert!(is_utc_alias("UTC"));
+        assert!(is_utc_alias("+00:00"));
+        assert!(is_utc_alias("Z"));
+        assert!(!is_utc_alias("America/New_York"));
+        assert!(!is_utc_alias("+05:30"));
+        assert!(!is_utc_alias(""));
+        assert!(!is_utc_alias("utc"));
+        assert!(!is_utc_alias("+0000"));
+        assert!(!is_utc_alias("+00"));
+    }
+
+    #[test]
+    fn test_equals_datatype_utc_aliases_flat() {
+        use crate::TimeUnit;
+        let aliases = ["UTC", "+00:00", "Z"];
+        for a in &aliases {
+            for b in &aliases {
+                let ta = DataType::Timestamp(TimeUnit::Microsecond, Some((*a).into()));
+                let tb = DataType::Timestamp(TimeUnit::Microsecond, Some((*b).into()));
+                assert!(ta.equals_datatype(&tb), "{a} should be equivalent to {b}",);
+            }
+        }
+    }
+
+    #[test]
+    fn test_equals_datatype_utc_aliases_nested() {
+        use crate::TimeUnit;
+        let leaf_a = DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into()));
+        let leaf_b = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
+
+        // List
+        let list_a = DataType::List(Arc::new(Field::new("item", leaf_a.clone(), true)));
+        let list_b = DataType::List(Arc::new(Field::new("item", leaf_b.clone(), true)));
+        assert!(list_a.equals_datatype(&list_b));
+
+        // LargeList
+        let ll_a = DataType::LargeList(Arc::new(Field::new("item", leaf_a.clone(), true)));
+        let ll_b = DataType::LargeList(Arc::new(Field::new("item", leaf_b.clone(), true)));
+        assert!(ll_a.equals_datatype(&ll_b));
+
+        // FixedSizeList
+        let fsl_a = DataType::FixedSizeList(Arc::new(Field::new("item", leaf_a.clone(), true)), 3);
+        let fsl_b = DataType::FixedSizeList(Arc::new(Field::new("item", leaf_b.clone(), true)), 3);
+        assert!(fsl_a.equals_datatype(&fsl_b));
+
+        // Struct
+        let struct_a = DataType::Struct(vec![Field::new("ts", leaf_a.clone(), true)].into());
+        let struct_b = DataType::Struct(vec![Field::new("ts", leaf_b.clone(), true)].into());
+        assert!(struct_a.equals_datatype(&struct_b));
+
+        // Map
+        let map_a = DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(
+                    vec![
+                        Field::new("keys", DataType::Utf8, false),
+                        Field::new("values", leaf_a.clone(), true),
+                    ]
+                    .into(),
+                ),
+                false,
+            )),
+            false,
+        );
+        let map_b = DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(
+                    vec![
+                        Field::new("keys", DataType::Utf8, false),
+                        Field::new("values", leaf_b.clone(), true),
+                    ]
+                    .into(),
+                ),
+                false,
+            )),
+            false,
+        );
+        assert!(map_a.equals_datatype(&map_b));
+    }
+
+    #[test]
+    fn test_equals_datatype_non_utc_timezones_differ() {
+        use crate::TimeUnit;
+        let utc = DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into()));
+        let est = DataType::Timestamp(TimeUnit::Microsecond, Some("America/New_York".into()));
+        let offset = DataType::Timestamp(TimeUnit::Microsecond, Some("+05:30".into()));
+        let diff_unit = DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()));
+
+        assert!(!utc.equals_datatype(&est));
+        assert!(!utc.equals_datatype(&offset));
+        assert!(!utc.equals_datatype(&diff_unit));
+    }
 }

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -2297,116 +2297,19 @@ mod tests {
     }
 
     #[test]
-    fn timestamp_utc_aliases_are_compatible() {
-        // Arrays produced by upstream systems often tag UTC differently than the
-        // writer's target schema. The writer should accept these aliases as long
-        // as the time unit matches; the on-disk parquet representation only cares
-        // whether a timezone is set, not what string was used.
-        let aliases = ["UTC", "+00:00", "Z"];
-        for &target in &aliases {
-            for &source in &aliases {
-                let target_ty = DataType::Timestamp(TimeUnit::Microsecond, Some(target.into()));
-                let source_ty = DataType::Timestamp(TimeUnit::Microsecond, Some(source.into()));
-                let array =
-                    Arc::new(TimestampMicrosecondArray::from(vec![0_i64, 1]).with_timezone(source))
-                        as ArrayRef;
-                let field = Field::new("ts", target_ty.clone(), true);
-                LevelInfoBuilder::try_new(&field, Default::default(), &array).unwrap_or_else(|e| {
-                    panic!("expected {target} ↔ {source} to be compatible, got: {e}")
-                });
-                assert!(
-                    LevelInfoBuilder::types_compatible(&target_ty, &source_ty),
-                    "{target} should be compatible with {source}",
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn timestamp_utc_aliases_are_compatible_when_nested() {
-        let leaf_target = DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into()));
-        let leaf_source = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
-
-        let nests: &[(DataType, DataType)] = &[
-            (
-                DataType::List(Arc::new(Field::new_list_field(leaf_target.clone(), true))),
-                DataType::List(Arc::new(Field::new_list_field(leaf_source.clone(), true))),
-            ),
-            (
-                DataType::LargeList(Arc::new(Field::new_list_field(leaf_target.clone(), true))),
-                DataType::LargeList(Arc::new(Field::new_list_field(leaf_source.clone(), true))),
-            ),
-            (
-                DataType::FixedSizeList(
-                    Arc::new(Field::new_list_field(leaf_target.clone(), true)),
-                    3,
-                ),
-                DataType::FixedSizeList(
-                    Arc::new(Field::new_list_field(leaf_source.clone(), true)),
-                    3,
-                ),
-            ),
-            (
-                DataType::Struct(vec![Field::new("ts", leaf_target.clone(), true)].into()),
-                DataType::Struct(vec![Field::new("ts", leaf_source.clone(), true)].into()),
-            ),
-            (
-                DataType::Map(
-                    Arc::new(Field::new(
-                        "entries",
-                        DataType::Struct(
-                            vec![
-                                Field::new("keys", DataType::Utf8, false),
-                                Field::new("values", leaf_target.clone(), true),
-                            ]
-                            .into(),
-                        ),
-                        false,
-                    )),
-                    false,
-                ),
-                DataType::Map(
-                    Arc::new(Field::new(
-                        "entries",
-                        DataType::Struct(
-                            vec![
-                                Field::new("keys", DataType::Utf8, false),
-                                Field::new("values", leaf_source.clone(), true),
-                            ]
-                            .into(),
-                        ),
-                        false,
-                    )),
-                    false,
-                ),
-            ),
-        ];
-
-        for (target, source) in nests {
-            assert!(
-                LevelInfoBuilder::types_compatible(target, source),
-                "nested UTC alias mismatch should be compatible: {target:?} vs {source:?}",
-            );
-        }
-    }
-
-    #[test]
-    fn timestamp_non_utc_timezones_remain_incompatible() {
-        // Only UTC aliases are folded together; named zones and arbitrary offsets
-        // must still match exactly so we don't silently misinterpret instants.
-        let target = DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into()));
-        let cases = [
-            DataType::Timestamp(TimeUnit::Microsecond, Some("America/New_York".into())),
-            DataType::Timestamp(TimeUnit::Microsecond, Some("+05:30".into())),
-            // Different time unit isn't covered either.
-            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
-        ];
-        for case in cases {
-            assert!(
-                !LevelInfoBuilder::types_compatible(&target, &case),
-                "{case:?} should not be compatible with {target:?}",
-            );
-        }
+    fn timestamp_utc_aliases_accepted_by_writer() {
+        // Verifies that LevelInfoBuilder::try_new (the writer's entry point)
+        // accepts arrays whose timezone is a UTC alias different from the field's.
+        // Detailed equivalence tests live in arrow_schema::datatype::tests.
+        let field = Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into())),
+            true,
+        );
+        let array = Arc::new(TimestampMicrosecondArray::from(vec![0_i64, 1]).with_timezone("UTC"))
+            as ArrayRef;
+        LevelInfoBuilder::try_new(&field, Default::default(), &array)
+            .expect("UTC and +00:00 should be treated as compatible");
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -723,6 +723,7 @@ impl LevelInfoBuilder {
     /// and the other is a native array, the dictionary values must have the same type as the
     /// native array
     fn types_compatible(a: &DataType, b: &DataType) -> bool {
+        // if the Arrow data types are equal, the types are deemed compatible
         if a.equals_datatype(b) {
             return true;
         }

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -2328,18 +2328,15 @@ mod tests {
         let aliases = ["UTC", "+00:00", "Z"];
         for &target in &aliases {
             for &source in &aliases {
-                let target_ty =
-                    DataType::Timestamp(TimeUnit::Microsecond, Some(target.into()));
-                let source_ty =
-                    DataType::Timestamp(TimeUnit::Microsecond, Some(source.into()));
-                let array = Arc::new(
-                    TimestampMicrosecondArray::from(vec![0_i64, 1])
-                        .with_timezone(source),
-                ) as ArrayRef;
+                let target_ty = DataType::Timestamp(TimeUnit::Microsecond, Some(target.into()));
+                let source_ty = DataType::Timestamp(TimeUnit::Microsecond, Some(source.into()));
+                let array =
+                    Arc::new(TimestampMicrosecondArray::from(vec![0_i64, 1]).with_timezone(source))
+                        as ArrayRef;
                 let field = Field::new("ts", target_ty.clone(), true);
-                LevelInfoBuilder::try_new(&field, Default::default(), &array).unwrap_or_else(
-                    |e| panic!("expected {target} ↔ {source} to be compatible, got: {e}"),
-                );
+                LevelInfoBuilder::try_new(&field, Default::default(), &array).unwrap_or_else(|e| {
+                    panic!("expected {target} ↔ {source} to be compatible, got: {e}")
+                });
                 assert!(
                     LevelInfoBuilder::types_compatible(&target_ty, &source_ty),
                     "{target} should be compatible with {source}",

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -730,10 +730,7 @@ impl LevelInfoBuilder {
 
         // Timestamps with matching unit but UTC-equivalent timezone aliases (e.g. "UTC"
         // vs "+00:00") are treated as compatible. The on-disk parquet representation
-        // depends only on whether the timezone is non-empty (see
-        // `arrow_to_parquet_type` in `schema/mod.rs`), so accepting these aliases
-        // does not change what is written. This matches DataFusion's
-        // `temporal_coercion_strict_timezone` rule.
+        // does not change for "UTC" vs "+00:00" so it's fine to accept either as being valid.
         if let (DataType::Timestamp(au, Some(atz)), DataType::Timestamp(bu, Some(btz))) = (a, b) {
             if au == bu && is_utc_alias(atz) && is_utc_alias(btz) {
                 return true;
@@ -778,9 +775,9 @@ impl LevelInfoBuilder {
 /// Returns true when `tz` is one of the recognized UTC timezone aliases.
 ///
 /// Producers of arrow batches use a variety of strings to denote UTC: `"UTC"`,
-/// `"+00:00"` or `"Z"` are all common and semantically
-/// identical. Treating these as interchangeable lets writers accept batches from
-/// upstream systems (DataFusion, Iceberg) that disagree on the canonical spelling.
+/// `"+00:00"` or `"Z"` are all common and semantically  identical. Treating these as
+/// interchangeable lets writers accept batches from upstream systems (DataFusion, Iceberg)
+/// that disagree on the canonical spelling.
 fn is_utc_alias(tz: &str) -> bool {
     matches!(tz, "UTC" | "+00:00" | "Z")
 }

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -728,6 +728,18 @@ impl LevelInfoBuilder {
             return true;
         }
 
+        // Timestamps with matching unit but UTC-equivalent timezone aliases (e.g. "UTC"
+        // vs "+00:00") are treated as compatible. The on-disk parquet representation
+        // depends only on whether the timezone is non-empty (see
+        // `arrow_to_parquet_type` in `schema/mod.rs`), so accepting these aliases
+        // does not change what is written. This matches DataFusion's
+        // `temporal_coercion_strict_timezone` rule.
+        if let (DataType::Timestamp(au, Some(atz)), DataType::Timestamp(bu, Some(btz))) = (a, b) {
+            if au == bu && is_utc_alias(atz) && is_utc_alias(btz) {
+                return true;
+            }
+        }
+
         // get the values out of the dictionaries
         let (a, b) = match (a, b) {
             (DataType::Dictionary(_, va), DataType::Dictionary(_, vb)) => {
@@ -761,6 +773,16 @@ impl LevelInfoBuilder {
             _ => false,
         }
     }
+}
+
+/// Returns true when `tz` is one of the recognized UTC timezone aliases.
+///
+/// Producers of arrow batches use a variety of strings to denote UTC: `"UTC"`,
+/// `"+00:00"` or `"Z"` are all common and semantically
+/// identical. Treating these as interchangeable lets writers accept batches from
+/// upstream systems (DataFusion, Iceberg) that disagree on the canonical spelling.
+fn is_utc_alias(tz: &str) -> bool {
+    matches!(tz, "UTC" | "+00:00" | "Z")
 }
 
 /// The data necessary to write a primitive Arrow array to parquet, taking into account
@@ -1029,7 +1051,7 @@ mod tests {
     use arrow_buffer::{Buffer, ToByteSlice};
     use arrow_cast::display::array_value_to_string;
     use arrow_data::{ArrayData, ArrayDataBuilder};
-    use arrow_schema::{Fields, Schema};
+    use arrow_schema::{Fields, Schema, TimeUnit};
 
     #[test]
     fn test_calculate_array_levels_twitter_example() {
@@ -2295,6 +2317,54 @@ mod tests {
             logical_nulls,
         };
         assert_eq!(levels[0], expected_level);
+    }
+
+    #[test]
+    fn timestamp_utc_aliases_are_compatible() {
+        // Arrays produced by upstream systems often tag UTC differently than the
+        // writer's target schema. The writer should accept these aliases as long
+        // as the time unit matches; the on-disk parquet representation only cares
+        // whether a timezone is set, not what string was used.
+        let aliases = ["UTC", "+00:00", "Z"];
+        for &target in &aliases {
+            for &source in &aliases {
+                let target_ty =
+                    DataType::Timestamp(TimeUnit::Microsecond, Some(target.into()));
+                let source_ty =
+                    DataType::Timestamp(TimeUnit::Microsecond, Some(source.into()));
+                let array = Arc::new(
+                    TimestampMicrosecondArray::from(vec![0_i64, 1])
+                        .with_timezone(source),
+                ) as ArrayRef;
+                let field = Field::new("ts", target_ty.clone(), true);
+                LevelInfoBuilder::try_new(&field, Default::default(), &array).unwrap_or_else(
+                    |e| panic!("expected {target} ↔ {source} to be compatible, got: {e}"),
+                );
+                assert!(
+                    LevelInfoBuilder::types_compatible(&target_ty, &source_ty),
+                    "{target} should be compatible with {source}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn timestamp_non_utc_timezones_remain_incompatible() {
+        // Only UTC aliases are folded together; named zones and arbitrary offsets
+        // must still match exactly so we don't silently misinterpret instants.
+        let target = DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into()));
+        let cases = [
+            DataType::Timestamp(TimeUnit::Microsecond, Some("America/New_York".into())),
+            DataType::Timestamp(TimeUnit::Microsecond, Some("+05:30".into())),
+            // Different time unit isn't covered either.
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+        ];
+        for case in cases {
+            assert!(
+                !LevelInfoBuilder::types_compatible(&target, &case),
+                "{case:?} should not be compatible with {target:?}",
+            );
+        }
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -723,18 +723,8 @@ impl LevelInfoBuilder {
     /// and the other is a native array, the dictionary values must have the same type as the
     /// native array
     fn types_compatible(a: &DataType, b: &DataType) -> bool {
-        // if the Arrow data types are equal, the types are deemed compatible
         if a.equals_datatype(b) {
             return true;
-        }
-
-        // Timestamps with matching unit but UTC-equivalent timezone aliases (e.g. "UTC"
-        // vs "+00:00") are treated as compatible. The on-disk parquet representation
-        // does not change for "UTC" vs "+00:00" so it's fine to accept either as being valid.
-        if let (DataType::Timestamp(au, Some(atz)), DataType::Timestamp(bu, Some(btz))) = (a, b) {
-            if au == bu && is_utc_alias(atz) && is_utc_alias(btz) {
-                return true;
-            }
         }
 
         // get the values out of the dictionaries
@@ -770,16 +760,6 @@ impl LevelInfoBuilder {
             _ => false,
         }
     }
-}
-
-/// Returns true when `tz` is one of the recognized UTC timezone aliases.
-///
-/// Producers of arrow batches use a variety of strings to denote UTC: `"UTC"`,
-/// `"+00:00"` or `"Z"` are all common and semantically  identical. Treating these as
-/// interchangeable lets writers accept batches from upstream systems (DataFusion, Iceberg)
-/// that disagree on the canonical spelling.
-fn is_utc_alias(tz: &str) -> bool {
-    matches!(tz, "UTC" | "+00:00" | "Z")
 }
 
 /// The data necessary to write a primitive Arrow array to parquet, taking into account
@@ -2339,6 +2319,74 @@ mod tests {
                     "{target} should be compatible with {source}",
                 );
             }
+        }
+    }
+
+    #[test]
+    fn timestamp_utc_aliases_are_compatible_when_nested() {
+        let leaf_target = DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into()));
+        let leaf_source = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
+
+        let nests: &[(DataType, DataType)] = &[
+            (
+                DataType::List(Arc::new(Field::new_list_field(leaf_target.clone(), true))),
+                DataType::List(Arc::new(Field::new_list_field(leaf_source.clone(), true))),
+            ),
+            (
+                DataType::LargeList(Arc::new(Field::new_list_field(leaf_target.clone(), true))),
+                DataType::LargeList(Arc::new(Field::new_list_field(leaf_source.clone(), true))),
+            ),
+            (
+                DataType::FixedSizeList(
+                    Arc::new(Field::new_list_field(leaf_target.clone(), true)),
+                    3,
+                ),
+                DataType::FixedSizeList(
+                    Arc::new(Field::new_list_field(leaf_source.clone(), true)),
+                    3,
+                ),
+            ),
+            (
+                DataType::Struct(vec![Field::new("ts", leaf_target.clone(), true)].into()),
+                DataType::Struct(vec![Field::new("ts", leaf_source.clone(), true)].into()),
+            ),
+            (
+                DataType::Map(
+                    Arc::new(Field::new(
+                        "entries",
+                        DataType::Struct(
+                            vec![
+                                Field::new("keys", DataType::Utf8, false),
+                                Field::new("values", leaf_target.clone(), true),
+                            ]
+                            .into(),
+                        ),
+                        false,
+                    )),
+                    false,
+                ),
+                DataType::Map(
+                    Arc::new(Field::new(
+                        "entries",
+                        DataType::Struct(
+                            vec![
+                                Field::new("keys", DataType::Utf8, false),
+                                Field::new("values", leaf_source.clone(), true),
+                            ]
+                            .into(),
+                        ),
+                        false,
+                    )),
+                    false,
+                ),
+            ),
+        ];
+
+        for (target, source) in nests {
+            assert!(
+                LevelInfoBuilder::types_compatible(target, source),
+                "nested UTC alias mismatch should be compatible: {target:?} vs {source:?}",
+            );
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Working towards: https://github.com/apache/arrow-rs/issues/3199
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #NNN.

# Rationale for this change

`types_compatible` will error today like so: 
```
 ArrowError(
    "Incompatible type. Field 'timestamp' has type Timestamp(µs, \"+00:00\"), array has type Timestamp(µs, \"UTC\")",
 ),
```
When datafusion creates a UTC timestamp but iceberg-rust is expecting to see a "+00:00". These two are semantically the same so we should allow the parquet write.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Slacken the `types_compatible` to allow UTC equivalent timestamps when writing parquet.  
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
