### PR TITLE
Bump max throughput in `flight` benchmark before blocking

### DIFF
--- a/arrow-flight/benches/common/mod.rs
+++ b/arrow-flight/benches/common/mod.rs
@@ -134,7 +134,7 @@ pub async fn start_server() -> (Channel, BenchServer) {
 
     let bench_server = BenchServer::default();
 
-    let (client, server) = tokio::io::duplex(1024 * 1024);
+    let (client, server) = tokio::io::duplex(64 * 1024 * 1024); // 64MB
 
     let mut client = Some(client);
     let channel = Endpoint::try_from(DUMMY_URL)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->
- Closes #10029.

# Rationale for this change
Increase the duplex buffer from 1 MB to 64 MB to eliminate artificial back-pressure in the roundtrip benchmarks.
See rational in this [comment](https://github.com/apache/arrow-rs/pull/10044#issuecomment-4623736500)
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
bumps `max_buf_size` to 64**MB**
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
n/a
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
n/a
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
