### PR TITLE
fix: Reject empty strings when casting strings to decimal

### DIFF
--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -559,6 +559,12 @@ where
     let integers = first_part;
     let decimals = if parts.len() == 2 { parts[1] } else { "" };
 
+    if integers.is_empty() && decimals.is_empty() {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "Invalid decimal format: {value_str:?}"
+        )));
+    }
+
     if !integers.is_empty() && !integers.as_bytes()[0].is_ascii_digit() {
         return Err(ArrowError::InvalidArgumentError(format!(
             "Invalid decimal format: {value_str:?}"
@@ -973,6 +979,17 @@ mod tests {
             parse_string_to_decimal_native::<Decimal128Type>("123.4567891", 5)?,
             12345679_i128
         );
+
+        for value in ["", " ", ".", "+", "-", "+.", "-."] {
+            assert!(
+                parse_string_to_decimal_native::<Decimal128Type>(value, 2).is_err(),
+                "expected {value:?} to fail parsing as Decimal128"
+            );
+            assert!(
+                parse_string_to_decimal_native::<Decimal256Type>(value, 2).is_err(),
+                "expected {value:?} to fail parsing as Decimal256"
+            );
+        }
         Ok(())
     }
 

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -10775,8 +10775,8 @@ mod tests {
         assert_eq!("0.12", decimal_arr.value_as_string(7));
         assert_eq!("12.23", decimal_arr.value_as_string(8));
         assert!(decimal_arr.is_null(9));
-        assert_eq!("0.00", decimal_arr.value_as_string(10));
-        assert_eq!("0.00", decimal_arr.value_as_string(11));
+        assert!(decimal_arr.is_null(10));
+        assert!(decimal_arr.is_null(11));
         assert!(decimal_arr.is_null(12));
         assert_eq!("-1.23", decimal_arr.value_as_string(13));
         assert_eq!("-1.24", decimal_arr.value_as_string(14));
@@ -10815,8 +10815,8 @@ mod tests {
         assert_eq!("0.123", decimal_arr.value_as_string(7));
         assert_eq!("12.234", decimal_arr.value_as_string(8));
         assert!(decimal_arr.is_null(9));
-        assert_eq!("0.000", decimal_arr.value_as_string(10));
-        assert_eq!("0.000", decimal_arr.value_as_string(11));
+        assert!(decimal_arr.is_null(10));
+        assert!(decimal_arr.is_null(11));
         assert!(decimal_arr.is_null(12));
         assert_eq!("-1.235", decimal_arr.value_as_string(13));
         assert_eq!("-1.236", decimal_arr.value_as_string(14));
@@ -10880,8 +10880,8 @@ mod tests {
 
         let test_cases = [
             (None, None),
-            // (Some(""), None),
-            // (Some("   "), None),
+            (Some(""), None),
+            (Some("   "), None),
             (Some("0"), Some("0")),
             (Some("000.000"), Some("0")),
             (Some("12345"), Some("12345")),
@@ -11028,6 +11028,15 @@ mod tests {
             casted_err
                 .to_string()
                 .contains("Cannot cast string '. 0.123' to value of Decimal128(38, 10) type")
+        );
+
+        let str_array = StringArray::from(vec![""]);
+        let array = Arc::new(str_array) as ArrayRef;
+        let casted_err = cast_with_options(&array, &output_type, &option).unwrap_err();
+        assert!(
+            casted_err
+                .to_string()
+                .contains("Cannot cast string '' to value of Decimal128(38, 10) type")
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10009.

# Rationale for this change

When casting string values to decimal, `parse_string_to_decimal_native` treated empty strings and whitespace-only strings as valid input, resulting in a decimal with a value of 0. This is inconsistent with `parse_decimal` and how parsing and string -> numeric casts work for floating point types: in all of those cases, empty strings and whitespace-only strings are rejected.

# What changes are included in this PR?

* Change `parse_string_to_decimal_native` to reject empty strings and whitespace-only strings
* Add test coverage

# Are these changes tested?

Yes, new tests added.

# Are there any user-facing changes?

Yes, this changes the behavior of string -> decimal casts. The previous behavior is (IMO) clearly incorrect but it is possible that some user code relies upon it.