### PR TITLE
perf(parquet): use SVE gather for dictionary decode on AArch64

### DIFF
--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -338,6 +338,143 @@ impl RleEncoder {
 /// Size, in number of `i32s` of buffer to use for RLE batch reading
 const RLE_DECODER_INDEX_BUFFER_SIZE: usize = 1024;
 
+/// SVE-accelerated dictionary gather for AArch64.
+///
+/// SVE is an optional extension that is not part of the AArch64 baseline, so a
+/// portable binary cannot rely on the autovectoriser emitting gather
+/// instructions for it. Rust also has no stable SVE intrinsics, so the kernels
+/// are written in inline assembly and guarded by a cached runtime feature check.
+#[cfg(target_arch = "aarch64")]
+mod sve_gather {
+    use std::arch::asm;
+    use std::mem::{needs_drop, size_of};
+    use std::sync::atomic::{AtomicU8, Ordering};
+
+    const UNCHECKED: u8 = 0;
+    const SUPPORTED: u8 = 1;
+    const UNSUPPORTED: u8 = 2;
+
+    static SVE_STATUS: AtomicU8 = AtomicU8::new(UNCHECKED);
+
+    #[inline]
+    fn sve_available() -> bool {
+        match SVE_STATUS.load(Ordering::Relaxed) {
+            UNCHECKED => {
+                let available = std::arch::is_aarch64_feature_detected!("sve");
+                SVE_STATUS.store(
+                    if available { SUPPORTED } else { UNSUPPORTED },
+                    Ordering::Relaxed,
+                );
+                available
+            }
+            status => status == SUPPORTED,
+        }
+    }
+
+    /// Gather `count` 4-byte elements `dict[indices[i]]` into `output`.
+    ///
+    /// # Safety
+    /// - every `indices[i]` must be a valid in-bounds offset into `dict`
+    /// - `indices` and `output` must be valid for `count` elements
+    /// - the `sve` feature must be available
+    #[target_feature(enable = "sve")]
+    unsafe fn gather_4byte(dict: *const u8, indices: *const i32, output: *mut u8, count: usize) {
+        // SAFETY: the caller guarantees the index/dict/output invariants and that
+        // the `sve` feature is present.
+        unsafe {
+            asm!(
+                "mov {pos}, #0",
+                "whilelt p0.s, {pos}, {count}",
+                "2:",
+                "ld1w {{z0.s}}, p0/z, [{idx}, {pos}, lsl #2]",
+                "ld1w {{z1.s}}, p0/z, [{dict}, z0.s, uxtw #2]",
+                "st1w {{z1.s}}, p0, [{out}, {pos}, lsl #2]",
+                "incw {pos}",
+                "whilelt p0.s, {pos}, {count}",
+                "b.first 2b",
+                pos = out(reg) _,
+                count = in(reg) count,
+                idx = in(reg) indices,
+                dict = in(reg) dict,
+                out = in(reg) output,
+                options(nostack)
+            );
+        }
+    }
+
+    /// Gather `count` 8-byte elements `dict[indices[i]]` into `output`.
+    ///
+    /// # Safety
+    /// Same contract as [`gather_4byte`], for 8-byte elements.
+    #[target_feature(enable = "sve")]
+    unsafe fn gather_8byte(dict: *const u8, indices: *const i32, output: *mut u8, count: usize) {
+        // SAFETY: the caller guarantees the index/dict/output invariants and that
+        // the `sve` feature is present.
+        unsafe {
+            asm!(
+                "mov {pos}, #0",
+                "mov {idx_pos}, #0",
+                "whilelt p0.d, {pos}, {count}",
+                "2:",
+                "ld1sw {{z0.d}}, p0/z, [{idx}, {idx_pos}, lsl #2]",
+                "ld1d {{z1.d}}, p0/z, [{dict}, z0.d, lsl #3]",
+                "st1d {{z1.d}}, p0, [{out}, {pos}, lsl #3]",
+                "incd {pos}",
+                "incd {idx_pos}",
+                "whilelt p0.d, {pos}, {count}",
+                "b.first 2b",
+                pos = out(reg) _,
+                idx_pos = out(reg) _,
+                count = in(reg) count,
+                idx = in(reg) indices,
+                dict = in(reg) dict,
+                out = in(reg) output,
+                options(nostack)
+            );
+        }
+    }
+
+    /// Gather `dict[indices[i]]` into `buffer` using SVE, returning `true` if the
+    /// SVE path ran and `false` if the caller must fall back to a scalar copy.
+    ///
+    /// The kernels copy raw element bytes, so they only run for 4- and 8-byte
+    /// types that do not need drop. Every index must already be known to be in
+    /// bounds.
+    #[inline]
+    pub fn try_gather<T: Clone>(dict: &[T], indices: &[i32], buffer: &mut [T]) -> bool {
+        if needs_drop::<T>() || !sve_available() {
+            return false;
+        }
+
+        let count = indices.len();
+        debug_assert!(buffer.len() >= count);
+
+        // SAFETY: the caller has checked every index is in bounds, the slices
+        // hold `count` elements, and SVE availability was confirmed above.
+        match size_of::<T>() {
+            4 => unsafe {
+                gather_4byte(
+                    dict.as_ptr() as *const u8,
+                    indices.as_ptr(),
+                    buffer.as_mut_ptr() as *mut u8,
+                    count,
+                );
+                true
+            },
+            8 => unsafe {
+                gather_8byte(
+                    dict.as_ptr() as *const u8,
+                    indices.as_ptr(),
+                    buffer.as_mut_ptr() as *mut u8,
+                    count,
+                );
+                true
+            },
+            _ => false,
+        }
+    }
+}
+
 /// A RLE/Bit-Packing hybrid decoder.
 pub struct RleDecoder {
     // Number of bits used to encode the value. Must be between [0, 64].
@@ -579,9 +716,17 @@ impl RleDecoder {
                             if (max_idx as usize) >= dict_len {
                                 return Err(oob(max_idx, dict_len));
                             }
-                            for (b, i) in out_chunk.iter_mut().zip(idx_chunk.iter()) {
-                                // SAFETY: all indices checked above to be in bounds
-                                b.clone_from(unsafe { dict.get_unchecked(*i as usize) });
+                            // Every index in this chunk is now known to be in
+                            // bounds, so the gather reuses that single check.
+                            #[cfg(target_arch = "aarch64")]
+                            let gathered = sve_gather::try_gather(dict, idx_chunk, out_chunk);
+                            #[cfg(not(target_arch = "aarch64"))]
+                            let gathered = false;
+                            if !gathered {
+                                for (b, i) in out_chunk.iter_mut().zip(idx_chunk.iter()) {
+                                    // SAFETY: all indices checked above to be in bounds
+                                    b.clone_from(unsafe { dict.get_unchecked(*i as usize) });
+                                }
                             }
                         }
                         for (b, i) in out_chunks


### PR DESCRIPTION
Add a runtime-detected SVE gather path to RleDecoder::get_batch_with_dict. On AArch64, NEON has no gather instruction and SVE is not part of the baseline ISA, so a portable binary cannot autovectorise the dictionary lookup to a hardware gather. This adds an inline-assembly SVE kernel, gated by a cached `is_aarch64_feature_detected!("sve")` check, that gathers 4- and 8-byte dictionary values.

The gather slots in at the existing `get_unchecked` site introduced in #9746 and reuses its hoisted max-reduction bounds check, so it adds no new per-element checks. It is gated on `!needs_drop::<T>()` since the kernel copies raw element bytes, and falls back to the scalar loop for every other type, width, or when SVE is unavailable. Non-AArch64 targets are unchanged.

# Which issue does this PR close?

- Closes #10036 .

# Rationale for this change

`RleDecoder::get_batch_with_dict` is on the hot path for decoding
dictionary-encoded columns. #9746 recently reworked the bit-packed branch so
the per-element bounds check is hoisted into a single u32 max-reduction
followed by an unchecked gather, which lets the autovectorizer emit a hardware
gather on x86 (AVX2/AVX-512) when those target features are enabled.

On AArch64 the situation is different: base Armv8-A / NEON has no gather
instruction, and the only Arm gather lives in SVE, which is an *optional*
extension that is not part of the AArch64 baseline. A portable
`aarch64-unknown-linux-gnu` binary therefore does not have `+sve` in its target
features, so even after #9746 the autovectorizer cannot emit an SVE gather for
this loop and falls back to scalar loads. This PR fills that gap with a
runtime-detected SVE gather, so portable binaries can use the hardware gather on
SVE-capable cores (e.g. Kunpeng 920B) without requiring `-C target-cpu=...` at
build time.

# What changes are included in this PR?

- A new `#[cfg(target_arch = "aarch64")] mod sve_gather` containing:
  - a cached runtime feature check (`is_aarch64_feature_detected!("sve")`),
  - `gather_4byte` / `gather_8byte` inline-assembly kernels (Rust has no stable
    SVE intrinsics yet, hence `asm!`),
  - a `try_gather` entry point that returns `false` so callers fall back to the
    scalar path.
- In the bit-packed branch of `get_batch_with_dict`, the SVE gather is attempted
  at the existing `get_unchecked` site introduced in #9746. It **reuses #9746's
  hoisted max-reduction bounds check unchanged** — every index in the chunk is
  already proven in-bounds — so it adds no new per-element checks and no new
  unsoundness. If SVE is unavailable (or the type is unsuitable) it falls back to
  the same scalar loop.
- The SVE path is gated on `!needs_drop::<T>()` and element size 4/8, since the
  kernels copy raw element bytes; everything else (other widths, drop types,
  non-AArch64 targets) is unchanged and takes the existing scalar path.

No public API changes; the x86 / non-AArch64 code paths are untouched.

# Are these changes tested?

Correctness is covered by the existing dictionary-decode tests
(`test_rle_decode_with_dict_int32`, `test_rle_skip_dict`, `test_truncated_rle`,
`test_long_run`), which exercise the same `get_batch_with_dict` path; on
SVE-capable hardware these run through the SVE gather, and on all other targets
through the unchanged scalar path. The SVE gather is type-transparent (it
produces the same bytes as the scalar `clone_from`), reusing the bounds check
that #9746 already validates.

Build/lint verified for both targets:
- `x86_64`: existing `rle` tests pass; `cargo clippy ... -D warnings` clean.
- `aarch64-unknown-linux-gnu` (cross): compiles and `cargo clippy -D warnings`
  is clean, so the `asm!` blocks are checked by the compiler.

Performance: measured on Kunpeng 920B over TPC-H. Note that my original numbers
were taken against a pre-#9746 baseline, so they conflate #9746's
autovectorization with the SVE gather. I'm re-running the benchmark against
current `main` (post-#9746) to isolate the SVE-only contribution and will post
the apples-to-apples results here. <!-- TODO: paste re-baselined numbers -->

# Are there any user-facing changes?

No public API or behavior changes. On AArch64 CPUs that report SVE support at
runtime, dictionary decoding uses an SVE gather; on every other CPU/target the
behavior and code path are identical to before. No new feature flags and no MSRV
change (uses stable `is_aarch64_feature_detected!` and `asm!`).