### PR TITLE
feat(arrow_array): add helper function to create MapArray from `Vec<Option<Vec<(Key, Option<Value>)>>>` for tests

### DIFF
--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::array::{get_offsets_from_buffer, print_long_array};
+use crate::builder::MapFieldNames;
 use crate::iterator::MapArrayIter;
 use crate::{Array, ArrayAccessor, ArrayRef, ListArray, StringArray, StructArray, make_array};
 use arrow_buffer::{ArrowNativeType, Buffer, NullBuffer, OffsetBuffer, ToByteSlice};
@@ -435,11 +436,13 @@ impl MapArray {
         let keys_array: ArrayRef = Arc::new(<Vec<K> as Into<KeyArray>>::into(keys));
         let values_array: ArrayRef = Arc::new(<Vec<Option<V>> as Into<ValueArray>>::into(values));
 
+        let field_names = MapFieldNames::default();
+
         let entries = StructArray::new(
             Fields::from(vec![
-                Field::new("keys", keys_array.data_type().clone(), false),
+                Field::new(field_names.key, keys_array.data_type().clone(), false),
                 Field::new(
-                    "values",
+                    field_names.value,
                     values_array.data_type().clone(),
                     values_array.is_nullable(),
                 ),
@@ -449,7 +452,11 @@ impl MapArray {
         );
 
         MapArray::new(
-            Arc::new(Field::new("entries", entries.data_type().clone(), false)),
+            Arc::new(Field::new(
+                field_names.entry,
+                entries.data_type().clone(),
+                false,
+            )),
             offsets,
             entries,
             nulls,

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -22,7 +22,6 @@ use arrow_buffer::{ArrowNativeType, Buffer, NullBuffer, OffsetBuffer, ToByteSlic
 use arrow_data::{ArrayData, ArrayDataBuilder};
 use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields};
 use std::any::Any;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// An array of key-value maps
@@ -362,7 +361,7 @@ impl MapArray {
         Ok(MapArray::from(map_data))
     }
 
-    /// Helper to create [`MapArray`] from [`HashMap`]s so the code will look clean and straightforward
+    /// Helper to create [`MapArray`] from [`Vec`]s of entries so the code will look clean and straightforward
     ///
     /// Useful for tests, this should not be used for performance sensitive operations
     ///
@@ -371,28 +370,28 @@ impl MapArray {
     /// # use arrow_array::{MapArray, Int32Array, StringArray};
     ///
     /// let map = vec![
-    ///    Some(HashMap::new()),
+    ///    Some(vec![]),
     ///    None,
-    ///    Some(HashMap::from([
+    ///    Some(vec![
     ///        ("a", Some(1)),
     ///        ("b", None),
     ///        ("cd", Some(4)),
-    ///    ])),
-    ///    Some(HashMap::from([("e", Some(0))])),
+    ///    ]),
+    ///    Some(vec![("e", Some(0))]),
     /// ];
     ///
     /// let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(map);
     /// // Or you could fill the last 2 generics manually for the key array item and value array item
     /// // let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, &str, i32>(map);
     ///```
+    #[allow(clippy::type_complexity)]
     pub fn from_vec_of_maps<KeyArray, ValueArray, K, V>(
-        input: Vec<Option<HashMap<K, Option<V>>>>,
+        input: Vec<Option<Vec<(K, Option<V>)>>>,
+        ordered: bool,
     ) -> Self
     where
         KeyArray: Array + 'static,
         ValueArray: Array + 'static,
-        K: Clone,
-        V: Clone,
         Vec<K>: Into<KeyArray>,
         Vec<Option<V>>: Into<ValueArray>,
     {
@@ -402,18 +401,11 @@ impl MapArray {
         let nulls = NullBuffer::from_iter(input.iter().map(|v| v.is_some()));
         let nulls = Some(nulls).filter(|b| b.null_count() > 0);
 
-        let keys = input
-            .iter()
+        let (keys, values): (Vec<K>, Vec<Option<V>>) = input
+            .into_iter()
             .flatten()
-            .flat_map(|m| m.keys())
-            .cloned()
-            .collect::<Vec<K>>();
-        let values = input
-            .iter()
-            .flatten()
-            .flat_map(|m| m.values())
-            .cloned()
-            .collect::<Vec<Option<V>>>();
+            .flat_map(|m| m.into_iter())
+            .unzip();
 
         let keys_array: ArrayRef = Arc::new(<Vec<K> as Into<KeyArray>>::into(keys));
         let values_array: ArrayRef = Arc::new(<Vec<Option<V>> as Into<ValueArray>>::into(values));
@@ -436,7 +428,7 @@ impl MapArray {
             offsets,
             entries,
             nulls,
-            false,
+            ordered,
         )
     }
 }
@@ -560,7 +552,7 @@ impl From<MapArray> for ListArray {
 mod tests {
     use crate::builder::{Int32Builder, MapBuilder, StringBuilder};
     use crate::cast::AsArray;
-    use crate::types::{Int32Type, UInt32Type};
+    use crate::types::UInt32Type;
     use crate::{Int32Array, UInt32Array};
     use arrow_schema::Fields;
 
@@ -922,62 +914,38 @@ mod tests {
     }
 
     #[test]
-    fn test_from_vec_of_hash_maps() {
-        let map = vec![
-            Some(HashMap::new()),
-            None,
-            Some(HashMap::from([
-                ("a", Some(1)),
-                ("b", None),
-                ("cd", Some(4)),
-            ])),
-            Some(HashMap::from([("e", Some(0))])),
-        ];
+    fn test_from_vec_of_maps() {
+        for ordered in [true, false] {
+            let map = vec![
+                Some(vec![]),
+                None,
+                Some(vec![("a", Some(1)), ("b", None), ("cd", Some(4))]),
+                Some(vec![("e", Some(0))]),
+            ];
 
-        let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(map);
-        assert_eq!(map_array.len(), 4);
+            let map_array =
+                MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(map, ordered);
+            assert_eq!(map_array.len(), 4);
 
-        // Because getting the entries from `HashMap` is not deterministic, we build every possible order
-        fn build_expected_map(
-            order_of_3_items: &[&str],
-            expected_values: &HashMap<&str, Option<i32>>,
-        ) -> MapArray {
             let mut builder = MapBuilder::new(None, StringBuilder::new(), Int32Builder::default());
             builder.append(true).unwrap();
             builder.append_nulls(1).unwrap();
-            order_of_3_items.iter().for_each(|key| {
-                builder.keys().append_value(*key);
-                builder
-                    .values()
-                    .append_option(*expected_values.get(*key).unwrap());
-            });
+            builder.keys().append_value("a");
+            builder.values().append_value(1);
+            builder.keys().append_value("b");
+            builder.values().append_null();
+            builder.keys().append_value("cd");
+            builder.values().append_value(4);
             builder.append(true).unwrap();
-
             builder.keys().append_value("e");
             builder.values().append_value(0);
             builder.append(true).unwrap();
 
-            builder.finish()
+            let (field, offsets, entries, null_buffer, _) = builder.finish().into_parts();
+
+            let expected_map = MapArray::new(field, offsets, entries, null_buffer, ordered);
+
+            assert_eq!(map_array, expected_map);
         }
-
-        let ref_map = HashMap::from([("a", Some(1)), ("b", None), ("cd", Some(4))]);
-
-        let possibilities = vec![
-            ["a", "b", "cd"],
-            ["a", "cd", "b"],
-            ["b", "a", "cd"],
-            ["b", "cd", "a"],
-            ["cd", "a", "b"],
-            ["cd", "b", "a"],
-        ];
-
-        let possible_maps = possibilities
-            .iter()
-            .map(|item| build_expected_map(item, &ref_map))
-            .collect::<Vec<_>>();
-
-        let found_map = possible_maps.iter().any(|expected| expected == &map_array);
-
-        assert!(found_map);
     }
 }

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -270,6 +270,8 @@ impl From<MapArray> for ArrayData {
     }
 }
 
+type Entries<Key, Value> = Vec<(Key, Value)>;
+
 impl MapArray {
     fn try_new_from_array_data(data: ArrayData) -> Result<Self, ArrowError> {
         let (data_type, len, nulls, offset, mut buffers, mut child_data) = data.into_parts();
@@ -363,6 +365,24 @@ impl MapArray {
 
     /// Helper to create [`MapArray`] from [`Vec`]s of entries so the code will look clean and straightforward
     ///
+    /// the input is:
+    /// ```no_run
+    /// // Maps
+    /// Vec<
+    ///   // Map
+    ///   Option<
+    ///     // Entries
+    ///     Vec<
+    ///       // Entry
+    ///       (
+    ///         Key,
+    ///         Option<Value>
+    ///       )
+    ///     >
+    ///   >
+    /// >
+    /// ```
+    ///
     /// Useful for tests, this should not be used for performance sensitive operations
     ///
     /// ```
@@ -370,23 +390,28 @@ impl MapArray {
     /// # use arrow_array::{MapArray, Int32Array, StringArray};
     ///
     /// let map = vec![
+    ///    // {}
     ///    Some(vec![]),
+    ///    // null
     ///    None,
+    ///    // { "a": 1, "b": null, "cd": 4 }
     ///    Some(vec![
     ///        ("a", Some(1)),
     ///        ("b", None),
     ///        ("cd", Some(4)),
     ///    ]),
+    ///    // { "e": 0 }
     ///    Some(vec![("e", Some(0))]),
     /// ];
     ///
+    /// // created map: [{}, null, {"a": 1, "b": null, "cd": 4}, {"e": 0}]
     /// let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(map);
     /// // Or you could fill the last 2 generics manually for the key array item and value array item
     /// // let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, &str, i32>(map);
     ///```
     #[allow(clippy::type_complexity)]
     pub fn from_vec_of_maps<KeyArray, ValueArray, K, V>(
-        input: Vec<Option<Vec<(K, Option<V>)>>>,
+        input: Vec<Option<Entries<K, Option<V>>>>,
         ordered: bool,
     ) -> Self
     where

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -32,7 +32,9 @@ use std::sync::Arc;
 /// [`MapArray`] is physically a [`ListArray`] of key values pairs stored as an `entries`
 /// [`StructArray`] with 2 child fields.
 ///
-/// See [`MapBuilder`](crate::builder::MapBuilder) for how to construct a [`MapArray`]
+/// # See also
+/// * [`MapBuilder`](crate::builder::MapBuilder) for how to construct a [`MapArray`]
+/// * [`Self::from_vec_of_maps`] for ergonomically creating maps for testing
 #[derive(Clone)]
 pub struct MapArray {
     data_type: DataType,

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -20,8 +20,9 @@ use crate::iterator::MapArrayIter;
 use crate::{Array, ArrayAccessor, ArrayRef, ListArray, StringArray, StructArray, make_array};
 use arrow_buffer::{ArrowNativeType, Buffer, NullBuffer, OffsetBuffer, ToByteSlice};
 use arrow_data::{ArrayData, ArrayDataBuilder};
-use arrow_schema::{ArrowError, DataType, Field, FieldRef};
+use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields};
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 /// An array of key-value maps
@@ -270,6 +271,7 @@ impl From<MapArray> for ArrayData {
     }
 }
 
+
 impl MapArray {
     fn try_new_from_array_data(data: ArrayData) -> Result<Self, ArrowError> {
         let (data_type, len, nulls, offset, mut buffers, mut child_data) = data.into_parts();
@@ -360,6 +362,61 @@ impl MapArray {
 
         Ok(MapArray::from(map_data))
     }
+
+
+    fn from_vec_of_maps<KeyArray, ValueArray>(input: Vec<Option<HashMap<for <'a> <&'a KeyArray as ArrayAccessor>::Item, Option<for <'a> <&'a ValueArray as ArrayAccessor>::Item>>>>) -> Self
+    where KeyArray: Array + 'static,
+
+      for <'a> &'a KeyArray: ArrayAccessor + 'static,
+          for <'a> <&'a KeyArray as ArrayAccessor>::Item: Clone,
+          for <'a> Vec<<&'a KeyArray as ArrayAccessor>::Item>: Into<KeyArray>,
+          
+          for <'a> &'a ValueArray: ArrayAccessor,
+              for <'a> <&'a ValueArray as ArrayAccessor>::Item: Clone,
+              for <'a> Vec<Option<<&'a ValueArray as ArrayAccessor>::Item>>: Into<ValueArray>,
+    {
+            let offsets = OffsetBuffer::<i32>::from_lengths(
+                input.iter().map(|v| v.as_ref().map_or(0, |m| m.len())),
+            );
+            let nulls = NullBuffer::from_iter(input.iter().map(|v| v.is_some()));
+            let nulls = Some(nulls).filter(|b| b.null_count() > 0);
+            let keys = input
+              .iter()
+              .flatten()
+              .flat_map(|v| v.keys())
+              .cloned()
+              .collect::<Vec<KeyArray::Item>>();
+            let values = input
+              .iter()
+              .flatten()
+              .flat_map(|v| v.values())
+              .cloned()
+              .collect::<Vec<Option<ValueArray::Item>>>();
+
+            let keys_array = Arc::new(KeyArray::from(keys));
+            let values_array = Arc::new(ValueArray::from(values));
+
+            let entries = StructArray::new(
+                Fields::from(vec![
+                    Field::new("keys", keys_array.data_type().clone(), false),
+                    Field::new(
+                        "values",
+                        values_array.data_type().clone(),
+                        values_array.is_nullable(),
+                    ),
+                ]),
+                vec![keys_array, values_array],
+                None,
+            );
+
+            MapArray::new(
+                Arc::new(Field::new("entries", entries.data_type().clone(), false)),
+                offsets,
+                entries,
+                nulls,
+                false,
+            )
+        }
 }
 
 /// SAFETY: Correctly implements the contract of Arrow Arrays
@@ -480,7 +537,7 @@ impl From<MapArray> for ListArray {
 #[cfg(test)]
 mod tests {
     use crate::cast::AsArray;
-    use crate::types::UInt32Type;
+    use crate::types::{Int32Type, UInt32Type};
     use crate::{Int32Array, UInt32Array};
     use arrow_schema::Fields;
 
@@ -839,5 +896,34 @@ mod tests {
             err.to_string(),
             "Invalid argument error: MapArray entries must contain two children, got 3"
         );
+    }
+
+    #[test]
+    fn test_from_vec_of_hash_maps() {
+        let map = vec![
+            Some(HashMap::new()),
+            None,
+            Some(HashMap::from([
+                ("a", Some(1)),
+                ("b", None),
+                ("cd", Some(4)),
+            ])),
+            Some(HashMap::from([("e", Some(0))])),
+        ];
+
+        let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array>(map);
+        assert_eq!(map_array.len(), 4);
+
+        assert_eq!(map_array.null_count(), 1);
+        assert_eq!(map_array.offsets().lengths().collect::<Vec<_>>(), vec![0, 0, 3, 1]);
+
+        let keys = map_array.keys().as_string::<i32>();
+        assert_eq!(keys.null_count(), 0);
+        assert_eq!(keys.iter().flatten().collect::<Vec<_>>(), vec!["a", "b", "cd", "e"]);
+
+        let values = map_array.values().as_primitive::<Int32Type>();
+        assert_eq!(values.iter().collect::<Vec<_>>(), vec![Some(1), None, Some(4), Some(0)]);
+
+
     }
 }

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -960,17 +960,23 @@ mod tests {
             assert_eq!(map_array.len(), 4);
 
             let mut builder = MapBuilder::new(None, StringBuilder::new(), Int32Builder::default());
+
+            // {}
             builder.append(true).unwrap();
+
+            // null
             builder.append_nulls(1).unwrap();
-            builder.keys().append_value("a");
-            builder.values().append_value(1);
-            builder.keys().append_value("b");
-            builder.values().append_null();
-            builder.keys().append_value("cd");
-            builder.values().append_value(4);
+
+            // {"a": 1, "b": null, "cd": 4}
+            builder.keys().extend(["a", "b", "cd"].map(Some));
+            builder.values().extend([Some(1), None, Some(4)]);
+
             builder.append(true).unwrap();
+
+            // {"e": 0}
             builder.keys().append_value("e");
             builder.values().append_value(0);
+
             builder.append(true).unwrap();
 
             let (field, offsets, entries, null_buffer, _) = builder.finish().into_parts();

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -404,11 +404,12 @@ impl MapArray {
     ///    // { "e": 0 }
     ///    Some(vec![("e", Some(0))]),
     /// ];
+    /// let ordered = true;
     ///
     /// // created map: [{}, null, {"a": 1, "b": null, "cd": 4}, {"e": 0}]
-    /// let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(map);
+    /// let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(map, ordered);
     /// // Or you could fill the last 2 generics manually for the key array item and value array item
-    /// // let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, &str, i32>(map);
+    /// // let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, &str, i32>(map, ordered);
     ///```
     #[allow(clippy::type_complexity)]
     pub fn from_vec_of_maps<KeyArray, ValueArray, K, V>(

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -271,7 +271,6 @@ impl From<MapArray> for ArrayData {
     }
 }
 
-
 impl MapArray {
     fn try_new_from_array_data(data: ArrayData) -> Result<Self, ArrowError> {
         let (data_type, len, nulls, offset, mut buffers, mut child_data) = data.into_parts();
@@ -363,60 +362,83 @@ impl MapArray {
         Ok(MapArray::from(map_data))
     }
 
-
-    fn from_vec_of_maps<KeyArray, ValueArray>(input: Vec<Option<HashMap<for <'a> <&'a KeyArray as ArrayAccessor>::Item, Option<for <'a> <&'a ValueArray as ArrayAccessor>::Item>>>>) -> Self
-    where KeyArray: Array + 'static,
-
-      for <'a> &'a KeyArray: ArrayAccessor + 'static,
-          for <'a> <&'a KeyArray as ArrayAccessor>::Item: Clone,
-          for <'a> Vec<<&'a KeyArray as ArrayAccessor>::Item>: Into<KeyArray>,
-          
-          for <'a> &'a ValueArray: ArrayAccessor,
-              for <'a> <&'a ValueArray as ArrayAccessor>::Item: Clone,
-              for <'a> Vec<Option<<&'a ValueArray as ArrayAccessor>::Item>>: Into<ValueArray>,
+    /// Helper to create [`MapArray`] from [`HashMap`]s so the code will look clean and straightforward
+    ///
+    /// Useful for tests, this should not be used for performance sensitive operations
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// # use arrow_array::{MapArray, Int32Array, StringArray};
+    ///
+    /// let map = vec![
+    ///    Some(HashMap::new()),
+    ///    None,
+    ///    Some(HashMap::from([
+    ///        ("a", Some(1)),
+    ///        ("b", None),
+    ///        ("cd", Some(4)),
+    ///    ])),
+    ///    Some(HashMap::from([("e", Some(0))])),
+    /// ];
+    ///
+    /// let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(map);
+    /// // Or you could fill the last 2 generics manually for the key array item and value array item
+    /// // let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, &str, i32>(map);
+    ///```
+    pub fn from_vec_of_maps<KeyArray, ValueArray, K, V>(
+        input: Vec<Option<HashMap<K, Option<V>>>>,
+    ) -> Self
+    where
+        KeyArray: Array + 'static,
+        ValueArray: Array + 'static,
+        K: Clone,
+        V: Clone,
+        Vec<K>: Into<KeyArray>,
+        Vec<Option<V>>: Into<ValueArray>,
     {
-            let offsets = OffsetBuffer::<i32>::from_lengths(
-                input.iter().map(|v| v.as_ref().map_or(0, |m| m.len())),
-            );
-            let nulls = NullBuffer::from_iter(input.iter().map(|v| v.is_some()));
-            let nulls = Some(nulls).filter(|b| b.null_count() > 0);
-            let keys = input
-              .iter()
-              .flatten()
-              .flat_map(|v| v.keys())
-              .cloned()
-              .collect::<Vec<KeyArray::Item>>();
-            let values = input
-              .iter()
-              .flatten()
-              .flat_map(|v| v.values())
-              .cloned()
-              .collect::<Vec<Option<ValueArray::Item>>>();
+        let offsets = OffsetBuffer::<i32>::from_lengths(
+            input.iter().map(|v| v.as_ref().map_or(0, |m| m.len())),
+        );
+        let nulls = NullBuffer::from_iter(input.iter().map(|v| v.is_some()));
+        let nulls = Some(nulls).filter(|b| b.null_count() > 0);
 
-            let keys_array = Arc::new(KeyArray::from(keys));
-            let values_array = Arc::new(ValueArray::from(values));
+        let keys = input
+            .iter()
+            .flatten()
+            .flat_map(|m| m.keys())
+            .cloned()
+            .collect::<Vec<K>>();
+        let values = input
+            .iter()
+            .flatten()
+            .flat_map(|m| m.values())
+            .cloned()
+            .collect::<Vec<Option<V>>>();
 
-            let entries = StructArray::new(
-                Fields::from(vec![
-                    Field::new("keys", keys_array.data_type().clone(), false),
-                    Field::new(
-                        "values",
-                        values_array.data_type().clone(),
-                        values_array.is_nullable(),
-                    ),
-                ]),
-                vec![keys_array, values_array],
-                None,
-            );
+        let keys_array: ArrayRef = Arc::new(<Vec<K> as Into<KeyArray>>::into(keys));
+        let values_array: ArrayRef = Arc::new(<Vec<Option<V>> as Into<ValueArray>>::into(values));
 
-            MapArray::new(
-                Arc::new(Field::new("entries", entries.data_type().clone(), false)),
-                offsets,
-                entries,
-                nulls,
-                false,
-            )
-        }
+        let entries = StructArray::new(
+            Fields::from(vec![
+                Field::new("keys", keys_array.data_type().clone(), false),
+                Field::new(
+                    "values",
+                    values_array.data_type().clone(),
+                    values_array.is_nullable(),
+                ),
+            ]),
+            vec![keys_array, values_array],
+            None,
+        );
+
+        MapArray::new(
+            Arc::new(Field::new("entries", entries.data_type().clone(), false)),
+            offsets,
+            entries,
+            nulls,
+            false,
+        )
+    }
 }
 
 /// SAFETY: Correctly implements the contract of Arrow Arrays
@@ -536,6 +558,7 @@ impl From<MapArray> for ListArray {
 
 #[cfg(test)]
 mod tests {
+    use crate::builder::{Int32Builder, MapBuilder, StringBuilder};
     use crate::cast::AsArray;
     use crate::types::{Int32Type, UInt32Type};
     use crate::{Int32Array, UInt32Array};
@@ -911,19 +934,50 @@ mod tests {
             Some(HashMap::from([("e", Some(0))])),
         ];
 
-        let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array>(map);
+        let map_array = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(map);
         assert_eq!(map_array.len(), 4);
 
-        assert_eq!(map_array.null_count(), 1);
-        assert_eq!(map_array.offsets().lengths().collect::<Vec<_>>(), vec![0, 0, 3, 1]);
+        // Because getting the entries from `HashMap` is not deterministic, we build every possible order
+        fn build_expected_map(
+            order_of_3_items: &[&str],
+            expected_values: &HashMap<&str, Option<i32>>,
+        ) -> MapArray {
+            let mut builder = MapBuilder::new(None, StringBuilder::new(), Int32Builder::default());
+            builder.append(true).unwrap();
+            builder.append_nulls(1).unwrap();
+            order_of_3_items.iter().for_each(|key| {
+                builder.keys().append_value(*key);
+                builder
+                    .values()
+                    .append_option(*expected_values.get(*key).unwrap());
+            });
+            builder.append(true).unwrap();
 
-        let keys = map_array.keys().as_string::<i32>();
-        assert_eq!(keys.null_count(), 0);
-        assert_eq!(keys.iter().flatten().collect::<Vec<_>>(), vec!["a", "b", "cd", "e"]);
+            builder.keys().append_value("e");
+            builder.values().append_value(0);
+            builder.append(true).unwrap();
 
-        let values = map_array.values().as_primitive::<Int32Type>();
-        assert_eq!(values.iter().collect::<Vec<_>>(), vec![Some(1), None, Some(4), Some(0)]);
+            builder.finish()
+        }
 
+        let ref_map = HashMap::from([("a", Some(1)), ("b", None), ("cd", Some(4))]);
 
+        let possibilities = vec![
+            ["a", "b", "cd"],
+            ["a", "cd", "b"],
+            ["b", "a", "cd"],
+            ["b", "cd", "a"],
+            ["cd", "a", "b"],
+            ["cd", "b", "a"],
+        ];
+
+        let possible_maps = possibilities
+            .iter()
+            .map(|item| build_expected_map(item, &ref_map))
+            .collect::<Vec<_>>();
+
+        let found_map = possible_maps.iter().any(|expected| expected == &map_array);
+
+        assert!(found_map);
     }
 }

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -366,23 +366,7 @@ impl MapArray {
 
     /// Helper to create [`MapArray`] from [`Vec`]s of entries so the code will look clean and straightforward
     ///
-    /// the input is:
-    /// ```no_run
-    /// // Maps
-    /// Vec<
-    ///   // Map
-    ///   Option<
-    ///     // Entries
-    ///     Vec<
-    ///       // Entry
-    ///       (
-    ///         Key,
-    ///         Option<Value>
-    ///       )
-    ///     >
-    ///   >
-    /// >
-    /// ```
+    /// the input is: `Vec<Option<Map>>` where each `Map` is `Vec<(Key, Option<Value>)>`
     ///
     /// Useful for tests, this should not be used for performance sensitive operations
     ///

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -10025,13 +10025,27 @@ mod tests {
 
     #[test]
     fn test_cast_map_dont_allow_change_of_order() {
-        let array = MapArray::from_vec_of_maps::<StringArray, StringArray, _, _>(
-            vec![
-                Some(vec![("0", Some("test_val_1"))]),
-                Some(vec![("1", Some("test_val_2"))]),
-            ],
-            false,
+        let string_builder = StringBuilder::new();
+        let value_builder = StringBuilder::new();
+        let mut builder = MapBuilder::new(
+            Some(MapFieldNames {
+                entry: "entries".to_string(),
+                key: "key".to_string(),
+                value: "value".to_string(),
+            }),
+            string_builder,
+            value_builder,
         );
+
+        builder.keys().append_value("0");
+        builder.values().append_value("test_val_1");
+        builder.append(true).unwrap();
+        builder.keys().append_value("1");
+        builder.values().append_value("test_val_2");
+        builder.append(true).unwrap();
+
+        // map builder returns unsorted map by default
+        let array = builder.finish();
 
         let new_ordered = true;
         let new_type = DataType::Map(
@@ -10187,10 +10201,26 @@ mod tests {
 
     #[test]
     fn test_cast_map_contained_values() {
-        let array = MapArray::from_vec_of_maps::<StringArray, Int8Array, _, _>(
-            vec![Some(vec![("0", Some(44))]), Some(vec![("1", Some(22))])],
-            false,
+        let string_builder = StringBuilder::new();
+        let value_builder = Int8Builder::new();
+        let mut builder = MapBuilder::new(
+            Some(MapFieldNames {
+                entry: "entries".to_string(),
+                key: "key".to_string(),
+                value: "value".to_string(),
+            }),
+            string_builder,
+            value_builder,
         );
+
+        builder.keys().append_value("0");
+        builder.values().append_value(44);
+        builder.append(true).unwrap();
+        builder.keys().append_value("1");
+        builder.values().append_value(22);
+        builder.append(true).unwrap();
+
+        let array = builder.finish();
 
         let new_type = DataType::Map(
             Arc::new(Field::new(
@@ -10208,13 +10238,31 @@ mod tests {
         );
 
         let new_array = cast(&array, &new_type.clone()).unwrap();
+        assert_eq!(new_type, new_array.data_type().clone());
+        let map_array = new_array.as_map();
 
-        let expected_map = MapArray::from_vec_of_maps::<StringArray, StringArray, _, _>(
-            vec![Some(vec![("0", Some("44"))]), Some(vec![("1", Some("22"))])],
-            false,
-        );
+        assert_ne!(new_type, array.data_type().clone());
+        assert_eq!(new_type, map_array.data_type().clone());
 
-        assert_eq!(new_array.as_map(), &expected_map);
+        let key_string = map_array
+            .keys()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        assert_eq!(&key_string, &vec!["0", "1"]);
+
+        let values_string_array = cast(map_array.values(), &DataType::Utf8).unwrap();
+        let values_string = values_string_array
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        assert_eq!(&values_string, &vec!["44", "22"]);
     }
 
     #[test]

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -10025,27 +10025,13 @@ mod tests {
 
     #[test]
     fn test_cast_map_dont_allow_change_of_order() {
-        let string_builder = StringBuilder::new();
-        let value_builder = StringBuilder::new();
-        let mut builder = MapBuilder::new(
-            Some(MapFieldNames {
-                entry: "entries".to_string(),
-                key: "key".to_string(),
-                value: "value".to_string(),
-            }),
-            string_builder,
-            value_builder,
+        let array = MapArray::from_vec_of_maps::<StringArray, StringArray, _, _>(
+            vec![
+                Some(vec![("0", Some("test_val_1"))]),
+                Some(vec![("1", Some("test_val_2"))]),
+            ],
+            false,
         );
-
-        builder.keys().append_value("0");
-        builder.values().append_value("test_val_1");
-        builder.append(true).unwrap();
-        builder.keys().append_value("1");
-        builder.values().append_value("test_val_2");
-        builder.append(true).unwrap();
-
-        // map builder returns unsorted map by default
-        let array = builder.finish();
 
         let new_ordered = true;
         let new_type = DataType::Map(
@@ -10201,26 +10187,10 @@ mod tests {
 
     #[test]
     fn test_cast_map_contained_values() {
-        let string_builder = StringBuilder::new();
-        let value_builder = Int8Builder::new();
-        let mut builder = MapBuilder::new(
-            Some(MapFieldNames {
-                entry: "entries".to_string(),
-                key: "key".to_string(),
-                value: "value".to_string(),
-            }),
-            string_builder,
-            value_builder,
+        let array = MapArray::from_vec_of_maps::<StringArray, Int8Array, _, _>(
+            vec![Some(vec![("0", Some(44))]), Some(vec![("1", Some(22))])],
+            false,
         );
-
-        builder.keys().append_value("0");
-        builder.values().append_value(44);
-        builder.append(true).unwrap();
-        builder.keys().append_value("1");
-        builder.values().append_value(22);
-        builder.append(true).unwrap();
-
-        let array = builder.finish();
 
         let new_type = DataType::Map(
             Arc::new(Field::new(
@@ -10238,31 +10208,13 @@ mod tests {
         );
 
         let new_array = cast(&array, &new_type.clone()).unwrap();
-        assert_eq!(new_type, new_array.data_type().clone());
-        let map_array = new_array.as_map();
 
-        assert_ne!(new_type, array.data_type().clone());
-        assert_eq!(new_type, map_array.data_type().clone());
+        let expected_map = MapArray::from_vec_of_maps::<StringArray, StringArray, _, _>(
+            vec![Some(vec![("0", Some("44"))]), Some(vec![("1", Some("22"))])],
+            false,
+        );
 
-        let key_string = map_array
-            .keys()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap()
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        assert_eq!(&key_string, &vec!["0", "1"]);
-
-        let values_string_array = cast(map_array.values(), &DataType::Utf8).unwrap();
-        let values_string = values_string_array
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap()
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        assert_eq!(&values_string, &vec!["44", "22"]);
+        assert_eq!(new_array.as_map(), &expected_map);
     }
 
     #[test]

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -795,7 +795,7 @@ mod tests {
     use arrow_cast::pretty::pretty_format_batches;
     use arrow_ipc::MetadataVersion;
     use arrow_schema::{UnionFields, UnionMode};
-    use builder::{GenericStringBuilder, MapBuilder};
+    use builder::MapBuilder;
     use std::collections::HashMap;
 
     use super::*;
@@ -1505,34 +1505,24 @@ mod tests {
 
         let expected_schema = Arc::new(expected_schema);
 
-        // Builder without dictionary fields
-        let mut builder = MapBuilder::new(
-            None,
-            GenericStringBuilder::<i32>::new(),
-            GenericStringBuilder::<i32>::new(),
+        // array without dictionary fields
+        let arr1 = MapArray::from_vec_of_maps::<StringArray, StringArray, _, _>(
+            vec![Some(vec![
+                ("k1", Some("a")),
+                ("k2", None),
+                ("k3", Some("b")),
+            ])],
+            false,
         );
 
-        // {"k1":"a","k2":null,"k3":"b"}
-        builder.keys().append_value("k1");
-        builder.values().append_value("a");
-        builder.keys().append_value("k2");
-        builder.values().append_null();
-        builder.keys().append_value("k3");
-        builder.values().append_value("b");
-        builder.append(true).unwrap();
-
-        let arr1 = builder.finish();
-
-        // {"k1":"c","k2":null,"k3":"d"}
-        builder.keys().append_value("k1");
-        builder.values().append_value("c");
-        builder.keys().append_value("k2");
-        builder.values().append_null();
-        builder.keys().append_value("k3");
-        builder.values().append_value("d");
-        builder.append(true).unwrap();
-
-        let arr2 = builder.finish();
+        let arr2 = MapArray::from_vec_of_maps::<StringArray, StringArray, _, _>(
+            vec![Some(vec![
+                ("k1", Some("c")),
+                ("k2", None),
+                ("k3", Some("d")),
+            ])],
+            false,
+        );
 
         let mut expected_arrays = vec![arr1, arr2].into_iter();
 

--- a/arrow-ord/src/ord.rs
+++ b/arrow-ord/src/ord.rs
@@ -568,7 +568,7 @@ pub fn make_comparator(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::builder::{Int32Builder, ListBuilder, MapBuilder, StringBuilder};
+    use arrow_array::builder::{Int32Builder, ListBuilder};
     use arrow_buffer::{IntervalDayTime, NullBuffer, OffsetBuffer, ScalarBuffer, i256};
     use arrow_schema::{DataType, Field, Fields, UnionFields};
     use half::f16;
@@ -1262,64 +1262,31 @@ mod tests {
     #[test]
     fn test_map() {
         // Create first map array demonstrating key priority over values:
-        // [{"a": 100, "b": 1}, {"b": 999, "c": 1}, {}, {"x": 1}]
-        let string_builder = StringBuilder::new();
-        let int_builder = Int32Builder::new();
-        let mut map1_builder = MapBuilder::new(None, string_builder, int_builder);
-
-        // {"a": 100, "b": 1} - high value for "a", low value for "b"
-        map1_builder.keys().append_value("a");
-        map1_builder.values().append_value(100);
-        map1_builder.keys().append_value("b");
-        map1_builder.values().append_value(1);
-        map1_builder.append(true).unwrap();
-
-        // {"b": 999, "c": 1} - very high value for "b", low value for "c"
-        map1_builder.keys().append_value("b");
-        map1_builder.values().append_value(999);
-        map1_builder.keys().append_value("c");
-        map1_builder.values().append_value(1);
-        map1_builder.append(true).unwrap();
-
-        // {}
-        map1_builder.append(true).unwrap();
-
-        // {"x": 1}
-        map1_builder.keys().append_value("x");
-        map1_builder.values().append_value(1);
-        map1_builder.append(true).unwrap();
-
-        let map1 = map1_builder.finish();
+        let map1 = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(
+            vec![
+                // high value for "a", low value for "b"
+                Some(vec![("a", Some(100)), ("b", Some(1))]),
+                // very high value for "b", low value for "c"
+                Some(vec![("b", Some(999)), ("c", Some(1))]),
+                Some(vec![]),
+                Some(vec![("x", Some(1))]),
+            ],
+            false,
+        );
 
         // Create second map array:
         // [{"a": 1, "c": 999}, {"b": 1, "d": 999}, {"a": 1}, None]
-        let string_builder = StringBuilder::new();
-        let int_builder = Int32Builder::new();
-        let mut map2_builder = MapBuilder::new(None, string_builder, int_builder);
-
-        // {"a": 1, "c": 999} - low value for "a", high value for "c"
-        map2_builder.keys().append_value("a");
-        map2_builder.values().append_value(1);
-        map2_builder.keys().append_value("c");
-        map2_builder.values().append_value(999);
-        map2_builder.append(true).unwrap();
-
-        // {"b": 1, "d": 999} - low value for "b", high value for "d"
-        map2_builder.keys().append_value("b");
-        map2_builder.values().append_value(1);
-        map2_builder.keys().append_value("d");
-        map2_builder.values().append_value(999);
-        map2_builder.append(true).unwrap();
-
-        // {"a": 1}
-        map2_builder.keys().append_value("a");
-        map2_builder.values().append_value(1);
-        map2_builder.append(true).unwrap();
-
-        // None
-        map2_builder.append(false).unwrap();
-
-        let map2 = map2_builder.finish();
+        let map2 = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(
+            vec![
+                // low value for "a", high value for "c"
+                Some(vec![("a", Some(1)), ("c", Some(999))]),
+                // low value for "b", high value for "d"
+                Some(vec![("b", Some(1)), ("d", Some(999))]),
+                Some(vec![("a", Some(1))]),
+                None,
+            ],
+            false,
+        );
 
         let opts = SortOptions {
             descending: false,
@@ -1380,59 +1347,25 @@ mod tests {
     #[test]
     fn test_map_vs_list_consistency() {
         // Create map arrays and convert them to list arrays to verify comparison consistency
-        // Map arrays: [{"a": 1, "b": 2}, {"x": 10}, {}, {"c": 3}]
-        let string_builder = StringBuilder::new();
-        let int_builder = Int32Builder::new();
-        let mut map1_builder = MapBuilder::new(None, string_builder, int_builder);
+        let map1 = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(
+            vec![
+                Some(vec![("a", Some(1)), ("b", Some(2))]),
+                Some(vec![("x", Some(10))]),
+                Some(vec![]),
+                Some(vec![("c", Some(3))]),
+            ],
+            false,
+        );
 
-        // {"a": 1, "b": 2}
-        map1_builder.keys().append_value("a");
-        map1_builder.values().append_value(1);
-        map1_builder.keys().append_value("b");
-        map1_builder.values().append_value(2);
-        map1_builder.append(true).unwrap();
-
-        // {"x": 10}
-        map1_builder.keys().append_value("x");
-        map1_builder.values().append_value(10);
-        map1_builder.append(true).unwrap();
-
-        // {}
-        map1_builder.append(true).unwrap();
-
-        // {"c": 3}
-        map1_builder.keys().append_value("c");
-        map1_builder.values().append_value(3);
-        map1_builder.append(true).unwrap();
-
-        let map1 = map1_builder.finish();
-
-        // Second map array: [{"a": 1, "b": 2}, {"y": 20}, {"d": 4}, None]
-        let string_builder = StringBuilder::new();
-        let int_builder = Int32Builder::new();
-        let mut map2_builder = MapBuilder::new(None, string_builder, int_builder);
-
-        // {"a": 1, "b": 2}
-        map2_builder.keys().append_value("a");
-        map2_builder.values().append_value(1);
-        map2_builder.keys().append_value("b");
-        map2_builder.values().append_value(2);
-        map2_builder.append(true).unwrap();
-
-        // {"y": 20}
-        map2_builder.keys().append_value("y");
-        map2_builder.values().append_value(20);
-        map2_builder.append(true).unwrap();
-
-        // {"d": 4}
-        map2_builder.keys().append_value("d");
-        map2_builder.values().append_value(4);
-        map2_builder.append(true).unwrap();
-
-        // None
-        map2_builder.append(false).unwrap();
-
-        let map2 = map2_builder.finish();
+        let map2 = MapArray::from_vec_of_maps::<StringArray, Int32Array, _, _>(
+            vec![
+                Some(vec![("a", Some(1)), ("b", Some(2))]),
+                Some(vec![("y", Some(20))]),
+                Some(vec![("d", Some(4))]),
+                None,
+            ],
+            false,
+        );
 
         // Convert map arrays to list arrays (Map entries are struct arrays with key-value pairs)
         let list1: ListArray = map1.clone().into();


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Whenever you try to write tests that use `MapArray` you have very verbose way to build the MapArray with the specific values you want

so adding this helper will allow arrow tests and user tests to be cleaner

# What changes are included in this PR?

added function and updated some of the tests in the repo that use the `MapBuilder` (that do not test the builder itself of course) with the new method to showcase how much cleaner it looks 

# Are these changes tested?
yes

# Are there any user-facing changes?

new function