### PR TITLE
Implement From<i128> for i256

### DIFF
--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -130,6 +130,12 @@ impl From<i64> for i256 {
     }
 }
 
+impl From<i128> for i256 {
+    fn from(value: i128) -> Self {
+        Self::from_i128(value)
+    }
+}
+
 /// Parse `s` with any sign and leading 0s removed
 fn parse_impl(s: &str, negative: bool) -> Result<i256, ParseI256Error> {
     if s.len() <= 38 {


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10080.

# Rationale for this change

`From` is already implemented for all other signed integer primitives, ran into it working on decimal aggregations in DataFusion, which this will make much simpler.

# What changes are included in this PR?

Adds an additional trait implementation for i256. I've also considered deprecating `i256::from_i128` as a public function, but figured I'll see what reviewers think.

# Are these changes tested?

Just exposes an additional path for existing functionality.

# Are there any user-facing changes?

No
