### PR TITLE
ci: Split miri tests into 4 parallel shards

### DIFF
--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Script
 #
@@ -7,13 +7,40 @@
 
 set -e
 
-export MIRIFLAGS="-Zmiri-disable-isolation"
-cargo miri setup
-cargo clean
+setup_miri() {
+    export MIRIFLAGS="-Zmiri-disable-isolation"
+    cargo miri setup
+    cargo clean
+}
 
-echo "Starting Arrow MIRI run..."
-cargo miri nextest run \
-    -p arrow-buffer -p arrow-data \
-    -p arrow-schema -p arrow-ord \
-    -p arrow-array -p arrow-arith \
-    --features ffi --no-fail-fast
+
+case $# in 
+    0)
+        setup_miri
+
+        echo "Starting Arrow MIRI run..."
+        cargo miri nextest run \
+        -p arrow-buffer -p arrow-data \
+        -p arrow-schema -p arrow-ord \
+        -p arrow-array -p arrow-arith \
+        --features ffi --no-fail-fast
+    ;;
+    2)
+        setup_miri
+
+        partition=$1
+        total=$2
+
+        echo "Starting Arrow MIRI run partition ${partition} out of ${total}..."
+        cargo miri nextest run \
+        --partition slice:"${partition}"/"${total}" \
+        -p arrow-buffer -p arrow-data \
+        -p arrow-schema -p arrow-ord \
+        -p arrow-array -p arrow-arith \
+        --features ffi --no-fail-fast
+    ;;
+    *)
+        echo "usage: $0 [partition total]" >&2
+        exit 1
+    ;;
+esac

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -46,6 +46,9 @@ jobs:
   miri-checks:
     name: MIRI
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -62,4 +65,4 @@ jobs:
         env:
           RUST_BACKTRACE: full
           RUST_LOG: "trace"
-        run: bash .github/workflows/miri.sh
+        run: bash .github/workflows/miri.sh ${{ matrix.partition }} 4


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #NNN.

# Rationale for this change

Miri currently takes just under an hour to run, with most of it being the actual tests.

# What changes are included in this PR?

This PR modifies the script that runs miri to optionally use nextest's [partitioning](https://nexte.st/docs/ci-features/partitioning/) feature, and makes use of it in CI with 4 partitions. This should reduce the overall miri runtime to just over 15 minutes with a minimal increase in CI resource usage.

This is also scalable if the number of tests keeps increasing, changing the number of partitions is trivial, picking 4 here is an arbitrary choice.

# Are these changes tested?

Tested the script locally.

# Are there any user-facing changes?

No
