### PR TITLE
Adjust Variant size expectation for s390x architecture

### DIFF
--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -298,7 +298,9 @@ pub enum Variant<'m, 'v> {
 }
 
 // We don't want this to grow because it could hurt performance of a frequently-created type.
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(target_pointer_width = "64", target_arch = "s390x"))]
+const _: () = crate::utils::expect_size_of::<Variant>(72);
+#[cfg(all(target_pointer_width = "64", not(target_arch = "s390x")))]
 const _: () = crate::utils::expect_size_of::<Variant>(80);
 #[cfg(target_pointer_width = "32")]
 const _: () = crate::utils::expect_size_of::<Variant>(48);


### PR DESCRIPTION
# Which issue does this PR close?
- Closes #10026 .

# Rationale for this change

The Variant enum has a different size on s390x (72 bytes) compared to other 64-bit architectures (80 bytes) due to architecture-specific alignment and padding requirements.

# What changes are included in this PR?

This change adds a conditional compilation check to expect 72 bytes on s390x while maintaining the existing 80-byte expectation for other 64-bit platforms. This ensures the size check passes on s390x without compromising the performance validation on other architectures.

# Are these changes tested?

Build-time test only

# Are there any user-facing changes?

N/A
