### PR TITLE
test(arrow-select): add take_bytes coverage for sliced values and nullable offset overflow

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -2843,16 +2843,20 @@ mod tests {
         assert_eq!(array.len(), 3);
     }
 
+    /// Fixture for the offset-overflow tests: a single large value plus the
+    /// number of times it must be selected so the cumulative offset exceeds
+    /// `i32::MAX`. Using a large value keeps the index count (and the test
+    /// runtime) small.
+    fn offset_overflow_fixture() -> (StringArray, usize) {
+        let value_len = 1_000_000;
+        let values = StringArray::from(vec![Some("a".repeat(value_len))]);
+        let n = i32::MAX as usize / value_len + 1;
+        (values, n)
+    }
+
     #[test]
     fn test_take_bytes_offset_overflow() {
-        // Select a single large value enough times that the cumulative offset
-        // exceeds i32::MAX. Using a large value keeps the number of indices
-        // (and therefore the runtime) small.
-        let value_len = 1_000_000;
-        let big = "a".repeat(value_len);
-        let values = StringArray::from(vec![Some(big.as_str())]);
-
-        let n = i32::MAX as usize / value_len + 1;
+        let (values, n) = offset_overflow_fixture();
         let indices = Int32Array::from(vec![0; n]);
         assert!(matches!(
             take(&values, &indices, None),
@@ -2864,14 +2868,9 @@ mod tests {
     /// path (when the output contains nulls), not only on the no-null fast path.
     #[test]
     fn test_take_bytes_offset_overflow_nullable() {
-        // Same overflow trigger as `test_take_bytes_offset_overflow`, but with a
-        // null index so the output contains nulls and the nullable code path is
-        // exercised. A large value keeps the index count (and runtime) small.
-        let value_len = 1_000_000;
-        let big = "a".repeat(value_len);
-        let values = StringArray::from(vec![Some(big.as_str())]);
-
-        let n = i32::MAX as usize / value_len + 1;
+        let (values, n) = offset_overflow_fixture();
+        // A null index forces the output to contain nulls, exercising the
+        // nullable code path.
         let validity =
             NullBuffer::from_iter(std::iter::once(false).chain(std::iter::repeat_n(true, n)));
         let indices = Int32Array::new(vec![0i32; n + 1].into(), Some(validity));

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1728,6 +1728,41 @@ mod tests {
         assert_eq!(result.as_ref(), &expected);
     }
 
+    /// Take from a *sliced* byte array, i.e. one whose value offsets do not
+    /// start at zero. This exercises copying byte data out of an array with a
+    /// non-zero base offset for both the no-null fast path and the nullable
+    /// path (null indices and selected null values).
+    #[test]
+    fn test_take_bytes_sliced_values() {
+        let values = StringArray::from(vec![
+            Some("aaa"),
+            Some("bbb"),
+            None,
+            Some("ccccc"),
+            Some("dd"),
+            None,
+            Some("eeee"),
+        ]);
+        // Slice so the underlying value offsets no longer start at 0:
+        // sliced == [None, "ccccc", "dd", None, "eeee"]
+        let sliced = values.slice(2, 5);
+
+        // Fast path: every output slot is valid (no null indices, no null
+        // values selected).
+        let indices = Int32Array::from(vec![1, 2, 4, 1]);
+        let result = take(&sliced, &indices, None).unwrap();
+        let expected =
+            StringArray::from(vec![Some("ccccc"), Some("dd"), Some("eeee"), Some("ccccc")]);
+        assert_eq!(result.as_string::<i32>(), &expected);
+
+        // Nullable path: a null index (position 1) and selected null values
+        // (sliced indices 0 and 3 are null).
+        let indices = Int32Array::from(vec![Some(1), None, Some(0), Some(4), Some(3)]);
+        let result = take(&sliced, &indices, None).unwrap();
+        let expected = StringArray::from(vec![Some("ccccc"), None, None, Some("eeee"), None]);
+        assert_eq!(result.as_string::<i32>(), &expected);
+    }
+
     fn _test_byte_view<T>()
     where
         T: ByteViewType,
@@ -2810,9 +2845,37 @@ mod tests {
 
     #[test]
     fn test_take_bytes_offset_overflow() {
-        let indices = Int32Array::from(vec![0; (i32::MAX >> 4) as usize]);
-        let text = ('a'..='z').collect::<String>();
-        let values = StringArray::from(vec![Some(text.clone())]);
+        // Select a single large value enough times that the cumulative offset
+        // exceeds i32::MAX. Using a large value keeps the number of indices
+        // (and therefore the runtime) small.
+        let value_len = 1_000_000;
+        let big = "a".repeat(value_len);
+        let values = StringArray::from(vec![Some(big.as_str())]);
+
+        let n = i32::MAX as usize / value_len + 1;
+        let indices = Int32Array::from(vec![0; n]);
+        assert!(matches!(
+            take(&values, &indices, None),
+            Err(ArrowError::OffsetOverflowError(_))
+        ));
+    }
+
+    /// The offset-overflow error must also be produced on the nullable code
+    /// path (when the output contains nulls), not only on the no-null fast path.
+    #[test]
+    fn test_take_bytes_offset_overflow_nullable() {
+        // Same overflow trigger as `test_take_bytes_offset_overflow`, but with a
+        // null index so the output contains nulls and the nullable code path is
+        // exercised. A large value keeps the index count (and runtime) small.
+        let value_len = 1_000_000;
+        let big = "a".repeat(value_len);
+        let values = StringArray::from(vec![Some(big.as_str())]);
+
+        let n = i32::MAX as usize / value_len + 1;
+        let validity =
+            NullBuffer::from_iter(std::iter::once(false).chain(std::iter::repeat_n(true, n)));
+        let indices = Int32Array::new(vec![0i32; n + 1].into(), Some(validity));
+
         assert!(matches!(
             take(&values, &indices, None),
             Err(ArrowError::OffsetOverflowError(_))


### PR DESCRIPTION
# Which issue does this PR close?

- test-only follow-up to #9625.

# Rationale for this change

While reviewing #9625 (which rewrites `take_bytes`), I noticed two paths in the existing test suite were not directly exercised:

1. **Taking from a *sliced* byte array**
2. **The `OffsetOverflowError` on the nullable path** — `test_take_bytes_offset_overflow` only uses non-null indices, so it only covers the no-null fast path.

I can write tests which pass against `main` today and show the existing behavior give #9625 (and future `take_bytes` changes) better coverage of the byte-copy and overflow paths.

# What changes are included in this PR?

Two new tests in `arrow-select/src/take.rs`:

# Are these changes tested?

These changes *are* tests. They pass on the current implementation.

# Are there any user-facing changes?

None.