### PR TITLE
test(parquet): drop confusing `main` reference in page-roundtrip test comment

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -4906,10 +4906,10 @@ mod tests {
 
     #[test]
     fn test_arrow_writer_granular_mode_roundtrip() {
-        // Granular mode subdivides chunks and writes more pages than
-        // `main`. Make sure the data we write back is bit-identical to
-        // what went in — page-count assertions elsewhere only prove
-        // pages were cut, not that the encoded data is correct.
+        // Granular mode subdivides chunks and writes more pages than the
+        // default batched path. Make sure the data we write back is
+        // bit-identical to what went in — page-count assertions elsewhere
+        // only prove pages were cut, not that the encoded data is correct.
         //
         // Mix value sizes so that the cumulative-byte-budget cutoff
         // lands mid-chunk, exercising both batched and granular paths


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up to #9972.

# Rationale for this change

A test comment added in #9972 described granular mode as writing "more pages than `main`". As noted in [review feedback](https://github.com/apache/arrow-rs/pull/9972#discussion_r3357602241), comparing to `main` is confusing now that the PR has merged — that code *is* main. This rephrases the comment to compare against the default batched path instead, which the same comment already references.

# What changes are included in this PR?

- Reword one test comment in `test_arrow_writer_granular_mode_roundtrip`. No behavior change.

# Are there any user-facing changes?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)