### PR TITLE
chore: Remove some deprecated functions from parquet crate

### DIFF
--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -1634,7 +1634,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(deprecated)]
     async fn empty_offset_index_doesnt_panic_in_read_row_group() {
         use tokio::fs::File;
         let testdata = arrow::util::test_util::parquet_test_data();
@@ -1642,7 +1641,7 @@ mod tests {
         let mut file = File::open(&path).await.unwrap();
         let file_size = file.metadata().await.unwrap().len();
         let mut metadata = ParquetMetaDataReader::new()
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .load_and_finish(&mut file, file_size)
             .await
             .unwrap();
@@ -1660,7 +1659,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(deprecated)]
     async fn non_empty_offset_index_doesnt_panic_in_read_row_group() {
         use tokio::fs::File;
         let testdata = arrow::util::test_util::parquet_test_data();
@@ -1668,7 +1666,7 @@ mod tests {
         let mut file = File::open(&path).await.unwrap();
         let file_size = file.metadata().await.unwrap().len();
         let metadata = ParquetMetaDataReader::new()
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .load_and_finish(&mut file, file_size)
             .await
             .unwrap();
@@ -1685,7 +1683,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(deprecated)]
     async fn empty_offset_index_doesnt_panic_in_column_chunks() {
         use tempfile::TempDir;
         use tokio::fs::File;
@@ -1705,7 +1702,7 @@ mod tests {
             use std::fs::File;
             let file = File::open(file).unwrap();
             ParquetMetaDataReader::new()
-                .with_page_indexes(true)
+                .with_page_index_policy(PageIndexPolicy::Required)
                 .parse_and_finish(&file)
                 .unwrap()
         }
@@ -1715,7 +1712,7 @@ mod tests {
         let mut file = File::open(&path).await.unwrap();
         let file_size = file.metadata().await.unwrap().len();
         let metadata = ParquetMetaDataReader::new()
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .load_and_finish(&mut file, file_size)
             .await
             .unwrap();

--- a/parquet/src/arrow/mod.rs
+++ b/parquet/src/arrow/mod.rs
@@ -485,7 +485,8 @@ pub fn parquet_column<'a>(
 mod test {
     use crate::arrow::ArrowWriter;
     use crate::file::metadata::{
-        ParquetMetaData, ParquetMetaDataOptions, ParquetMetaDataReader, ParquetMetaDataWriter,
+        PageIndexPolicy, ParquetMetaData, ParquetMetaDataOptions, ParquetMetaDataReader,
+        ParquetMetaDataWriter,
     };
     use crate::file::properties::{EnabledStatistics, WriterProperties};
     use crate::schema::parser::parse_message_type;
@@ -497,7 +498,6 @@ mod test {
     use super::ProjectionMask;
 
     #[test]
-    #[allow(deprecated)]
     // Reproducer for https://github.com/apache/arrow-rs/issues/6464
     fn test_metadata_read_write_partial_offset() {
         let parquet_bytes = create_parquet_file();
@@ -514,7 +514,7 @@ mod test {
         let options = ParquetMetaDataOptions::new().with_encoding_stats_as_mask(false);
         let err = ParquetMetaDataReader::new()
             .with_metadata_options(Some(options))
-            .with_page_indexes(true) // there are no page indexes in the metadata
+            .with_page_index_policy(PageIndexPolicy::Required) // there are no page indexes in the metadata
             .parse_and_finish(&metadata_bytes)
             .err()
             .unwrap();
@@ -553,7 +553,6 @@ mod test {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn test_metadata_read_write_roundtrip_page_index() {
         let parquet_bytes = create_parquet_file();
 
@@ -562,7 +561,7 @@ mod test {
         let options = ParquetMetaDataOptions::new().with_encoding_stats_as_mask(false);
         let original_metadata = ParquetMetaDataReader::new()
             .with_metadata_options(Some(options))
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .parse_and_finish(&parquet_bytes)
             .unwrap();
 
@@ -571,7 +570,7 @@ mod test {
         let options = ParquetMetaDataOptions::new().with_encoding_stats_as_mask(false);
         let roundtrip_metadata = ParquetMetaDataReader::new()
             .with_metadata_options(Some(options))
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .parse_and_finish(&metadata_bytes)
             .unwrap();
 

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -56,12 +56,12 @@ use crate::arrow::async_reader::{MetadataFetch, MetadataSuffixFetch};
 ///
 /// # Example
 /// ```no_run
-/// # use parquet::file::metadata::ParquetMetaDataReader;
+/// # use parquet::file::metadata::{PageIndexPolicy, ParquetMetaDataReader};
 /// # fn open_parquet_file(path: &str) -> std::fs::File { unimplemented!(); }
 /// // read parquet metadata including page indexes from a file
 /// let file = open_parquet_file("some_path.parquet");
 /// let mut reader = ParquetMetaDataReader::new()
-///     .with_page_indexes(true);
+///     .with_page_with_page_index_policy(PageIndexPolicy::Required);
 /// reader.try_parse(&file).unwrap();
 /// let metadata = reader.finish().unwrap();
 /// assert!(metadata.column_index().is_some());
@@ -115,33 +115,6 @@ impl ParquetMetaDataReader {
             metadata: Some(metadata),
             ..Default::default()
         }
-    }
-
-    /// Enable or disable reading the page index structures described in
-    /// "[Parquet page index]: Layout to Support Page Skipping".
-    ///
-    /// [Parquet page index]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
-    #[deprecated(since = "56.1.0", note = "Use `with_page_index_policy` instead")]
-    pub fn with_page_indexes(self, val: bool) -> Self {
-        self.with_page_index_policy(PageIndexPolicy::from(val))
-    }
-
-    /// Enable or disable reading the Parquet [ColumnIndex] structure.
-    ///
-    /// [ColumnIndex]:  https://github.com/apache/parquet-format/blob/master/PageIndex.md
-    #[deprecated(since = "56.1.0", note = "Use `with_column_index_policy` instead")]
-    pub fn with_column_indexes(self, val: bool) -> Self {
-        let policy = PageIndexPolicy::from(val);
-        self.with_column_index_policy(policy)
-    }
-
-    /// Enable or disable reading the Parquet [OffsetIndex] structure.
-    ///
-    /// [OffsetIndex]:  https://github.com/apache/parquet-format/blob/master/PageIndex.md
-    #[deprecated(since = "56.1.0", note = "Use `with_offset_index_policy` instead")]
-    pub fn with_offset_indexes(self, val: bool) -> Self {
-        let policy = PageIndexPolicy::from(val);
-        self.with_offset_index_policy(policy)
     }
 
     /// Sets the [`PageIndexPolicy`] for the column and offset indexes
@@ -218,12 +191,12 @@ impl ParquetMetaDataReader {
     ///
     /// # Example
     /// ```no_run
-    /// # use parquet::file::metadata::ParquetMetaDataReader;
+    /// # use parquet::file::metadata::{PageIndexPolicy, ParquetMetaDataReader};
     /// # fn open_parquet_file(path: &str) -> std::fs::File { unimplemented!(); }
     /// // read parquet metadata including page indexes
     /// let file = open_parquet_file("some_path.parquet");
     /// let metadata = ParquetMetaDataReader::new()
-    ///     .with_page_indexes(true)
+    ///     .with_page_index_policy(PageIndexPolicy::Required)
     ///     .parse_and_finish(&file).unwrap();
     /// ```
     pub fn parse_and_finish<R: ChunkReader>(mut self, reader: &R) -> Result<ParquetMetaData> {
@@ -257,7 +230,7 @@ impl ParquetMetaDataReader {
     ///
     /// # Example
     /// ```no_run
-    /// # use parquet::file::metadata::ParquetMetaDataReader;
+    /// # use parquet::file::metadata::{PageIndexPolicy, ParquetMetaDataReader};
     /// # use parquet::errors::ParquetError;
     /// # use crate::parquet::file::reader::Length;
     /// # fn get_bytes(file: &std::fs::File, range: std::ops::Range<u64>) -> bytes::Bytes { unimplemented!(); }
@@ -266,7 +239,7 @@ impl ParquetMetaDataReader {
     /// let len = file.len();
     /// // Speculatively read 1 kilobyte from the end of the file
     /// let bytes = get_bytes(&file, len - 1024..len);
-    /// let mut reader = ParquetMetaDataReader::new().with_page_indexes(true);
+    /// let mut reader = ParquetMetaDataReader::new().with_page_index_policy(PageIndexPolicy::Required);
     /// match reader.try_parse_sized(&bytes, len) {
     ///     Ok(_) => (),
     ///     Err(ParquetError::NeedMoreData(needed)) => {
@@ -284,7 +257,7 @@ impl ParquetMetaDataReader {
     /// to test for this. In the event the file metadata is present, re-parsing of the file
     /// metadata can be skipped by using [`Self::read_page_indexes_sized()`], as shown below.
     /// ```no_run
-    /// # use parquet::file::metadata::ParquetMetaDataReader;
+    /// # use parquet::file::metadata::{PageIndexPolicy, ParquetMetaDataReader};
     /// # use parquet::errors::ParquetError;
     /// # use crate::parquet::file::reader::Length;
     /// # fn get_bytes(file: &std::fs::File, range: std::ops::Range<u64>) -> bytes::Bytes { unimplemented!(); }
@@ -293,7 +266,7 @@ impl ParquetMetaDataReader {
     /// let len = file.len();
     /// // Speculatively read 1 kilobyte from the end of the file
     /// let mut bytes = get_bytes(&file, len - 1024..len);
-    /// let mut reader = ParquetMetaDataReader::new().with_page_indexes(true);
+    /// let mut reader = ParquetMetaDataReader::new().with_page_index_policy(PageIndexPolicy::Required);
     /// // Loop until `bytes` is large enough
     /// loop {
     ///     match reader.try_parse_sized(&bytes, len) {
@@ -720,18 +693,6 @@ impl ParquetMetaDataReader {
         }
     }
 
-    /// Decodes a [`FooterTail`] from the provided 8-byte slice.
-    #[deprecated(since = "57.0.0", note = "Use FooterTail::try_from instead")]
-    pub fn decode_footer_tail(slice: &[u8; FOOTER_SIZE]) -> Result<FooterTail> {
-        FooterTail::try_new(slice)
-    }
-
-    /// Decodes the Parquet footer, returning the metadata length in bytes
-    #[deprecated(since = "54.3.0", note = "Use decode_footer_tail instead")]
-    pub fn decode_footer(slice: &[u8; FOOTER_SIZE]) -> Result<usize> {
-        FooterTail::try_new(slice).map(|f| f.metadata_length())
-    }
-
     /// Decodes [`ParquetMetaData`] from the provided bytes.
     ///
     /// Typically, this is used to decode the metadata from the end of a parquet
@@ -915,12 +876,12 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn test_try_parse() {
         let file = get_test_file("alltypes_tiny_pages.parquet");
         let len = file.len();
 
-        let mut reader = ParquetMetaDataReader::new().with_page_indexes(true);
+        let mut reader =
+            ParquetMetaDataReader::new().with_page_index_policy(PageIndexPolicy::Required);
 
         let bytes_for_range = |range: Range<u64>| {
             file.get_bytes(range.start, (range.end - range.start).try_into().unwrap())
@@ -964,7 +925,8 @@ mod tests {
         };
 
         // not enough for file metadata, but keep trying until page indexes are read
-        let mut reader = ParquetMetaDataReader::new().with_page_indexes(true);
+        let mut reader =
+            ParquetMetaDataReader::new().with_page_index_policy(PageIndexPolicy::Required);
         let mut bytes = bytes_for_range(452505..len);
         loop {
             match reader.try_parse_sized(&bytes, len) {
@@ -1301,7 +1263,6 @@ mod async_tests {
     }
 
     #[tokio::test]
-    #[allow(deprecated)]
     async fn test_page_index() {
         let mut file = get_test_file("alltypes_tiny_pages.parquet");
         let len = file.len();
@@ -1312,7 +1273,8 @@ mod async_tests {
         };
 
         let f = MetadataFetchFn(&mut fetch);
-        let mut loader = ParquetMetaDataReader::new().with_page_indexes(true);
+        let mut loader =
+            ParquetMetaDataReader::new().with_page_index_policy(PageIndexPolicy::Required);
         loader.try_load(f, len).await.unwrap();
         assert_eq!(fetch_count.load(Ordering::SeqCst), 3);
         let metadata = loader.finish().unwrap();
@@ -1322,7 +1284,7 @@ mod async_tests {
         fetch_count.store(0, Ordering::SeqCst);
         let f = MetadataFetchFn(&mut fetch);
         let mut loader = ParquetMetaDataReader::new()
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .with_prefetch_hint(Some(1729));
         loader.try_load(f, len).await.unwrap();
         assert_eq!(fetch_count.load(Ordering::SeqCst), 2);
@@ -1333,7 +1295,7 @@ mod async_tests {
         fetch_count.store(0, Ordering::SeqCst);
         let f = MetadataFetchFn(&mut fetch);
         let mut loader = ParquetMetaDataReader::new()
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .with_prefetch_hint(Some(130649));
         loader.try_load(f, len).await.unwrap();
         assert_eq!(fetch_count.load(Ordering::SeqCst), 2);
@@ -1344,7 +1306,7 @@ mod async_tests {
         fetch_count.store(0, Ordering::SeqCst);
         let f = MetadataFetchFn(&mut fetch);
         let metadata = ParquetMetaDataReader::new()
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .with_prefetch_hint(Some(130650))
             .load_and_finish(f, len)
             .await
@@ -1356,7 +1318,7 @@ mod async_tests {
         fetch_count.store(0, Ordering::SeqCst);
         let f = MetadataFetchFn(&mut fetch);
         let metadata = ParquetMetaDataReader::new()
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .with_prefetch_hint(Some((len - 1000) as usize)) // prefetch entire file
             .load_and_finish(f, len)
             .await
@@ -1368,7 +1330,7 @@ mod async_tests {
         fetch_count.store(0, Ordering::SeqCst);
         let f = MetadataFetchFn(&mut fetch);
         let metadata = ParquetMetaDataReader::new()
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .with_prefetch_hint(Some(len as usize)) // prefetch entire file
             .load_and_finish(f, len)
             .await
@@ -1380,7 +1342,7 @@ mod async_tests {
         fetch_count.store(0, Ordering::SeqCst);
         let f = MetadataFetchFn(&mut fetch);
         let metadata = ParquetMetaDataReader::new()
-            .with_page_indexes(true)
+            .with_page_index_policy(PageIndexPolicy::Required)
             .with_prefetch_hint(Some((len + 1000) as usize)) // prefetch entire file
             .load_and_finish(f, len)
             .await

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -61,7 +61,7 @@ use crate::arrow::async_reader::{MetadataFetch, MetadataSuffixFetch};
 /// // read parquet metadata including page indexes from a file
 /// let file = open_parquet_file("some_path.parquet");
 /// let mut reader = ParquetMetaDataReader::new()
-///     .with_page_with_page_index_policy(PageIndexPolicy::Required);
+///     .with_page_index_policy(PageIndexPolicy::Required);
 /// reader.try_parse(&file).unwrap();
 /// let metadata = reader.finish().unwrap();
 /// assert!(metadata.column_index().is_some());

--- a/parquet/src/file/page_index/index_reader.rs
+++ b/parquet/src/file/page_index/index_reader.rs
@@ -20,12 +20,10 @@
 use crate::basic::{BoundaryOrder, Type};
 use crate::data_type::Int96;
 use crate::errors::{ParquetError, Result};
-use crate::file::metadata::ColumnChunkMetaData;
 use crate::file::page_index::column_index::{
     ByteArrayColumnIndex, ColumnIndexMetaData, PrimitiveColumnIndex,
 };
 use crate::file::page_index::offset_index::OffsetIndexMetaData;
-use crate::file::reader::ChunkReader;
 use crate::parquet_thrift::{
     ElementType, FieldType, ReadThrift, ThriftCompactInputProtocol, ThriftCompactOutputProtocol,
     ThriftSliceInputProtocol, WriteThrift, WriteThriftField, read_thrift_vec,
@@ -42,97 +40,6 @@ pub(crate) fn acc_range(a: Option<Range<u64>>, b: Option<Range<u64>>) -> Option<
         (Some(a), Some(b)) => Some(a.start.min(b.start)..a.end.max(b.end)),
         (None, x) | (x, None) => x,
     }
-}
-
-/// Reads per-column [`ColumnIndexMetaData`] for all columns of a row group by
-/// decoding [`ColumnIndex`] .
-///
-/// Returns a vector of `index[column_number]`.
-///
-/// Returns `None` if this row group does not contain a [`ColumnIndex`].
-///
-/// See [Page Index Documentation] for more details.
-///
-/// [Page Index Documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
-/// [`ColumnIndex`]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
-#[deprecated(
-    since = "55.2.0",
-    note = "Use ParquetMetaDataReader instead; will be removed in 58.0.0"
-)]
-pub fn read_columns_indexes<R: ChunkReader>(
-    reader: &R,
-    chunks: &[ColumnChunkMetaData],
-) -> Result<Option<Vec<ColumnIndexMetaData>>, ParquetError> {
-    let fetch = chunks
-        .iter()
-        .fold(None, |range, c| acc_range(range, c.column_index_range()));
-
-    let fetch = match fetch {
-        Some(r) => r,
-        None => return Ok(None),
-    };
-
-    let bytes = reader.get_bytes(fetch.start as _, (fetch.end - fetch.start).try_into()?)?;
-
-    Some(
-        chunks
-            .iter()
-            .map(|c| match c.column_index_range() {
-                Some(r) => decode_column_index(
-                    &bytes[usize::try_from(r.start - fetch.start)?
-                        ..usize::try_from(r.end - fetch.start)?],
-                    c.column_type(),
-                ),
-                None => Ok(ColumnIndexMetaData::NONE),
-            })
-            .collect(),
-    )
-    .transpose()
-}
-
-/// Reads per-column [`OffsetIndexMetaData`] for all columns of a row group by
-/// decoding [`OffsetIndex`] .
-///
-/// Returns a vector of `offset_index[column_number]`.
-///
-/// Returns `None` if this row group does not contain an [`OffsetIndex`].
-///
-/// See [Page Index Documentation] for more details.
-///
-/// [Page Index Documentation]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
-/// [`OffsetIndex`]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
-#[deprecated(
-    since = "55.2.0",
-    note = "Use ParquetMetaDataReader instead; will be removed in 58.0.0"
-)]
-pub fn read_offset_indexes<R: ChunkReader>(
-    reader: &R,
-    chunks: &[ColumnChunkMetaData],
-) -> Result<Option<Vec<OffsetIndexMetaData>>, ParquetError> {
-    let fetch = chunks
-        .iter()
-        .fold(None, |range, c| acc_range(range, c.offset_index_range()));
-
-    let fetch = match fetch {
-        Some(r) => r,
-        None => return Ok(None),
-    };
-
-    let bytes = reader.get_bytes(fetch.start as _, (fetch.end - fetch.start).try_into()?)?;
-
-    Some(
-        chunks
-            .iter()
-            .map(|c| match c.offset_index_range() {
-                Some(r) => decode_offset_index(
-                    &bytes[usize::try_from(r.start - fetch.start)?
-                        ..usize::try_from(r.end - fetch.start)?],
-                ),
-                None => Err(general_err!("missing offset index")),
-            })
-            .collect(),
-    )
-    .transpose()
 }
 
 pub(crate) fn decode_offset_index(data: &[u8]) -> Result<OffsetIndexMetaData, ParquetError> {

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -240,7 +240,6 @@ impl<R: 'static + ChunkReader> SerializedFileReader<R> {
 
     /// Creates file reader from a Parquet file with read options.
     /// Returns an error if the Parquet file does not exist or is corrupt.
-    #[allow(deprecated)]
     pub fn new_with_options(chunk_reader: R, options: ReadOptions) -> Result<Self> {
         let mut metadata_builder = ParquetMetaDataReader::new()
             .with_metadata_options(Some(options.metadata_options.clone()))
@@ -266,8 +265,8 @@ impl<R: 'static + ChunkReader> SerializedFileReader<R> {
 
         // If page indexes are desired, build them with the filtered set of row groups
         if options.enable_page_index {
-            let mut reader =
-                ParquetMetaDataReader::new_with_metadata(metadata).with_page_indexes(true);
+            let mut reader = ParquetMetaDataReader::new_with_metadata(metadata)
+                .with_page_index_policy(PageIndexPolicy::Required);
             reader.read_page_indexes(&chunk_reader)?;
             metadata = reader.finish()?;
         }

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1185,8 +1185,6 @@ mod tests {
     use crate::data_type::private::ParquetValueType;
     use crate::data_type::{AsBytes, FixedLenByteArrayType, Int32Type};
     use crate::file::metadata::thrift::DataPageHeaderV2;
-    #[allow(deprecated)]
-    use crate::file::page_index::index_reader::{read_columns_indexes, read_offset_indexes};
     use crate::file::writer::SerializedFileWriter;
     use crate::record::RowAccessor;
     use crate::schema::parser::parse_message_type;
@@ -2179,31 +2177,6 @@ mod tests {
         assert_eq!(4, page_offset.offset);
         assert_eq!(152, page_offset.compressed_page_size);
         assert_eq!(0, page_offset.first_row_index);
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn test_page_index_reader_out_of_order() {
-        let test_file = get_test_file("alltypes_tiny_pages_plain.parquet");
-        let options = ReadOptionsBuilder::new().with_page_index().build();
-        let reader = SerializedFileReader::new_with_options(test_file, options).unwrap();
-        let metadata = reader.metadata();
-
-        let test_file = get_test_file("alltypes_tiny_pages_plain.parquet");
-        let columns = metadata.row_group(0).columns();
-        let reversed: Vec<_> = columns.iter().cloned().rev().collect();
-
-        let a = read_columns_indexes(&test_file, columns).unwrap().unwrap();
-        let mut b = read_columns_indexes(&test_file, &reversed)
-            .unwrap()
-            .unwrap();
-        b.reverse();
-        assert_eq!(a, b);
-
-        let a = read_offset_indexes(&test_file, columns).unwrap().unwrap();
-        let mut b = read_offset_indexes(&test_file, &reversed).unwrap().unwrap();
-        b.reverse();
-        assert_eq!(a, b);
     }
 
     #[test]

--- a/parquet/tests/arrow_reader/bad_data.rs
+++ b/parquet/tests/arrow_reader/bad_data.rs
@@ -188,9 +188,8 @@ fn skip_unknown_types() {
 
 #[cfg(feature = "async")]
 #[tokio::test]
-#[allow(deprecated)]
 async fn bad_metadata_err() {
-    use parquet::file::metadata::ParquetMetaDataReader;
+    use parquet::file::metadata::{PageIndexPolicy, ParquetMetaDataReader};
 
     let metadata_buffer = Bytes::from_static(include_bytes!("bad_raw_metadata.bin"));
 
@@ -199,13 +198,13 @@ async fn bad_metadata_err() {
     let mut reader = std::io::Cursor::new(&metadata_buffer);
     let mut loader = ParquetMetaDataReader::new();
     loader.try_load(&mut reader, metadata_length).await.unwrap();
-    loader = loader.with_page_indexes(false);
+    loader = loader.with_page_index_policy(PageIndexPolicy::Skip);
     loader.load_page_index(&mut reader).await.unwrap();
 
-    loader = loader.with_offset_indexes(true);
+    loader = loader.with_offset_index_policy(PageIndexPolicy::Required);
     loader.load_page_index(&mut reader).await.unwrap();
 
-    loader = loader.with_column_indexes(true);
+    loader = loader.with_column_index_policy(PageIndexPolicy::Required);
     let err = loader.load_page_index(&mut reader).await.unwrap_err();
 
     assert_eq!(


### PR DESCRIPTION
# Which issue does this PR close?
None

# Rationale for this change
Tidying up for 59.0.0. 

# What changes are included in this PR?
Removes public APIs that were due to be removed per the [deprecation policy](https://github.com/apache/arrow-rs#deprecation-guidelines).

# Are these changes tested?
Should be covered by existing tests

# Are there any user-facing changes?
Yes, public functions have been removed, including `ParquetMetaDataReader::with_page_indexes`, `read_columns_indexes`, and `read_offset_indexes`.
