### PR TITLE
Avoid an extra copy in `SerializedRowGroupWriter`

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -20,11 +20,9 @@
 use crate::column::chunker::ContentDefinedChunker;
 
 use bytes::Bytes;
-use std::io::{Read, Write};
-use std::iter::Peekable;
+use std::io::Write;
 use std::slice::Iter;
 use std::sync::{Arc, Mutex};
-use std::vec::IntoIter;
 
 use arrow_array::cast::AsArray;
 use arrow_array::types::*;
@@ -49,7 +47,6 @@ use crate::encryption::encrypt::FileEncryptor;
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::{KeyValue, ParquetMetaData, RowGroupMetaData};
 use crate::file::properties::{WriterProperties, WriterPropertiesPtr};
-use crate::file::reader::{ChunkReader, Length};
 use crate::file::writer::{SerializedFileWriter, SerializedRowGroupWriter};
 use crate::parquet_thrift::{ThriftCompactOutputProtocol, WriteThrift};
 use crate::schema::types::{ColumnDescPtr, SchemaDescPtr, SchemaDescriptor};
@@ -604,54 +601,15 @@ impl ArrowWriterOptions {
 }
 
 /// A single column chunk produced by [`ArrowColumnWriter`]
+///
+/// Holds the column's serialized pages (each page's header followed by its
+/// compressed data, in file order) as a sequence of byte buffers, ready to be
+/// spliced into the row group via
+/// [`SerializedRowGroupWriter::append_column_from_pages`].
 #[derive(Default)]
 struct ArrowColumnChunkData {
     length: usize,
     data: Vec<Bytes>,
-}
-
-impl Length for ArrowColumnChunkData {
-    fn len(&self) -> u64 {
-        self.length as _
-    }
-}
-
-impl ChunkReader for ArrowColumnChunkData {
-    type T = ArrowColumnChunkReader;
-
-    fn get_read(&self, start: u64) -> Result<Self::T> {
-        assert_eq!(start, 0); // Assume append_column writes all data in one-shot
-        Ok(ArrowColumnChunkReader(
-            self.data.clone().into_iter().peekable(),
-        ))
-    }
-
-    fn get_bytes(&self, _start: u64, _length: usize) -> Result<Bytes> {
-        unimplemented!()
-    }
-}
-
-/// A [`Read`] for [`ArrowColumnChunkData`]
-struct ArrowColumnChunkReader(Peekable<IntoIter<Bytes>>);
-
-impl Read for ArrowColumnChunkReader {
-    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
-        let buffer = loop {
-            match self.0.peek_mut() {
-                Some(b) if b.is_empty() => {
-                    self.0.next();
-                    continue;
-                }
-                Some(b) => break b,
-                None => return Ok(0),
-            }
-        };
-
-        let len = buffer.len().min(out.len());
-        let b = buffer.split_to(len);
-        out[..len].copy_from_slice(&b);
-        Ok(len)
-    }
 }
 
 /// A shared [`ArrowColumnChunkData`]
@@ -785,12 +743,15 @@ impl ArrowColumnChunk {
         &mut self.close
     }
 
-    /// Calls [`SerializedRowGroupWriter::append_column`] with this column's data
+    /// Splices this column's buffered pages into the row group via
+    /// [`SerializedRowGroupWriter::append_column_from_pages`], writing each page
+    /// buffer directly to the output without copying through an intermediate
+    /// buffer.
     pub fn append_to_row_group<W: Write + Send>(
         self,
         writer: &mut SerializedRowGroupWriter<'_, W>,
     ) -> Result<()> {
-        writer.append_column(&self.data, self.close)
+        writer.append_column_from_pages(self.data.data, self.close)
     }
 }
 

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -22,6 +22,7 @@ use crate::file::metadata::thrift::PageHeader;
 use crate::file::page_index::column_index::ColumnIndexMetaData;
 use crate::file::page_index::offset_index::OffsetIndexMetaData;
 use crate::parquet_thrift::{ThriftCompactOutputProtocol, WriteThrift};
+use bytes::Bytes;
 use std::fmt::Debug;
 use std::io::{BufWriter, IoSlice, Read};
 use std::{io::Write, sync::Arc};
@@ -684,15 +685,77 @@ impl<'a, W: Write + Send> SerializedRowGroupWriter<'a, W> {
     pub fn append_column<R: ChunkReader>(
         &mut self,
         reader: &R,
-        mut close: ColumnCloseResult,
+        close: ColumnCloseResult,
     ) -> Result<()> {
+        let (src_offset, src_length, write_offset) = self.begin_appended_column(&close)?;
+
+        let mut read = reader.get_read(src_offset as _)?.take(src_length as _);
+        let write_length = std::io::copy(&mut read, &mut self.buf)?;
+
+        if src_length as u64 != write_length {
+            return Err(general_err!(
+                "Failed to splice column data, expected {} got {}",
+                src_length,
+                write_length
+            ));
+        }
+
+        self.finish_appended_column(close, src_offset, write_offset)
+    }
+
+    /// Append an already-encoded column chunk from an in-order sequence of
+    /// [`Bytes`] buffers (typically its serialized pages) directly into the
+    /// underlying writer.
+    ///
+    /// This is a lower-overhead alternative to [`Self::append_column`] for
+    /// callers that already hold the encoded column as owned [`Bytes`],
+    /// avoiding an intermediate copy.
+    ///
+    /// # Arguments
+    /// - `pages`: an iterator that yields the chunk's compressed bytes in final file
+    ///   order (the dictionary page, if any, first) and together total exactly
+    ///   the compressed size in `close`
+    /// - `close`: the [`ColumnCloseResult`] metadata returned from closing
+    ///   the column writer that wrote the data in `pages`.
+    pub fn append_column_from_pages<I>(&mut self, pages: I, close: ColumnCloseResult) -> Result<()>
+    where
+        I: IntoIterator<Item = Bytes>,
+    {
+        let (src_offset, src_length, write_offset) = self.begin_appended_column(&close)?;
+
+        let mut write_length = 0u64;
+        for page in pages {
+            self.buf.write_all(&page)?;
+            write_length += page.len() as u64;
+        }
+
+        if src_length as u64 != write_length {
+            return Err(general_err!(
+                "Failed to splice column data, expected {} got {}",
+                src_length,
+                write_length
+            ));
+        }
+
+        self.finish_appended_column(close, src_offset, write_offset)
+    }
+
+    /// [`Self::append_column`] and [`Self::append_column_from_pages`] preamble
+    ///
+    /// Validates the writer state and that `close` matches the next expected
+    /// column.
+    ///
+    /// Returns `(src_offset, src_length, write_offset)`:
+    /// * `src_offset`: the start offset in the source buffer
+    /// * `src_length`: length of the chunk in the source buffer
+    /// * `write_offset`: the offset at which it will be written in the output file.
+    fn begin_appended_column(&mut self, close: &ColumnCloseResult) -> Result<(i64, i64, usize)> {
         self.assert_previous_writer_closed()?;
         let desc = self
             .next_column_desc()
             .ok_or_else(|| general_err!("exhausted columns in SerializedRowGroupWriter"))?;
 
-        let metadata = close.metadata;
-
+        let metadata = &close.metadata;
         if metadata.column_descr() != desc.as_ref() {
             return Err(general_err!(
                 "column descriptor mismatch, expected {:?} got {:?}",
@@ -701,20 +764,32 @@ impl<'a, W: Write + Send> SerializedRowGroupWriter<'a, W> {
             ));
         }
 
-        let src_dictionary_offset = metadata.dictionary_page_offset();
-        let src_data_offset = metadata.data_page_offset();
-        let src_offset = src_dictionary_offset.unwrap_or(src_data_offset);
+        let src_offset = metadata
+            .dictionary_page_offset()
+            .unwrap_or_else(|| metadata.data_page_offset());
         let src_length = metadata.compressed_size();
-
         let write_offset = self.buf.bytes_written();
-        let mut read = reader.get_read(src_offset as _)?.take(src_length as _);
-        let write_length = std::io::copy(&mut read, &mut self.buf)?;
+        Ok((src_offset, src_length, write_offset))
+    }
 
-        if src_length as u64 != write_length {
-            return Err(general_err!(
-                "Failed to splice column data, expected {read_length} got {write_length}"
-            ));
-        }
+    /// [`Self::append_column`] and [`Self::append_column_from_pages`] epilogue
+    ///
+    /// Rewrites the buffer-relative page offsets recorded in `close` to their
+    /// final positions in the output file.
+    ///
+    /// # Arguments
+    /// * `close`: the [`ColumnCloseResult`] metadata whose offsets are rewritten
+    /// * `write_offset`: the start of the actual write
+    /// * `src_offset`: the original source offset
+    fn finish_appended_column(
+        &mut self,
+        mut close: ColumnCloseResult,
+        src_offset: i64,
+        write_offset: usize,
+    ) -> Result<()> {
+        let metadata = close.metadata;
+        let src_data_offset = metadata.data_page_offset();
+        let src_dictionary_offset = metadata.dictionary_page_offset();
 
         let map_offset = |x| x - src_offset + write_offset as i64;
         let mut builder = ColumnChunkMetaData::builder(metadata.column_descr_ptr())


### PR DESCRIPTION
# Which issue does this PR close?

- Inspired by reviewing #10020  from @adriangb 

# Rationale for this change

When the Arrow `ArrowWriter` flushes a row group, each column chunk's encoded pages (buffered as a `Vec<Bytes>`) are written into the output file. Today that copy goes through `ArrowColumnChunkReader` that implements `Read`, driven by `std::io::copy`:

```rust
// arrow_writer: ArrowColumnChunkData implements ChunkReader/Read ...
writer.append_column(&self.data, self.close)
// file/writer.rs:
let mut read = reader.get_read(src_offset)?.take(src_length);
std::io::copy(&mut read, &mut self.buf)?;   // copies every byte through an 8 KiB buffer
```

This means that every byte of every column chunk is copied **twice**, in ~`len / 8 KiB` write calls. The `Bytes` blobs are already contiguous and owned; we can write each straight to the sink with a single `write_all`.

# What changes are included in this PR?

- **New public API** `SerializedRowGroupWriter::append_column_from_pages: splices an already-encoded column chunk supplied as in-order byte buffers (typically its serialized pages), writing each directly to the output. 

# Are these changes tested?

Yes, but existig CI

# Are there any user-facing changes?

One additive public method (`append_column_from_pages`). No breaking changes, and the resulting files are the same byte for byte

Partly 🤖 Generated with [Claude Code](https://claude.com/claude-code) (which is very good at advertising itself)