### PR TITLE
Add test for `parquet-testing/bad_data/ARROW-GH-47662.parquet`

### DIFF
--- a/parquet/tests/arrow_reader/bad_data.rs
+++ b/parquet/tests/arrow_reader/bad_data.rs
@@ -33,6 +33,7 @@ static KNOWN_FILES: &[&str] = &[
     "ARROW-RS-GH-6229-DICTHEADER.parquet",
     "ARROW-RS-GH-6229-LEVELS.parquet",
     "ARROW-GH-45185.parquet",
+    "ARROW-GH-47662.parquet",
     "README.md",
 ];
 
@@ -129,6 +130,15 @@ fn test_arrow_rs_gh_45185_dict_levels() {
     assert_eq!(
         err.to_string(),
         "External: Parquet argument error: Parquet error: first repetition level of batch must be 0"
+    );
+}
+
+#[test]
+fn test_arrow_gh_47662() {
+    let err = read_file("ARROW-GH-47662.parquet").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "External: Parquet argument error: Parquet error: insufficient values read from column - expected: 100, got: 91"
     );
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Issue raised in #9110

# Rationale for this change
Add a "bad_data" test for newly added file in parquet-testing

# What changes are included in this PR?

Adds a new test so the `bad_data` unit test doesn't fail.

# Are these changes tested?

Yes

# Are there any user-facing changes?

No, only tests
