### PR TITLE
perf(interleave): Optimize list interleave_list when child is primitive

### DIFF
--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -373,6 +373,64 @@ fn interleave_struct(
     Ok(Arc::new(struct_array))
 }
 
+/// Specialized interleave for list child arrays that are primitive.
+/// Directly copies typed value slices and null bit ranges without
+/// going through MutableArrayData's function pointer indirection.
+fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
+    interleaved: &Interleave<'_, GenericListArray<O>>,
+    indices: &[(usize, usize)],
+    capacity: usize,
+) -> ArrayRef {
+    let child_arrays: Vec<&PrimitiveArray<T>> = interleaved
+        .arrays
+        .iter()
+        .map(|list| list.values().as_primitive::<T>())
+        .collect();
+
+    let has_child_nulls = child_arrays.iter().any(|a| a.null_count() > 0);
+
+    // Build values buffer by copying contiguous slices
+    let mut values: Vec<T::Native> = Vec::with_capacity(capacity);
+    for &(array, row) in indices {
+        let o = interleaved.arrays[array].value_offsets();
+        let start = o[row].as_usize();
+        let end = o[row + 1].as_usize();
+        if end > start {
+            values.extend_from_slice(&child_arrays[array].values()[start..end]);
+        }
+    }
+
+    // Build null buffer. Pre-allocate capacity so appends never resize.
+    // For sources without nulls: append_n sets bits to 1 (byte-level fill).
+    // For sources with nulls: append_packed_range copies the validity bits.
+    let nulls = if has_child_nulls {
+        let mut builder = BooleanBufferBuilder::new(capacity);
+        for &(array, row) in indices {
+            let o = interleaved.arrays[array].value_offsets();
+            let start = o[row].as_usize();
+            let end = o[row + 1].as_usize();
+            let len = end - start;
+            if len > 0 {
+                match child_arrays[array].nulls() {
+                    Some(null_buffer) => {
+                        let offset = null_buffer.offset();
+                        builder.append_packed_range(
+                            offset + start..offset + end,
+                            null_buffer.validity(),
+                        );
+                    }
+                    None => builder.append_n(len, true),
+                }
+            }
+        }
+        Some(NullBuffer::new(builder.finish()))
+    } else {
+        None
+    };
+
+    Arc::new(PrimitiveArray::<T>::new(values.into(), nulls))
+}
+
 fn interleave_list<O: OffsetSizeTrait>(
     values: &[&dyn Array],
     indices: &[(usize, usize)],
@@ -394,52 +452,40 @@ fn interleave_list<O: OffsetSizeTrait>(
     }
 
     // Step 2: build child values.
-    // For primitive child types, use MutableArrayData to directly memcpy contiguous
-    // ranges, avoiding the intermediate child_indices Vec allocation.
-    // For complex child types (nested lists, structs, views, dictionaries, etc.),
-    // use recursive interleave to benefit from type-specific optimizations.
-    let child_values = if field.data_type().primitive_width().is_some() {
-        let child_data: Vec<_> = interleaved
-            .arrays
-            .iter()
-            .map(|list| list.values().to_data())
-            .collect();
-        let child_data_refs: Vec<_> = child_data.iter().collect();
-        let mut mutable_child = MutableArrayData::new(child_data_refs, false, capacity);
+    macro_rules! list_primitive_helper {
+        ($t:ty) => {
+            interleave_list_primitive_child::<O, $t>(&interleaved, indices, capacity)
+        };
+    }
 
-        for &(array, row) in indices {
-            let o = interleaved.arrays[array].value_offsets();
-            let start = o[row].as_usize();
-            let end = o[row + 1].as_usize();
-            if end > start {
-                mutable_child.extend(array, start, end);
+    let child_values = downcast_primitive! {
+        // For primitive child types, directly copy typed value slices and null bit
+        // ranges, avoiding both the intermediate child_indices Vec allocation and
+        // MutableArrayData's function pointer indirection.
+        field.data_type() => (list_primitive_helper),
+        _ => {
+            // For complex child types (nested lists, structs, views, dictionaries, etc.),
+            // use recursive interleave to benefit from type-specific optimizations.
+            let mut child_indices = Vec::with_capacity(capacity);
+            for (array, row) in indices {
+                let list = interleaved.arrays[*array];
+                let start = list.value_offsets()[*row].as_usize();
+                let end = list.value_offsets()[*row + 1].as_usize();
+                child_indices.extend((start..end).map(|i| (*array, i)));
             }
-        }
-        make_array(mutable_child.freeze())
-    } else {
-        let mut child_indices = Vec::with_capacity(capacity);
-        for (array, row) in indices {
-            let list = interleaved.arrays[*array];
-            let start = list.value_offsets()[*row].as_usize();
-            let end = list.value_offsets()[*row + 1].as_usize();
-            child_indices.extend((start..end).map(|i| (*array, i)));
-        }
 
-        let child_arrays: Vec<&dyn Array> = interleaved
-            .arrays
-            .iter()
-            .map(|list| list.values().as_ref())
-            .collect();
-        interleave(&child_arrays, &child_indices)?
+            let child_arrays: Vec<&dyn Array> = interleaved
+                .arrays
+                .iter()
+                .map(|list| list.values().as_ref())
+                .collect();
+            interleave(&child_arrays, &child_indices)?
+        }
     };
 
     let offsets = OffsetBuffer::new(offsets.into());
-    let list_array = GenericListArray::<O>::new(
-        field.clone(),
-        offsets,
-        child_values,
-        interleaved.nulls,
-    );
+    let list_array =
+        GenericListArray::<O>::new(field.clone(), offsets, child_values, interleaved.nulls);
 
     Ok(Arc::new(list_array))
 }

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -380,6 +380,7 @@ fn interleave_list<O: OffsetSizeTrait>(
 ) -> Result<ArrayRef, ArrowError> {
     let interleaved = Interleave::<'_, GenericListArray<O>>::new(values, indices);
 
+    // Step 1: compute output offsets and total child capacity
     let mut capacity = 0usize;
     let mut offsets = Vec::with_capacity(indices.len() + 1);
     offsets.push(O::from_usize(0).unwrap());
@@ -392,27 +393,49 @@ fn interleave_list<O: OffsetSizeTrait>(
         );
     }
 
-    let mut child_indices = Vec::with_capacity(capacity);
-    for (array, row) in indices {
-        let list = interleaved.arrays[*array];
-        let start = list.value_offsets()[*row].as_usize();
-        let end = list.value_offsets()[*row + 1].as_usize();
-        child_indices.extend((start..end).map(|i| (*array, i)));
-    }
-
-    let child_arrays: Vec<&dyn Array> = interleaved
+    // Step 2: use MutableArrayData to directly copy child ranges,
+    // merging adjacent contiguous ranges from the same source array.
+    let child_data: Vec<_> = interleaved
         .arrays
         .iter()
-        .map(|list| list.values().as_ref())
+        .map(|list| list.values().to_data())
         .collect();
+    let child_data_refs: Vec<_> = child_data.iter().collect();
+    // nulls are derived from children.
+    let mut mutable_child = MutableArrayData::new(child_data_refs, /*use_nulls=*/false, capacity);
 
-    let interleaved_values = interleave(&child_arrays, &child_indices)?;
+    let first_offsets = interleaved.arrays[indices[0].0].value_offsets();
+    let mut cur_array = indices[0].0;
+    let mut cur_start = first_offsets[indices[0].1].as_usize();
+    let mut cur_end = first_offsets[indices[0].1 + 1].as_usize();
+
+    for &(array, row) in &indices[1..] {
+        let o = interleaved.arrays[array].value_offsets();
+        let row_start = o[row].as_usize();
+        let row_end = o[row + 1].as_usize();
+        if array == cur_array && row_start == cur_end {
+            // Extend current contiguous range
+            cur_end = row_end;
+        } else {
+            // Flush accumulated range
+            if cur_end > cur_start {
+                mutable_child.extend(cur_array, cur_start, cur_end);
+            }
+            cur_array = array;
+            cur_start = row_start;
+            cur_end = row_end;
+        }
+    }
+    // Flush final range
+    if cur_end > cur_start {
+        mutable_child.extend(cur_array, cur_start, cur_end);
+    }
 
     let offsets = OffsetBuffer::new(offsets.into());
     let list_array = GenericListArray::<O>::new(
         field.clone(),
         offsets,
-        interleaved_values,
+        make_array(mutable_child.freeze()),
         interleaved.nulls,
     );
 

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -401,15 +401,14 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
     }
 
     // Build null buffer. Pre-allocate with 0x00 (all null), then:
-    // - Sources with nulls: set_bits ORs in valid bits from source.
+    // - Sources with nulls: set_bits copies the source validity bits into the destination range.
     // - Sources without nulls: set the bit range to all 1s directly.
     let nulls = if has_child_nulls {
         let null_byte_len = bit_util::ceil(capacity, 8);
-        let mut null_buf = MutableBuffer::new(null_byte_len);
-        null_buf.resize(null_byte_len, 0);
+        let mut output_null_buf = MutableBuffer::from_len_zeroed(null_byte_len);
 
         let mut offset_write = 0;
-        let mut null_count = 0usize;
+        let mut output_null_count = 0usize;
         for &(array, row) in indices {
             let o = interleaved.arrays[array].value_offsets();
             let start = o[row].as_usize();
@@ -418,8 +417,8 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
             if len > 0 {
                 match child_arrays[array].nulls() {
                     Some(null_buffer) => {
-                        null_count += set_bits(
-                            null_buf.as_slice_mut(),
+                        output_null_count += set_bits(
+                            output_null_buf.as_slice_mut(),
                             null_buffer.validity(),
                             offset_write,
                             null_buffer.offset() + start,
@@ -428,7 +427,7 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
                     }
                     None => {
                         // For a non-nullable source, set the bit range to all 1s directly.
-                        let buf = null_buf.as_slice_mut();
+                        let buf = output_null_buf.as_slice_mut();
                         (offset_write..offset_write + len).for_each(|i| bit_util::set_bit(buf, i));
                     }
                 }
@@ -436,10 +435,10 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
             offset_write += len;
         }
 
-        if null_count > 0 {
-            let bool_buf = BooleanBuffer::new(null_buf.into(), 0, capacity);
+        if output_null_count > 0 {
+            let bool_buf = BooleanBuffer::new(output_null_buf.into(), 0, capacity);
             // SAFETY: null_count is accumulated from set_bits which correctly counts unset bits
-            Some(unsafe { NullBuffer::new_unchecked(bool_buf, null_count) })
+            Some(unsafe { NullBuffer::new_unchecked(bool_buf, output_null_count) })
         } else {
             None
         }

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -23,6 +23,8 @@ use arrow_array::builder::{BooleanBufferBuilder, PrimitiveBuilder};
 use arrow_array::cast::AsArray;
 use arrow_array::types::*;
 use arrow_array::*;
+use arrow_buffer::bit_mask::set_bits;
+use arrow_buffer::bit_util;
 use arrow_buffer::{ArrowNativeType, BooleanBuffer, MutableBuffer, NullBuffer, OffsetBuffer};
 use arrow_data::ByteView;
 use arrow_data::transform::MutableArrayData;
@@ -400,11 +402,15 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
         }
     }
 
-    // Build null buffer. Pre-allocate capacity so appends never resize.
-    // For sources without nulls: append_n sets bits to 1 (byte-level fill).
-    // For sources with nulls: append_packed_range copies the validity bits.
+    // Build null buffer. Pre-allocate with 0x00 (all null), then:
+    // - Sources with nulls: set_bits ORs in valid bits from source.
+    // - Sources without nulls: set the bit range to all 1s directly.
     let nulls = if has_child_nulls {
-        let mut builder = BooleanBufferBuilder::new(capacity);
+        let null_byte_len = bit_util::ceil(capacity, 8);
+        let mut null_buf = MutableBuffer::new(null_byte_len);
+        null_buf.resize(null_byte_len, 0);
+
+        let mut offset_write = 0;
         for &(array, row) in indices {
             let o = interleaved.arrays[array].value_offsets();
             let start = o[row].as_usize();
@@ -413,17 +419,26 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
             if len > 0 {
                 match child_arrays[array].nulls() {
                     Some(null_buffer) => {
-                        let offset = null_buffer.offset();
-                        builder.append_packed_range(
-                            offset + start..offset + end,
+                        set_bits(
+                            null_buf.as_slice_mut(),
                             null_buffer.validity(),
+                            offset_write,
+                            null_buffer.offset() + start,
+                            len,
                         );
                     }
-                    None => builder.append_n(len, true),
+                    None => {
+                        // Slow path. For a non-nullable source, set the bit range to all 1s directly.
+                        let buf = null_buf.as_slice_mut();
+                        (offset_write..offset_write + len).for_each(|i| bit_util::set_bit(buf, i));
+                    }
                 }
             }
+            offset_write += len;
         }
-        Some(NullBuffer::new(builder.finish()))
+
+        let bool_buf = BooleanBuffer::new(null_buf.into(), 0, capacity);
+        Some(NullBuffer::new(bool_buf))
     } else {
         None
     };

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -393,29 +393,51 @@ fn interleave_list<O: OffsetSizeTrait>(
         );
     }
 
-    // Step 2: use MutableArrayData to directly copy child ranges.
-    let child_data: Vec<_> = interleaved
-        .arrays
-        .iter()
-        .map(|list| list.values().to_data())
-        .collect();
-    let child_data_refs: Vec<_> = child_data.iter().collect();
-    let mut mutable_child = MutableArrayData::new(child_data_refs, false, capacity);
+    // Step 2: build child values.
+    // For primitive child types, use MutableArrayData to directly memcpy contiguous
+    // ranges, avoiding the intermediate child_indices Vec allocation.
+    // For complex child types (nested lists, structs, views, dictionaries, etc.),
+    // use recursive interleave to benefit from type-specific optimizations.
+    let child_values = if field.data_type().primitive_width().is_some() {
+        let child_data: Vec<_> = interleaved
+            .arrays
+            .iter()
+            .map(|list| list.values().to_data())
+            .collect();
+        let child_data_refs: Vec<_> = child_data.iter().collect();
+        let mut mutable_child = MutableArrayData::new(child_data_refs, false, capacity);
 
-    for &(array, row) in indices {
-        let o = interleaved.arrays[array].value_offsets();
-        let start = o[row].as_usize();
-        let end = o[row + 1].as_usize();
-        if end > start {
-            mutable_child.extend(array, start, end);
+        for &(array, row) in indices {
+            let o = interleaved.arrays[array].value_offsets();
+            let start = o[row].as_usize();
+            let end = o[row + 1].as_usize();
+            if end > start {
+                mutable_child.extend(array, start, end);
+            }
         }
-    }
+        make_array(mutable_child.freeze())
+    } else {
+        let mut child_indices = Vec::with_capacity(capacity);
+        for (array, row) in indices {
+            let list = interleaved.arrays[*array];
+            let start = list.value_offsets()[*row].as_usize();
+            let end = list.value_offsets()[*row + 1].as_usize();
+            child_indices.extend((start..end).map(|i| (*array, i)));
+        }
+
+        let child_arrays: Vec<&dyn Array> = interleaved
+            .arrays
+            .iter()
+            .map(|list| list.values().as_ref())
+            .collect();
+        interleave(&child_arrays, &child_indices)?
+    };
 
     let offsets = OffsetBuffer::new(offsets.into());
     let list_array = GenericListArray::<O>::new(
         field.clone(),
         offsets,
-        make_array(mutable_child.freeze()),
+        child_values,
         interleaved.nulls,
     );
 

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -393,42 +393,22 @@ fn interleave_list<O: OffsetSizeTrait>(
         );
     }
 
-    // Step 2: use MutableArrayData to directly copy child ranges,
-    // merging adjacent contiguous ranges from the same source array.
+    // Step 2: use MutableArrayData to directly copy child ranges.
     let child_data: Vec<_> = interleaved
         .arrays
         .iter()
         .map(|list| list.values().to_data())
         .collect();
     let child_data_refs: Vec<_> = child_data.iter().collect();
-    // nulls are derived from children.
-    let mut mutable_child = MutableArrayData::new(child_data_refs, /*use_nulls=*/false, capacity);
+    let mut mutable_child = MutableArrayData::new(child_data_refs, false, capacity);
 
-    let first_offsets = interleaved.arrays[indices[0].0].value_offsets();
-    let mut cur_array = indices[0].0;
-    let mut cur_start = first_offsets[indices[0].1].as_usize();
-    let mut cur_end = first_offsets[indices[0].1 + 1].as_usize();
-
-    for &(array, row) in &indices[1..] {
+    for &(array, row) in indices {
         let o = interleaved.arrays[array].value_offsets();
-        let row_start = o[row].as_usize();
-        let row_end = o[row + 1].as_usize();
-        if array == cur_array && row_start == cur_end {
-            // Extend current contiguous range
-            cur_end = row_end;
-        } else {
-            // Flush accumulated range
-            if cur_end > cur_start {
-                mutable_child.extend(cur_array, cur_start, cur_end);
-            }
-            cur_array = array;
-            cur_start = row_start;
-            cur_end = row_end;
+        let start = o[row].as_usize();
+        let end = o[row + 1].as_usize();
+        if end > start {
+            mutable_child.extend(array, start, end);
         }
-    }
-    // Flush final range
-    if cur_end > cur_start {
-        mutable_child.extend(cur_array, cur_start, cur_end);
     }
 
     let offsets = OffsetBuffer::new(offsets.into());

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -379,6 +379,7 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
     interleaved: &Interleave<'_, GenericListArray<O>>,
     indices: &[(usize, usize)],
     capacity: usize,
+    data_type: &DataType,
 ) -> ArrayRef {
     let child_arrays: Vec<&PrimitiveArray<T>> = interleaved
         .arrays
@@ -408,6 +409,7 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
         null_buf.resize(null_byte_len, 0);
 
         let mut offset_write = 0;
+        let mut null_count = 0usize;
         for &(array, row) in indices {
             let o = interleaved.arrays[array].value_offsets();
             let start = o[row].as_usize();
@@ -416,7 +418,7 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
             if len > 0 {
                 match child_arrays[array].nulls() {
                     Some(null_buffer) => {
-                        set_bits(
+                        null_count += set_bits(
                             null_buf.as_slice_mut(),
                             null_buffer.validity(),
                             offset_write,
@@ -425,7 +427,7 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
                         );
                     }
                     None => {
-                        // Slow path. For a non-nullable source, set the bit range to all 1s directly.
+                        // For a non-nullable source, set the bit range to all 1s directly.
                         let buf = null_buf.as_slice_mut();
                         (offset_write..offset_write + len).for_each(|i| bit_util::set_bit(buf, i));
                     }
@@ -434,13 +436,18 @@ fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
             offset_write += len;
         }
 
-        let bool_buf = BooleanBuffer::new(null_buf.into(), 0, capacity);
-        Some(NullBuffer::new(bool_buf))
+        if null_count > 0 {
+            let bool_buf = BooleanBuffer::new(null_buf.into(), 0, capacity);
+            // SAFETY: null_count is accumulated from set_bits which correctly counts unset bits
+            Some(unsafe { NullBuffer::new_unchecked(bool_buf, null_count) })
+        } else {
+            None
+        }
     } else {
         None
     };
 
-    Arc::new(PrimitiveArray::<T>::new(values.into(), nulls))
+    Arc::new(PrimitiveArray::<T>::new(values.into(), nulls).with_data_type(data_type.clone()))
 }
 
 fn interleave_list<O: OffsetSizeTrait>(
@@ -466,7 +473,12 @@ fn interleave_list<O: OffsetSizeTrait>(
     // Step 2: build child values.
     macro_rules! list_primitive_helper {
         ($t:ty) => {
-            interleave_list_primitive_child::<O, $t>(&interleaved, indices, capacity)
+            interleave_list_primitive_child::<O, $t>(
+                &interleaved,
+                indices,
+                capacity,
+                field.data_type(),
+            )
         };
     }
 

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -375,9 +375,6 @@ fn interleave_struct(
     Ok(Arc::new(struct_array))
 }
 
-/// Specialized interleave for list child arrays that are primitive.
-/// Directly copies typed value slices and null bit ranges without
-/// going through MutableArrayData's function pointer indirection.
 fn interleave_list_primitive_child<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
     interleaved: &Interleave<'_, GenericListArray<O>>,
     indices: &[(usize, usize)],


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10022.

# Rationale for this change

Optimize interleave_list when child is primitive type.

# What changes are included in this PR?

1. Special path when child is primitive type.
2. new `interleave_list_primitive_child` function

# Are these changes tested?

Covered by existing

# Are there any user-facing changes?

no