### PR TITLE
fix: write error for dbg output of out of range timestamps

### DIFF
--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -1360,21 +1360,30 @@ impl<T: ArrowPrimitiveType> std::fmt::Debug for PrimitiveArray<T> {
                             // if the time zone is valid, construct a DateTime<Tz> and format it as rfc3339
                             Ok(tz) => match as_datetime_with_timezone::<T>(v, tz) {
                                 Some(datetime) => write!(f, "{}", datetime.to_rfc3339()),
-                                None => write!(f, "null"),
+                                None => write!(
+                                    f,
+                                    "Cast error: Failed to convert {v} to timestamp for {data_type}"
+                                ),
                             },
                             // if the time zone is invalid, shows NaiveDateTime with an error message
                             Err(_) => match as_datetime::<T>(v) {
                                 Some(datetime) => {
                                     write!(f, "{datetime:?} (Unknown Time Zone '{tz_string}')")
                                 }
-                                None => write!(f, "null"),
+                                None => write!(
+                                    f,
+                                    "Cast error: Failed to convert {v} to timestamp for {data_type}"
+                                ),
                             },
                         }
                     }
                     // for Timestamp without TimeZone
                     None => match as_datetime::<T>(v) {
                         Some(datetime) => write!(f, "{datetime:?}"),
-                        None => write!(f, "null"),
+                        None => write!(
+                            f,
+                            "Cast error: Failed to convert {v} to timestamp for {data_type}"
+                        ),
                     },
                 }
             }
@@ -2128,6 +2137,34 @@ mod tests {
     }
 
     #[test]
+    fn test_timestamp_fmt_debug_out_of_range() {
+        let arr = TimestampSecondArray::from(vec![i64::MAX, i64::MIN]);
+        assert_eq!(
+            "PrimitiveArray<Timestamp(s)>\n[\n  Cast error: Failed to convert 9223372036854775807 to timestamp for Timestamp(s),\n  Cast error: Failed to convert -9223372036854775808 to timestamp for Timestamp(s),\n]",
+            format!("{arr:?}")
+        );
+
+        let arr = TimestampMillisecondArray::from(vec![i64::MAX, i64::MIN]);
+        assert_eq!(
+            "PrimitiveArray<Timestamp(ms)>\n[\n  Cast error: Failed to convert 9223372036854775807 to timestamp for Timestamp(ms),\n  Cast error: Failed to convert -9223372036854775808 to timestamp for Timestamp(ms),\n]",
+            format!("{arr:?}")
+        );
+
+        let arr = TimestampMicrosecondArray::from(vec![i64::MAX, i64::MIN]);
+        assert_eq!(
+            "PrimitiveArray<Timestamp(µs)>\n[\n  Cast error: Failed to convert 9223372036854775807 to timestamp for Timestamp(µs),\n  Cast error: Failed to convert -9223372036854775808 to timestamp for Timestamp(µs),\n]",
+            format!("{arr:?}")
+        );
+
+        // Nanoseconds always in range
+        let arr = TimestampNanosecondArray::from(vec![i64::MAX, i64::MIN]);
+        assert_eq!(
+            "PrimitiveArray<Timestamp(ns)>\n[\n  2262-04-11T23:47:16.854775807,\n  1677-09-21T00:12:43.145224192,\n]",
+            format!("{arr:?}")
+        );
+    }
+
+    #[test]
     fn test_timestamp_utc_fmt_debug() {
         let arr: PrimitiveArray<TimestampMillisecondType> =
             TimestampMillisecondArray::from(vec![1546214400000, 1546214400000, -1546214400000])
@@ -2228,16 +2265,6 @@ mod tests {
         assert_eq!(
             "PrimitiveArray<Time32(s)>\n[\n  Cast error: Failed to convert -7201 to temporal for Time32(s),\n  Cast error: Failed to convert -60054 to temporal for Time32(s),\n]",
             // "PrimitiveArray<Time32(s)>\n[\n  null,\n  null,\n]",
-            format!("{arr:?}")
-        )
-    }
-
-    #[test]
-    fn test_timestamp_micros_out_of_range() {
-        // replicate the issue from https://github.com/apache/arrow-datafusion/issues/3832
-        let arr: PrimitiveArray<TimestampMicrosecondType> = vec![9065525203050843594].into();
-        assert_eq!(
-            "PrimitiveArray<Timestamp(µs)>\n[\n  null,\n]",
             format!("{arr:?}")
         )
     }

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -2138,28 +2138,54 @@ mod tests {
 
     #[test]
     fn test_timestamp_fmt_debug_out_of_range() {
-        let arr = TimestampSecondArray::from(vec![i64::MAX, i64::MIN]);
+        // Include a true null into dataset to ensure we don't write that as an error
+        let data = Int64Array::new(
+            vec![i64::MAX, i64::MIN, i64::MAX].into(),
+            Some(vec![true, true, false].into()),
+        );
+
+        let arr = data.reinterpret_cast::<TimestampSecondType>();
         assert_eq!(
-            "PrimitiveArray<Timestamp(s)>\n[\n  Cast error: Failed to convert 9223372036854775807 to timestamp for Timestamp(s),\n  Cast error: Failed to convert -9223372036854775808 to timestamp for Timestamp(s),\n]",
+            "PrimitiveArray<Timestamp(s)>
+[
+  Cast error: Failed to convert 9223372036854775807 to timestamp for Timestamp(s),
+  Cast error: Failed to convert -9223372036854775808 to timestamp for Timestamp(s),
+  null,
+]",
             format!("{arr:?}")
         );
 
-        let arr = TimestampMillisecondArray::from(vec![i64::MAX, i64::MIN]);
+        let arr = data.reinterpret_cast::<TimestampMillisecondType>();
         assert_eq!(
-            "PrimitiveArray<Timestamp(ms)>\n[\n  Cast error: Failed to convert 9223372036854775807 to timestamp for Timestamp(ms),\n  Cast error: Failed to convert -9223372036854775808 to timestamp for Timestamp(ms),\n]",
+            "PrimitiveArray<Timestamp(ms)>
+[
+  Cast error: Failed to convert 9223372036854775807 to timestamp for Timestamp(ms),
+  Cast error: Failed to convert -9223372036854775808 to timestamp for Timestamp(ms),
+  null,
+]",
             format!("{arr:?}")
         );
 
-        let arr = TimestampMicrosecondArray::from(vec![i64::MAX, i64::MIN]);
+        let arr = data.reinterpret_cast::<TimestampMicrosecondType>();
         assert_eq!(
-            "PrimitiveArray<Timestamp(µs)>\n[\n  Cast error: Failed to convert 9223372036854775807 to timestamp for Timestamp(µs),\n  Cast error: Failed to convert -9223372036854775808 to timestamp for Timestamp(µs),\n]",
+            "PrimitiveArray<Timestamp(µs)>
+[
+  Cast error: Failed to convert 9223372036854775807 to timestamp for Timestamp(µs),
+  Cast error: Failed to convert -9223372036854775808 to timestamp for Timestamp(µs),
+  null,
+]",
             format!("{arr:?}")
         );
 
         // Nanoseconds always in range
-        let arr = TimestampNanosecondArray::from(vec![i64::MAX, i64::MIN]);
+        let arr = data.reinterpret_cast::<TimestampNanosecondType>();
         assert_eq!(
-            "PrimitiveArray<Timestamp(ns)>\n[\n  2262-04-11T23:47:16.854775807,\n  1677-09-21T00:12:43.145224192,\n]",
+            "PrimitiveArray<Timestamp(ns)>
+[
+  2262-04-11T23:47:16.854775807,
+  1677-09-21T00:12:43.145224192,
+  null,
+]",
             format!("{arr:?}")
         );
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #7287

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Confusing to print `null` when the value is not formattable via chrono, so instead clearly write an error.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Instead of writing `null` in debug output of timestamp arrays for values that exceed chronos range, write an error message for that row similar to date/time types

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

Yes.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

Not really.
