### PR TITLE
Add `StructArray::field_` APIs symmetric to `StructArray::column_` ones

### DIFF
--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -175,11 +175,10 @@ impl MapArray {
 
     /// Returns a reference to the fields of the [`StructArray`] that backs this map.
     pub fn entries_fields(&self) -> (&Field, &Field) {
-        let fields = self.entries.fields().iter().collect::<Vec<_>>();
-        let fields = TryInto::<[&FieldRef; 2]>::try_into(fields)
-            .expect("Every map has a key and value field");
-
-        (fields[0].as_ref(), fields[1].as_ref())
+        (
+            self.entries.field(0).as_ref(),
+            self.entries.field(1).as_ref(),
+        )
     }
 
     /// Returns the data type of the map's keys.

--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -319,12 +319,26 @@ impl StructArray {
     ///
     /// Note: A schema can currently have duplicate field names, in which case
     /// the first field will always be selected.
-    /// This issue will be addressed in [ARROW-11178](https://issues.apache.org/jira/browse/ARROW-11178)
+    /// This issue will be addressed in [#9205](https://github.com/apache/arrow-rs/issues/9205)
     pub fn column_by_name(&self, column_name: &str) -> Option<&ArrayRef> {
         self.column_names()
             .iter()
             .position(|c| c == &column_name)
             .map(|pos| self.column(pos))
+    }
+
+    /// Returns the [`FieldRef`] at `pos`.
+    pub fn field(&self, pos: usize) -> &FieldRef {
+        &self.fields()[pos]
+    }
+
+    /// Return the [`FieldRef`] whose name equals to `field_name`
+    ///
+    /// Note: A schema can currently have duplicate field names, in which case
+    /// the first field will always be selected.
+    /// This issue will be addressed in [#9205](https://github.com/apache/arrow-rs/issues/9205)
+    pub fn field_by_name(&self, field_name: &str) -> Option<&FieldRef> {
+        self.fields().iter().find(|f| f.name() == field_name)
     }
 
     /// Returns a zero-copy slice of this array with the indicated offset and length.
@@ -754,6 +768,27 @@ mod tests {
         ]);
         assert_eq!(struct_array["b"].as_ref(), boolean.as_ref());
         assert_eq!(struct_array["c"].as_ref(), int.as_ref());
+    }
+
+    #[test]
+    fn test_struct_array_field_access() {
+        let boolean = Arc::new(BooleanArray::from(vec![false, false, true, true]));
+        let int = Arc::new(Int32Array::from(vec![42, 28, 19, 31]));
+
+        let b_field = Arc::new(Field::new("b", DataType::Boolean, false));
+        let c_field = Arc::new(Field::new("c", DataType::Int32, false));
+
+        let struct_array = StructArray::from(vec![
+            (b_field.clone(), boolean as ArrayRef),
+            (c_field.clone(), int as ArrayRef),
+        ]);
+
+        assert_eq!(struct_array.field(0), &b_field);
+        assert_eq!(struct_array.field(1), &c_field);
+
+        assert_eq!(struct_array.field_by_name("b"), Some(&b_field));
+        assert_eq!(struct_array.field_by_name("c"), Some(&c_field));
+        assert_eq!(struct_array.field_by_name("d"), None);
     }
 
     /// validates that the in-memory representation follows [the spec](https://arrow.apache.org/docs/format/Columnar.html#struct-layout)

--- a/arrow-array/src/array/struct_array.rs
+++ b/arrow-array/src/array/struct_array.rs
@@ -321,10 +321,9 @@ impl StructArray {
     /// the first field will always be selected.
     /// This issue will be addressed in [#9205](https://github.com/apache/arrow-rs/issues/9205)
     pub fn column_by_name(&self, column_name: &str) -> Option<&ArrayRef> {
-        self.column_names()
-            .iter()
-            .position(|c| c == &column_name)
-            .map(|pos| self.column(pos))
+        self.fields()
+            .find(column_name)
+            .map(|(pos, _)| self.column(pos))
     }
 
     /// Returns the [`FieldRef`] at `pos`.
@@ -338,7 +337,7 @@ impl StructArray {
     /// the first field will always be selected.
     /// This issue will be addressed in [#9205](https://github.com/apache/arrow-rs/issues/9205)
     pub fn field_by_name(&self, field_name: &str) -> Option<&FieldRef> {
-        self.fields().iter().find(|f| f.name() == field_name)
+        self.fields().find(field_name).map(|(_, field)| field)
     }
 
     /// Returns a zero-copy slice of this array with the indicated offset and length.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10092.

# Rationale for this change

check issue
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Add two `field_` APIs symmetric to `column_` ones.
- Reuse `Fields::find` in `column_by_name` to avoid a `Vec` alloc.
- Fix doc pointing to an old Jira issue. Now points to #9205
- `MapArray::entries_fields` avoid a `Vec` alloc.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

- Yes, unit tests

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

New `StructArray` APIs.