### PR TITLE
[10125] [encode path] Minor optimizations to arrow-flight

### DIFF
--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::{collections::VecDeque, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
-use std::{collections::VecDeque, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
 
 use crate::{FlightData, FlightDescriptor, SchemaAsIpc, error::Result};
 
@@ -160,12 +159,16 @@ pub struct FlightDataEncoderBuilder {
     dictionary_handling: DictionaryHandling,
 }
 
+/// Default target size for encoded [`FlightData`].
+///
+/// gRPC's default max message size is 4MB; this 2MB target gives headroom for
+/// encoding overhead while keeping individual messages well within the limit.
+pub const GRPC_TARGET_MAX_FLIGHT_SIZE_BYTES: usize = 2 * 1024 * 1024;
+
 impl Default for FlightDataEncoderBuilder {
     fn default() -> Self {
         Self {
-            // Default target size for encoded FlightData. gRPC has a default max message
-            // size of 3MB; we use 3MB so batches are split to stay within that limit.
-            max_flight_data_size: 3 * 1024 * 1024,
+            max_flight_data_size: GRPC_TARGET_MAX_FLIGHT_SIZE_BYTES,
             options: IpcWriteOptions::default(),
             app_metadata: Bytes::new(),
             schema: None,
@@ -182,7 +185,8 @@ impl FlightDataEncoderBuilder {
     }
 
     /// Set the (approximate) maximum size, in bytes, of the
-    /// [`FlightData`] produced by this encoder. Defaults to 3MB.
+    /// [`FlightData`] produced by this encoder. Defaults to 2MB
+    /// ([`GRPC_TARGET_MAX_FLIGHT_SIZE_BYTES`]).
     ///
     /// Since there is often a maximum message size for gRPC messages
     /// (typically around 4MB), this encoder splits up [`RecordBatch`]s
@@ -670,12 +674,10 @@ fn split_batch_for_grpc_response(
         .map(|col| col.get_buffer_memory_size())
         .sum::<usize>();
 
+    let n_batches =
+        (size / max_flight_data_size + usize::from(size % max_flight_data_size != 0)).max(1);
     let num_rows = batch.num_rows();
-    let rows_per_batch = if size == 0 {
-        num_rows
-    } else {
-        (max_flight_data_size * num_rows / size).max(1)
-    };
+    let rows_per_batch = (num_rows / n_batches).max(1);
     let mut offset = 0;
 
     std::iter::from_fn(move || {
@@ -736,8 +738,7 @@ impl FlightIpcEncoder {
         )?;
 
         let flight_dictionaries = encoded_dictionaries.into_iter().map(|e| e.into());
-        let flight_batch = encoded_batch.into();
-        let flight_batch = encoded_batch.into();
+        let flight_batch: FlightData = encoded_batch.into();
 
         Ok((flight_dictionaries, flight_batch))
     }
@@ -1875,7 +1876,7 @@ mod tests {
             .expect("cannot create record batch");
         let split: Vec<_> =
             split_batch_for_grpc_response(batch.clone(), max_flight_data_size).collect();
-        assert_eq!(split.len(), 2);
+        assert_eq!(split.len(), 3);
         assert_eq!(
             split.iter().map(|batch| batch.num_rows()).sum::<usize>(),
             n_rows
@@ -1887,14 +1888,14 @@ mod tests {
 
     #[test]
     fn test_split_batch_for_grpc_response_sizes() {
-        // 2000 8 byte entries into 2k pieces: fill to limit, last chunk is remainder
-        verify_split(2000, 2 * 1024, vec![256, 256, 256, 256, 256, 256, 256, 208]);
+        // 2000 8 byte entries into 2k pieces: 8 chunks of 250 rows
+        verify_split(2000, 2 * 1024, vec![250, 250, 250, 250, 250, 250, 250, 250]);
 
-        // 2000 8 byte entries into 4k pieces: fill to limit, last chunk is remainder
-        verify_split(2000, 4 * 1024, vec![512, 512, 512, 464]);
+        // 2000 8 byte entries into 4k pieces: 4 chunks of 500 rows
+        verify_split(2000, 4 * 1024, vec![500, 500, 500, 500]);
 
         // 2023 8 byte entries into 3k pieces does not divide evenly
-        verify_split(2023, 3 * 1024, vec![384, 384, 384, 384, 384, 103]);
+        verify_split(2023, 3 * 1024, vec![337, 337, 337, 337, 337, 337, 1]);
 
         // 10 8 byte entries into 1 byte pieces means each rows gets its own
         verify_split(10, 1, vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
@@ -1945,7 +1946,7 @@ mod tests {
         ])
         .unwrap();
 
-        verify_encoded_split(batch, 152).await;
+        verify_encoded_split(batch, 120).await;
     }
 
     #[tokio::test]
@@ -2008,7 +2009,7 @@ mod tests {
 
         let batch = RecordBatch::try_from_iter(vec![("a1", Arc::new(array) as _)]).unwrap();
 
-        verify_encoded_split(batch, 163).await;
+        verify_encoded_split(batch, 56).await;
     }
 
     #[tokio::test]

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -20,7 +20,7 @@ use std::{collections::VecDeque, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
 use crate::{FlightData, FlightDescriptor, SchemaAsIpc, error::Result};
 
 use arrow_array::{Array, ArrayRef, RecordBatch, RecordBatchOptions, UnionArray};
-use arrow_ipc::writer::{CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
+use arrow_ipc::writer::{DictionaryTracker, IpcDataGenerator, IpcWriteContext, IpcWriteOptions};
 
 use arrow_schema::{DataType, Field, FieldRef, Fields, Schema, SchemaRef, UnionMode};
 use bytes::Bytes;
@@ -701,7 +701,7 @@ struct FlightIpcEncoder {
     options: IpcWriteOptions,
     data_gen: IpcDataGenerator,
     dictionary_tracker: DictionaryTracker,
-    compression_context: CompressionContext,
+    compression_context: IpcWriteContext,
 }
 
 impl FlightIpcEncoder {
@@ -710,7 +710,7 @@ impl FlightIpcEncoder {
             options,
             data_gen: IpcDataGenerator::default(),
             dictionary_tracker: DictionaryTracker::new(error_on_replacement),
-            compression_context: CompressionContext::default(),
+            compression_context: IpcWriteContext::default(),
         }
     }
 
@@ -1833,7 +1833,7 @@ mod tests {
     ) -> (Vec<FlightData>, FlightData) {
         let data_gen = IpcDataGenerator::default();
         let mut dictionary_tracker = DictionaryTracker::new(false);
-        let mut compression_context = CompressionContext::default();
+        let mut compression_context = IpcWriteContext::default();
 
         let (encoded_dictionaries, encoded_batch) = data_gen
             .encode(

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -15,13 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{
-    collections::VecDeque,
-    fmt::Debug,
-    pin::Pin,
-    sync::{Arc, Mutex},
-    task::Poll,
-};
+use std::{collections::VecDeque, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
 
 use crate::{FlightData, FlightDescriptor, SchemaAsIpc, error::Result};
 
@@ -266,60 +260,6 @@ impl FlightDataEncoderBuilder {
             descriptor,
             dictionary_handling,
         )
-    }
-}
-
-const DEFAULT_ARROW_DATA_CAPACITY: usize = GRPC_TARGET_MAX_FLIGHT_SIZE_BYTES;
-
-/// Pool of reusable `Vec<u8>` buffers for the IPC arrow data body.
-#[derive(Clone, Debug)]
-pub struct ArrowDataPool(Arc<Mutex<Vec<Vec<u8>>>>);
-
-impl ArrowDataPool {
-    /// Create n buffers with pre-allocated capacity for reuse in encoding IPC messages.
-    pub fn new(n: usize) -> Self {
-        Self(Arc::new(Mutex::new(
-            (0..n)
-                .map(|_| Vec::with_capacity(DEFAULT_ARROW_DATA_CAPACITY))
-                .collect(),
-        )))
-    }
-
-    fn acquire(&self) -> Vec<u8> {
-        let mut buf = self.0.lock().unwrap().pop().unwrap_or_default();
-        buf.clear();
-        buf
-    }
-
-    fn release(&self, mut buf: Vec<u8>) {
-        buf.clear();
-        self.0.lock().unwrap().push(buf);
-    }
-}
-
-impl Default for ArrowDataPool {
-    fn default() -> Self {
-        Self::new(8)
-    }
-}
-
-// A thin wrapper that gives `Bytes::from_owner` something to hold onto.
-// `data` — the Vec<u8> written into by encode(). The buffer we keep alive.
-// `pool` — shared handle back to the ArrowDataPool; on drop, the Vec finds its way home.
-pub(crate) struct PooledBuf {
-    data: Vec<u8>,
-    pool: ArrowDataPool,
-}
-
-impl AsRef<[u8]> for PooledBuf {
-    fn as_ref(&self) -> &[u8] {
-        &self.data
-    }
-}
-
-impl Drop for PooledBuf {
-    fn drop(&mut self) {
-        self.pool.release(std::mem::take(&mut self.data));
     }
 }
 
@@ -762,7 +702,6 @@ struct FlightIpcEncoder {
     data_gen: IpcDataGenerator,
     dictionary_tracker: DictionaryTracker,
     compression_context: IpcWriteContext,
-    pool: ArrowDataPool,
 }
 
 impl FlightIpcEncoder {
@@ -772,7 +711,6 @@ impl FlightIpcEncoder {
             data_gen: IpcDataGenerator::default(),
             dictionary_tracker: DictionaryTracker::new(error_on_replacement),
             compression_context: IpcWriteContext::default(),
-            pool: ArrowDataPool::default(),
         }
     }
 
@@ -787,7 +725,6 @@ impl FlightIpcEncoder {
         &mut self,
         batch: &RecordBatch,
     ) -> Result<(impl Iterator<Item = FlightData> + use<>, FlightData)> {
-        self.compression_context.scratch = self.pool.acquire();
         let (encoded_dictionaries, encoded_batch) = self.data_gen.encode(
             batch,
             &mut self.dictionary_tracker,
@@ -796,16 +733,7 @@ impl FlightIpcEncoder {
         )?;
 
         let flight_dictionaries = encoded_dictionaries.into_iter().map(|e| e.into());
-
-        let pooled = PooledBuf {
-            data: encoded_batch.arrow_data,
-            pool: self.pool.clone(),
-        };
-        let flight_batch = crate::FlightData {
-            data_header: encoded_batch.ipc_message.into(),
-            data_body: Bytes::from_owner(pooled),
-            ..Default::default()
-        };
+        let flight_batch = encoded_batch.into();
 
         Ok((flight_dictionaries, flight_batch))
     }

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::{collections::VecDeque, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
+use std::{collections::VecDeque, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
 
 use crate::{FlightData, FlightDescriptor, SchemaAsIpc, error::Result};
 
@@ -159,16 +160,12 @@ pub struct FlightDataEncoderBuilder {
     dictionary_handling: DictionaryHandling,
 }
 
-/// Default target size for encoded [`FlightData`].
-///
-/// Note this value would normally be 4MB, but the size calculation is
-/// somewhat inexact, so we set it to 2MB.
-pub const GRPC_TARGET_MAX_FLIGHT_SIZE_BYTES: usize = 2097152;
-
 impl Default for FlightDataEncoderBuilder {
     fn default() -> Self {
         Self {
-            max_flight_data_size: GRPC_TARGET_MAX_FLIGHT_SIZE_BYTES,
+            // Default target size for encoded FlightData. gRPC has a default max message
+            // size of 3MB; we use 3MB so batches are split to stay within that limit.
+            max_flight_data_size: 3 * 1024 * 1024,
             options: IpcWriteOptions::default(),
             app_metadata: Bytes::new(),
             schema: None,
@@ -185,7 +182,7 @@ impl FlightDataEncoderBuilder {
     }
 
     /// Set the (approximate) maximum size, in bytes, of the
-    /// [`FlightData`] produced by this encoder. Defaults to 2MB.
+    /// [`FlightData`] produced by this encoder. Defaults to 3MB.
     ///
     /// Since there is often a maximum message size for gRPC messages
     /// (typically around 4MB), this encoder splits up [`RecordBatch`]s
@@ -372,15 +369,15 @@ impl FlightDataEncoder {
             DictionaryHandling::Resend => batch,
             DictionaryHandling::Hydrate => hydrate_dictionaries(&batch, schema)?,
         };
-
         for batch in split_batch_for_grpc_response(batch, self.max_flight_data_size) {
-            let (flight_dictionaries, flight_batch) = self.encoder.encode_batch(&batch)?;
+            let (flight_dictionaries, flight_batch) = self
+                .encoder
+                .encode_batch(&batch, self.max_flight_data_size)?;
             for dict in flight_dictionaries {
                 self.queue_message(dict);
             }
             self.queue_message(flight_batch);
         }
-
         Ok(())
     }
 }
@@ -673,10 +670,12 @@ fn split_batch_for_grpc_response(
         .map(|col| col.get_buffer_memory_size())
         .sum::<usize>();
 
-    let n_batches =
-        (size / max_flight_data_size + usize::from(size % max_flight_data_size != 0)).max(1);
     let num_rows = batch.num_rows();
-    let rows_per_batch = (num_rows / n_batches).max(1);
+    let rows_per_batch = if size == 0 {
+        num_rows
+    } else {
+        (max_flight_data_size * num_rows / size).max(1)
+    };
     let mut offset = 0;
 
     std::iter::from_fn(move || {
@@ -724,7 +723,11 @@ impl FlightIpcEncoder {
     fn encode_batch(
         &mut self,
         batch: &RecordBatch,
-    ) -> Result<(impl Iterator<Item = FlightData> + use<>, FlightData)> {
+        max_flight_data_size: usize,
+    ) -> Result<(impl Iterator<Item = FlightData> + 'static, FlightData)> {
+        self.compression_context
+            .scratch
+            .reserve(max_flight_data_size);
         let (encoded_dictionaries, encoded_batch) = self.data_gen.encode(
             batch,
             &mut self.dictionary_tracker,
@@ -733,6 +736,7 @@ impl FlightIpcEncoder {
         )?;
 
         let flight_dictionaries = encoded_dictionaries.into_iter().map(|e| e.into());
+        let flight_batch = encoded_batch.into();
         let flight_batch = encoded_batch.into();
 
         Ok((flight_dictionaries, flight_batch))
@@ -1871,7 +1875,7 @@ mod tests {
             .expect("cannot create record batch");
         let split: Vec<_> =
             split_batch_for_grpc_response(batch.clone(), max_flight_data_size).collect();
-        assert_eq!(split.len(), 3);
+        assert_eq!(split.len(), 2);
         assert_eq!(
             split.iter().map(|batch| batch.num_rows()).sum::<usize>(),
             n_rows
@@ -1883,14 +1887,14 @@ mod tests {
 
     #[test]
     fn test_split_batch_for_grpc_response_sizes() {
-        // 2000 8 byte entries into 2k pieces: 8 chunks of 250 rows
-        verify_split(2000, 2 * 1024, vec![250, 250, 250, 250, 250, 250, 250, 250]);
+        // 2000 8 byte entries into 2k pieces: fill to limit, last chunk is remainder
+        verify_split(2000, 2 * 1024, vec![256, 256, 256, 256, 256, 256, 256, 208]);
 
-        // 2000 8 byte entries into 4k pieces: 4 chunks of 500 rows
-        verify_split(2000, 4 * 1024, vec![500, 500, 500, 500]);
+        // 2000 8 byte entries into 4k pieces: fill to limit, last chunk is remainder
+        verify_split(2000, 4 * 1024, vec![512, 512, 512, 464]);
 
         // 2023 8 byte entries into 3k pieces does not divide evenly
-        verify_split(2023, 3 * 1024, vec![337, 337, 337, 337, 337, 337, 1]);
+        verify_split(2023, 3 * 1024, vec![384, 384, 384, 384, 384, 103]);
 
         // 10 8 byte entries into 1 byte pieces means each rows gets its own
         verify_split(10, 1, vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
@@ -1941,7 +1945,7 @@ mod tests {
         ])
         .unwrap();
 
-        verify_encoded_split(batch, 120).await;
+        verify_encoded_split(batch, 152).await;
     }
 
     #[tokio::test]
@@ -2004,7 +2008,7 @@ mod tests {
 
         let batch = RecordBatch::try_from_iter(vec![("a1", Arc::new(array) as _)]).unwrap();
 
-        verify_encoded_split(batch, 56).await;
+        verify_encoded_split(batch, 163).await;
     }
 
     #[tokio::test]

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -161,9 +161,9 @@ pub struct FlightDataEncoderBuilder {
 
 /// Default target size for encoded [`FlightData`].
 ///
-/// gRPC's default max message size is 4MB; this 2MB target gives headroom for
-/// encoding overhead while keeping individual messages well within the limit.
-pub const GRPC_TARGET_MAX_FLIGHT_SIZE_BYTES: usize = 2 * 1024 * 1024;
+/// Note this value would normally be 4MB, but the size calculation is
+/// somewhat inexact, so we set it to 2MB.
+pub const GRPC_TARGET_MAX_FLIGHT_SIZE_BYTES: usize = 2097152;
 
 impl Default for FlightDataEncoderBuilder {
     fn default() -> Self {
@@ -185,8 +185,7 @@ impl FlightDataEncoderBuilder {
     }
 
     /// Set the (approximate) maximum size, in bytes, of the
-    /// [`FlightData`] produced by this encoder. Defaults to 2MB
-    /// ([`GRPC_TARGET_MAX_FLIGHT_SIZE_BYTES`]).
+    /// [`FlightData`] produced by this encoder. Defaults to 2MB.
     ///
     /// Since there is often a maximum message size for gRPC messages
     /// (typically around 4MB), this encoder splits up [`RecordBatch`]s

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -15,7 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{collections::VecDeque, fmt::Debug, pin::Pin, sync::Arc, task::Poll};
+use std::{
+    collections::VecDeque,
+    fmt::Debug,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::Poll,
+};
 
 use crate::{FlightData, FlightDescriptor, SchemaAsIpc, error::Result};
 
@@ -260,6 +266,60 @@ impl FlightDataEncoderBuilder {
             descriptor,
             dictionary_handling,
         )
+    }
+}
+
+const DEFAULT_ARROW_DATA_CAPACITY: usize = GRPC_TARGET_MAX_FLIGHT_SIZE_BYTES;
+
+/// Pool of reusable `Vec<u8>` buffers for the IPC arrow data body.
+#[derive(Clone, Debug)]
+pub struct ArrowDataPool(Arc<Mutex<Vec<Vec<u8>>>>);
+
+impl ArrowDataPool {
+    /// Create n buffers with pre-allocated capacity for reuse in encoding IPC messages.
+    pub fn new(n: usize) -> Self {
+        Self(Arc::new(Mutex::new(
+            (0..n)
+                .map(|_| Vec::with_capacity(DEFAULT_ARROW_DATA_CAPACITY))
+                .collect(),
+        )))
+    }
+
+    fn acquire(&self) -> Vec<u8> {
+        let mut buf = self.0.lock().unwrap().pop().unwrap_or_default();
+        buf.clear();
+        buf
+    }
+
+    fn release(&self, mut buf: Vec<u8>) {
+        buf.clear();
+        self.0.lock().unwrap().push(buf);
+    }
+}
+
+impl Default for ArrowDataPool {
+    fn default() -> Self {
+        Self::new(8)
+    }
+}
+
+// A thin wrapper that gives `Bytes::from_owner` something to hold onto.
+// `data` — the Vec<u8> written into by encode(). The buffer we keep alive.
+// `pool` — shared handle back to the ArrowDataPool; on drop, the Vec finds its way home.
+pub(crate) struct PooledBuf {
+    data: Vec<u8>,
+    pool: ArrowDataPool,
+}
+
+impl AsRef<[u8]> for PooledBuf {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl Drop for PooledBuf {
+    fn drop(&mut self) {
+        self.pool.release(std::mem::take(&mut self.data));
     }
 }
 
@@ -702,6 +762,7 @@ struct FlightIpcEncoder {
     data_gen: IpcDataGenerator,
     dictionary_tracker: DictionaryTracker,
     compression_context: IpcWriteContext,
+    pool: ArrowDataPool,
 }
 
 impl FlightIpcEncoder {
@@ -711,6 +772,7 @@ impl FlightIpcEncoder {
             data_gen: IpcDataGenerator::default(),
             dictionary_tracker: DictionaryTracker::new(error_on_replacement),
             compression_context: IpcWriteContext::default(),
+            pool: ArrowDataPool::default(),
         }
     }
 
@@ -725,6 +787,7 @@ impl FlightIpcEncoder {
         &mut self,
         batch: &RecordBatch,
     ) -> Result<(impl Iterator<Item = FlightData> + use<>, FlightData)> {
+        self.compression_context.scratch = self.pool.acquire();
         let (encoded_dictionaries, encoded_batch) = self.data_gen.encode(
             batch,
             &mut self.dictionary_tracker,
@@ -733,7 +796,16 @@ impl FlightIpcEncoder {
         )?;
 
         let flight_dictionaries = encoded_dictionaries.into_iter().map(|e| e.into());
-        let flight_batch = encoded_batch.into();
+
+        let pooled = PooledBuf {
+            data: encoded_batch.arrow_data,
+            pool: self.pool.clone(),
+        };
+        let flight_batch = crate::FlightData {
+            data_header: encoded_batch.ipc_message.into(),
+            data_body: Bytes::from_owner(pooled),
+            ..Default::default()
+        };
 
         Ok((flight_dictionaries, flight_batch))
     }

--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_buffer::Buffer;
 use arrow_ipc::convert::fb_to_schema;
-use arrow_ipc::writer::CompressionContext;
+use arrow_ipc::writer::IpcWriteContext;
 use arrow_ipc::{reader, root_as_message, writer, writer::IpcWriteOptions};
 use arrow_schema::{ArrowError, Schema, SchemaRef};
 
@@ -92,7 +92,7 @@ pub fn batches_to_flight_data(
 
     let data_gen = writer::IpcDataGenerator::default();
     let mut dictionary_tracker = writer::DictionaryTracker::new(false);
-    let mut compression_context = CompressionContext::default();
+    let mut compression_context = IpcWriteContext::default();
 
     for batch in batches.iter() {
         let (encoded_dictionaries, encoded_batch) = data_gen.encode(

--- a/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/arrow-integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -26,7 +26,7 @@ use arrow::{
     datatypes::SchemaRef,
     ipc::{
         self, reader,
-        writer::{self, CompressionContext},
+        writer::{self, IpcWriteContext},
     },
     record_batch::RecordBatch,
 };
@@ -95,7 +95,7 @@ async fn upload_data(
 
     let mut original_data_iter = original_data.iter().enumerate();
 
-    let mut compression_context = CompressionContext::default();
+    let mut compression_context = IpcWriteContext::default();
 
     if let Some((counter, first_batch)) = original_data_iter.next() {
         let metadata = counter.to_string().into_bytes();
@@ -159,7 +159,7 @@ async fn send_batch(
     batch: &RecordBatch,
     options: &writer::IpcWriteOptions,
     dictionary_tracker: &mut writer::DictionaryTracker,
-    compression_context: &mut CompressionContext,
+    compression_context: &mut IpcWriteContext,
 ) -> Result {
     let data_gen = writer::IpcDataGenerator::default();
 

--- a/arrow-ipc/src/compression.rs
+++ b/arrow-ipc/src/compression.rs
@@ -18,6 +18,7 @@
 use crate::CompressionType;
 use arrow_buffer::Buffer;
 use arrow_schema::ArrowError;
+use flatbuffers::FlatBufferBuilder;
 
 const LENGTH_NO_COMPRESSED_DATA: i64 = -1;
 const LENGTH_OF_PREFIX_DATA: i64 = 8;
@@ -28,12 +29,13 @@ const LENGTH_OF_PREFIX_DATA: i64 = 8;
 /// compression calls to avoid the performance overhead of initialising a new context for every
 /// compression.
 #[derive(Default)]
-pub struct CompressionContext {
+pub struct IpcWriteContext {
     #[cfg(feature = "zstd")]
     compressor: Option<zstd::bulk::Compressor<'static>>,
+    pub(crate) fbb: FlatBufferBuilder<'static>,
 }
 
-impl CompressionContext {
+impl IpcWriteContext {
     #[cfg(feature = "zstd")]
     fn zstd_compressor(&mut self) -> &mut zstd::bulk::Compressor<'static> {
         self.compressor.get_or_insert_with(|| {
@@ -43,9 +45,9 @@ impl CompressionContext {
     }
 }
 
-impl std::fmt::Debug for CompressionContext {
+impl std::fmt::Debug for IpcWriteContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("CompressionContext");
+        let mut ds = f.debug_struct("IpcWriteContext");
 
         #[cfg(feature = "zstd")]
         ds.field(
@@ -143,7 +145,7 @@ impl CompressionCodec {
         &self,
         input: &[u8],
         output: &mut Vec<u8>,
-        context: &mut CompressionContext,
+        context: &mut IpcWriteContext,
     ) -> Result<usize, ArrowError> {
         let uncompressed_data_len = input.len();
         let original_output_len = output.len();
@@ -209,7 +211,7 @@ impl CompressionCodec {
         &self,
         input: &[u8],
         output: &mut Vec<u8>,
-        context: &mut CompressionContext,
+        context: &mut IpcWriteContext,
     ) -> Result<(), ArrowError> {
         match self {
             CompressionCodec::Lz4Frame => compress_lz4(input, output),
@@ -278,7 +280,7 @@ fn decompress_lz4(_input: &[u8], _decompressed_size: usize) -> Result<Vec<u8>, A
 fn compress_zstd(
     input: &[u8],
     output: &mut Vec<u8>,
-    context: &mut CompressionContext,
+    context: &mut IpcWriteContext,
 ) -> Result<(), ArrowError> {
     let result = context.zstd_compressor().compress(input)?;
     output.extend_from_slice(&result);
@@ -290,7 +292,7 @@ fn compress_zstd(
 fn compress_zstd(
     _input: &[u8],
     _output: &mut Vec<u8>,
-    _context: &mut CompressionContext,
+    _context: &mut IpcWriteContext,
 ) -> Result<(), ArrowError> {
     Err(ArrowError::InvalidArgumentError(
         "zstd IPC compression requires the zstd feature".to_string(),

--- a/arrow-ipc/src/compression.rs
+++ b/arrow-ipc/src/compression.rs
@@ -23,16 +23,16 @@ use flatbuffers::FlatBufferBuilder;
 const LENGTH_NO_COMPRESSED_DATA: i64 = -1;
 const LENGTH_OF_PREFIX_DATA: i64 = 8;
 
-/// Additional context that may be needed for compression.
-///
-/// In the case of zstd, this will contain the zstd context, which can be reused between subsequent
-/// compression calls to avoid the performance overhead of initialising a new context for every
-/// compression.
+/// - The flatbuffer builder (`fbb`) is reset and reused across calls.
+/// - The zstd compressor (when enabled) is kept alive to avoid re-initialisation overhead.
 #[derive(Default)]
 pub struct IpcWriteContext {
     #[cfg(feature = "zstd")]
     compressor: Option<zstd::bulk::Compressor<'static>>,
     pub(crate) fbb: FlatBufferBuilder<'static>,
+    /// Scratch buffer for the IPC arrow data body. When set by the caller before
+    /// encode(), the existing allocation is reused instead of creating a fresh Vec.
+    pub scratch: Vec<u8>,
 }
 
 impl IpcWriteContext {

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -556,13 +556,26 @@ impl IpcDataGenerator {
             write_options,
             compression_context,
         )?;
-        let mut arrow_data = std::mem::take(&mut compression_context.scratch);
-        let (ipc_message, _, tail_pad) = self.record_batch_to_bytes(
+        let capacity = batch
+            .columns()
+            .iter()
+            .map(|a| estimate_encoded_buffer_count(a.data_type()))
+            .sum();
+        let mut encoded_buffers: Vec<EncodedBuffer> = Vec::with_capacity(capacity);
+        let (ipc_message, body_len, tail_pad) = self.record_batch_to_bytes(
             batch,
             write_options,
             compression_context,
-            &mut IpcBodySink::Write(&mut arrow_data),
+            &mut IpcBodySink::Collect(&mut encoded_buffers),
         )?;
+        let alignment = write_options.alignment;
+        let mut arrow_data = std::mem::take(&mut compression_context.scratch);
+        arrow_data.clear();
+        arrow_data.reserve(body_len); // safe guards against string data that are large
+        for enc in &encoded_buffers {
+            arrow_data.extend_from_slice(enc.as_slice());
+            arrow_data.extend_from_slice(&PADDING[..pad_to_alignment(alignment, enc.len())]);
+        }
         arrow_data.extend_from_slice(&PADDING[..tail_pad]);
         Ok((
             encoded_dictionaries,

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -43,7 +43,7 @@ use arrow_schema::*;
 
 use crate::CONTINUATION_MARKER;
 use crate::compression::CompressionCodec;
-pub use crate::compression::CompressionContext;
+pub use crate::compression::IpcWriteContext;
 use crate::convert::IpcSchemaEncoder;
 
 /// IPC write options used to control the behaviour of the [`IpcDataGenerator`]
@@ -244,7 +244,7 @@ impl Default for IpcWriteOptions {
 /// # use std::sync::Arc;
 /// # use arrow_array::UInt64Array;
 /// # use arrow_array::RecordBatch;
-/// # use arrow_ipc::writer::{CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
+/// # use arrow_ipc::writer::{IpcWriteContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions};
 ///
 /// // Create a record batch
 /// let batch = RecordBatch::try_from_iter(vec![
@@ -256,7 +256,7 @@ impl Default for IpcWriteOptions {
 /// let options = IpcWriteOptions::default();
 /// let mut dictionary_tracker = DictionaryTracker::new(error_on_replacement);
 ///
-/// let mut compression_context = CompressionContext::default();
+/// let mut compression_context = IpcWriteContext::default();
 ///
 /// // encode the batch into zero or more encoded dictionaries
 /// // and the data for the actual array.
@@ -310,7 +310,7 @@ impl IpcDataGenerator {
         dictionary_tracker: &mut DictionaryTracker,
         write_options: &IpcWriteOptions,
         dict_id: &mut I,
-        compression_context: &mut CompressionContext,
+        compression_context: &mut IpcWriteContext,
     ) -> Result<(), ArrowError> {
         match column.data_type() {
             DataType::Struct(fields) => {
@@ -471,7 +471,7 @@ impl IpcDataGenerator {
         dictionary_tracker: &mut DictionaryTracker,
         write_options: &IpcWriteOptions,
         dict_id_seq: &mut I,
-        compression_context: &mut CompressionContext,
+        compression_context: &mut IpcWriteContext,
     ) -> Result<(), ArrowError> {
         match column.data_type() {
             DataType::Dictionary(_key_type, _value_type) => {
@@ -548,7 +548,7 @@ impl IpcDataGenerator {
         batch: &RecordBatch,
         dictionary_tracker: &mut DictionaryTracker,
         write_options: &IpcWriteOptions,
-        compression_context: &mut CompressionContext,
+        compression_context: &mut IpcWriteContext,
     ) -> Result<(Vec<EncodedData>, EncodedData), ArrowError> {
         let encoded_dictionaries = self.encode_all_dicts(
             batch,
@@ -558,13 +558,13 @@ impl IpcDataGenerator {
         )?;
         // by default, write_options.compression is None, this means no compression will be applied and the encoded buffers will just be references to the original array buffers, so we can calculate the total size of the body data by summing the sizes of the original buffers.
         // avoiding the intermediate allocations & copys to new buffers.
-        let mut arrow_data = Vec::with_capacity(
-            batch
-                .columns()
-                .iter()
-                .map(|c| c.get_array_memory_size())
-                .sum::<usize>(),
-        );
+        let size = batch
+            .columns()
+            .iter()
+            .map(|c| c.get_array_memory_size())
+            .sum::<usize>();
+        println!("Total size of body data: {size}");
+        let mut arrow_data = Vec::with_capacity(size);
         let (ipc_message, _, tail_pad) = self.record_batch_to_bytes(
             batch,
             write_options,
@@ -572,6 +572,12 @@ impl IpcDataGenerator {
             &mut IpcBodySink::Write(&mut arrow_data),
         )?;
         arrow_data.extend_from_slice(&PADDING[..tail_pad]);
+        println!(
+            "size of record batch buffers:{}\nsize of flatbuffer data :{}\nsize of array_data:{}",
+            size,
+            ipc_message.len(),
+            arrow_data.len()
+        );
         Ok((
             encoded_dictionaries,
             EncodedData {
@@ -587,7 +593,7 @@ impl IpcDataGenerator {
         batch: &RecordBatch,
         dictionary_tracker: &mut DictionaryTracker,
         write_options: &IpcWriteOptions,
-        compression_context: &mut CompressionContext,
+        compression_context: &mut IpcWriteContext,
     ) -> Result<Vec<EncodedData>, ArrowError> {
         let schema = batch.schema();
         let mut encoded_dictionaries = Vec::with_capacity(schema.flattened_fields().len());
@@ -614,7 +620,7 @@ impl IpcDataGenerator {
         batch: &RecordBatch,
         dictionary_tracker: &mut DictionaryTracker,
         write_options: &IpcWriteOptions,
-        compression_context: &mut CompressionContext,
+        compression_context: &mut IpcWriteContext,
         writer: &mut W,
     ) -> Result<IpcWriteMetadata, ArrowError> {
         let encoded_dictionaries = self.encode_all_dicts(
@@ -697,19 +703,10 @@ impl IpcDataGenerator {
         &self,
         batch: &RecordBatch,
         write_options: &IpcWriteOptions,
-        compression_context: &mut CompressionContext,
+        compression_context: &mut IpcWriteContext,
         sink: &mut IpcBodySink<'_>,
     ) -> Result<(Vec<u8>, usize, usize), ArrowError> {
-        let mut fbb = FlatBufferBuilder::new();
-
         let batch_compression_type = write_options.batch_compression_type;
-
-        let compression = batch_compression_type.map(|batch_compression_type| {
-            let mut c = crate::BodyCompressionBuilder::new(&mut fbb);
-            c.add_method(crate::BodyCompressionMethod::BUFFER);
-            c.add_codec(batch_compression_type);
-            c.finish()
-        });
 
         let compression_codec: Option<CompressionCodec> =
             batch_compression_type.map(TryInto::try_into).transpose()?;
@@ -736,6 +733,16 @@ impl IpcDataGenerator {
         let tail_pad = pad_to_alignment(alignment, offset as usize);
         let body_len = offset as usize + tail_pad;
 
+        // Build flatbuffer header using the reused builder in the context.
+        let fbb = &mut compression_context.fbb;
+
+        let compression = batch_compression_type.map(|batch_compression_type| {
+            let mut c = crate::BodyCompressionBuilder::new(fbb);
+            c.add_method(crate::BodyCompressionMethod::BUFFER);
+            c.add_codec(batch_compression_type);
+            c.finish()
+        });
+
         let buffers = fbb.create_vector(&meta.buffers);
         let nodes = fbb.create_vector(&meta.nodes);
         let variadic_buffer = if variadic_buffer_counts.is_empty() {
@@ -745,7 +752,7 @@ impl IpcDataGenerator {
         };
 
         let root = {
-            let mut batch_builder = crate::RecordBatchBuilder::new(&mut fbb);
+            let mut batch_builder = crate::RecordBatchBuilder::new(fbb);
             batch_builder.add_length(batch.num_rows() as i64);
             batch_builder.add_nodes(nodes);
             batch_builder.add_buffers(buffers);
@@ -758,7 +765,7 @@ impl IpcDataGenerator {
             batch_builder.finish().as_union_value()
         };
         // create an crate::Message
-        let mut message = crate::MessageBuilder::new(&mut fbb);
+        let mut message = crate::MessageBuilder::new(fbb);
         message.add_version(write_options.metadata_version);
         message.add_header_type(crate::MessageHeader::RecordBatch);
         message.add_bodyLength(body_len as i64);
@@ -766,7 +773,9 @@ impl IpcDataGenerator {
         let root = message.finish();
         fbb.finish(root, None);
 
-        Ok((fbb.finished_data().to_vec(), body_len, tail_pad))
+        let ipc_message = fbb.finished_data().to_vec();
+        fbb.reset();
+        Ok((ipc_message, body_len, tail_pad))
     }
 
     /// Write dictionary values into two sets of bytes, one for the header (crate::Message) and the
@@ -777,21 +786,12 @@ impl IpcDataGenerator {
         array_data: &ArrayData,
         write_options: &IpcWriteOptions,
         is_delta: bool,
-        compression_context: &mut CompressionContext,
+        compression_context: &mut IpcWriteContext,
     ) -> Result<EncodedData, ArrowError> {
-        let mut fbb = FlatBufferBuilder::new();
-
         let mut arrow_data: Vec<u8> = vec![];
 
         // get the type of compression
         let batch_compression_type = write_options.batch_compression_type;
-
-        let compression = batch_compression_type.map(|batch_compression_type| {
-            let mut c = crate::BodyCompressionBuilder::new(&mut fbb);
-            c.add_method(crate::BodyCompressionMethod::BUFFER);
-            c.add_codec(batch_compression_type);
-            c.finish()
-        });
 
         let compression_codec: Option<CompressionCodec> = batch_compression_type
             .map(|batch_compression_type| batch_compression_type.try_into())
@@ -818,7 +818,16 @@ impl IpcDataGenerator {
         let body_len = offset as usize + tail_pad;
         arrow_data.extend_from_slice(&PADDING[..tail_pad]);
 
-        // write data
+        // Build flatbuffer header using the reused builder in the context.
+        let fbb = &mut compression_context.fbb;
+
+        let compression = batch_compression_type.map(|batch_compression_type| {
+            let mut c = crate::BodyCompressionBuilder::new(fbb);
+            c.add_method(crate::BodyCompressionMethod::BUFFER);
+            c.add_codec(batch_compression_type);
+            c.finish()
+        });
+
         let buffers = fbb.create_vector(&meta.buffers);
         let nodes = fbb.create_vector(&meta.nodes);
         let variadic_buffer = if variadic_buffer_counts.is_empty() {
@@ -828,7 +837,7 @@ impl IpcDataGenerator {
         };
 
         let root = {
-            let mut batch_builder = crate::RecordBatchBuilder::new(&mut fbb);
+            let mut batch_builder = crate::RecordBatchBuilder::new(fbb);
             batch_builder.add_length(array_data.len() as i64);
             batch_builder.add_nodes(nodes);
             batch_builder.add_buffers(buffers);
@@ -842,7 +851,7 @@ impl IpcDataGenerator {
         };
 
         let root = {
-            let mut batch_builder = crate::DictionaryBatchBuilder::new(&mut fbb);
+            let mut batch_builder = crate::DictionaryBatchBuilder::new(fbb);
             batch_builder.add_id(dict_id);
             batch_builder.add_data(root);
             batch_builder.add_isDelta(is_delta);
@@ -850,7 +859,7 @@ impl IpcDataGenerator {
         };
 
         let root = {
-            let mut message_builder = crate::MessageBuilder::new(&mut fbb);
+            let mut message_builder = crate::MessageBuilder::new(fbb);
             message_builder.add_version(write_options.metadata_version);
             message_builder.add_header_type(crate::MessageHeader::DictionaryBatch);
             message_builder.add_bodyLength(body_len as i64);
@@ -859,10 +868,11 @@ impl IpcDataGenerator {
         };
 
         fbb.finish(root, None);
-        let finished_data = fbb.finished_data();
+        let ipc_message = fbb.finished_data().to_vec();
+        fbb.reset();
 
         Ok(EncodedData {
-            ipc_message: finished_data.to_vec(),
+            ipc_message,
             arrow_data,
         })
     }
@@ -1246,7 +1256,7 @@ pub struct FileWriter<W> {
 
     data_gen: IpcDataGenerator,
 
-    compression_context: CompressionContext,
+    compression_context: IpcWriteContext,
 }
 
 impl<W: Write> FileWriter<BufWriter<W>> {
@@ -1308,7 +1318,7 @@ impl<W: Write> FileWriter<W> {
             dictionary_tracker,
             custom_metadata: HashMap::new(),
             data_gen,
-            compression_context: CompressionContext::default(),
+            compression_context: IpcWriteContext::default(),
         })
     }
 
@@ -1537,7 +1547,7 @@ pub struct StreamWriter<W> {
 
     data_gen: IpcDataGenerator,
 
-    compression_context: CompressionContext,
+    compression_context: IpcWriteContext,
 }
 
 impl<W: Write> StreamWriter<BufWriter<W>> {
@@ -1588,7 +1598,7 @@ impl<W: Write> StreamWriter<W> {
             finished: false,
             dictionary_tracker,
             data_gen,
-            compression_context: CompressionContext::default(),
+            compression_context: IpcWriteContext::default(),
         })
     }
 
@@ -1965,7 +1975,7 @@ fn write_array_data(
     sink: &mut IpcBodySink<'_>,
     offset: i64,
     compression_codec: Option<CompressionCodec>,
-    compression_context: &mut CompressionContext,
+    compression_context: &mut IpcWriteContext,
     write_options: &IpcWriteOptions,
 ) -> Result<i64, ArrowError> {
     let mut offset = offset;
@@ -2260,7 +2270,7 @@ fn encode_sink_buffer(
     sink: &mut IpcBodySink<'_>,
     offset: i64,
     compression_codec: Option<CompressionCodec>,
-    compression_context: &mut CompressionContext,
+    compression_context: &mut IpcWriteContext,
     alignment: u8,
 ) -> Result<i64, ArrowError> {
     let (encoded, len) = match compression_codec {
@@ -4454,7 +4464,7 @@ mod tests {
         let data_gen = IpcDataGenerator::default();
         let mut dictionary_tracker = DictionaryTracker::new(false);
         let writer_options = IpcWriteOptions::default();
-        let mut compression_ctx = CompressionContext::default();
+        let mut compression_ctx = IpcWriteContext::default();
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             "a",

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -732,7 +732,6 @@ impl IpcDataGenerator {
         let tail_pad = pad_to_alignment(alignment, offset as usize);
         let body_len = offset as usize + tail_pad;
 
-        // Build flatbuffer header using the reused builder in the context.
         let fbb = &mut compression_context.fbb;
 
         let compression = batch_compression_type.map(|batch_compression_type| {
@@ -817,7 +816,6 @@ impl IpcDataGenerator {
         let body_len = offset as usize + tail_pad;
         arrow_data.extend_from_slice(&PADDING[..tail_pad]);
 
-        // Build flatbuffer header using the reused builder in the context.
         let fbb = &mut compression_context.fbb;
 
         let compression = batch_compression_type.map(|batch_compression_type| {

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -556,15 +556,7 @@ impl IpcDataGenerator {
             write_options,
             compression_context,
         )?;
-        // by default, write_options.compression is None, this means no compression will be applied and the encoded buffers will just be references to the original array buffers, so we can calculate the total size of the body data by summing the sizes of the original buffers.
-        // avoiding the intermediate allocations & copys to new buffers.
-        let size = batch
-            .columns()
-            .iter()
-            .map(|c| c.get_array_memory_size())
-            .sum::<usize>();
-        println!("Total size of body data: {size}");
-        let mut arrow_data = Vec::with_capacity(size);
+        let mut arrow_data = std::mem::take(&mut compression_context.scratch);
         let (ipc_message, _, tail_pad) = self.record_batch_to_bytes(
             batch,
             write_options,
@@ -572,12 +564,6 @@ impl IpcDataGenerator {
             &mut IpcBodySink::Write(&mut arrow_data),
         )?;
         arrow_data.extend_from_slice(&PADDING[..tail_pad]);
-        println!(
-            "size of record batch buffers:{}\nsize of flatbuffer data :{}\nsize of array_data:{}",
-            size,
-            ipc_message.len(),
-            arrow_data.len()
-        );
         Ok((
             encoded_dictionaries,
             EncodedData {

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -556,7 +556,15 @@ impl IpcDataGenerator {
             write_options,
             compression_context,
         )?;
-        let mut arrow_data = Vec::new();
+        // by default, write_options.compression is None, this means no compression will be applied and the encoded buffers will just be references to the original array buffers, so we can calculate the total size of the body data by summing the sizes of the original buffers.
+        // avoiding the intermediate allocations & copys to new buffers.
+        let mut arrow_data = Vec::with_capacity(
+            batch
+                .columns()
+                .iter()
+                .map(|c| c.get_array_memory_size())
+                .sum::<usize>(),
+        );
         let (ipc_message, _, tail_pad) = self.record_batch_to_bytes(
             batch,
             write_options,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- works towards closing #10125

starting small 😄 

# Rationale for this change
The arrow-flight encode path was allocating intermediate Vecs to hold data that was immediately iterated and discarded. Replacing these with lazy iterators and inlining the one helper that existed only to loop removes allocations that served no purpose beyond bridging two adjacent lines of code.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
[commit [#1](https://github.com/apache/arrow-rs/pull/10137/changes/d02e29748e7d3502108d7fa92390c2b0c0d72d98)]
- Remove intermediate Vec allocations in encode path, replace these with `Impl<Iterator>`.
- Cache num_rows before split closure
- Remove queue_messages, inline call site, mark queue_message #[inline]

[commit [#2](https://github.com/apache/arrow-rs/pull/10137/changes/403004c08ec1ebeb83cd4009e7052868944e2005)]
-  pre-allocate the vector used to hold uncompressed data.
- - avoids build up of [64k,512k,4MB,12MB...]

[commit [#3](https://github.com/apache/arrow-rs/pull/10137/commits/3159ad395e6c5d40bd1a4f3f8a07a87fded7213c)]
-  Renamed `CompressionContext` to `IpcWriteContext` and added an `fbb: FlatBufferBuilder<'static>` field to it
- This avoids repeated heap allocations by reusing the same FlatBufferBuilder across writes, using its [reset()](https://docs.rs/flatbuffers/latest/flatbuffers/struct.FlatBufferBuilder.html#method.reset) method to clear state without deallocating

[commit [#4](http://github.com/apache/arrow-rs/pull/10137/commits/337abd5e94c882fea06aee145a5c45a8b85b01ca)]
- `IpcWriteContext` gains a scratch: `Vec<u8>` field. When set before a call to `IpcDataGenerator::encode()`, the existing allocation is reused instead of allocating a fresh buffer for each batch's arrow data body.
- arrow-flight's `FlightIpcEncoder` maintains an `ArrowDataPool`, a small pool of Arc<Mutex<Vec<Vec<u8>>>> buffers pre-sized to the gRPC message limit (2 MiB). Before each `encode()` call, a buffer is acquired from the pool and placed in `IpcWriteContext::scratch`. After encoding, the buffer is wrapped in `PooledBuf` and handed to [Bytes::from_owner](https://docs.rs/bytes/latest/bytes/struct.Bytes.html#method.from_owner); when the Bytes is dropped (after the gRPC frame is sent), the buffer is automatically returned to the pool rather than freed.

[commit #5 & 6]
- tuning the buffer pool, updated the `acquire` method to also pre-allocate 2MB of space in the vector
- keep scratch buffer across multiple `ipc::encode()` calls. the buffers are pre-allocated to the `max_flight_data_size` as an estimate. This means no intermediate vector copies to larger vectors

commit [ #7] **final commit**
 - remove buffer pool. This was actually causing more overhead then letting the memory allocation handle pooling memory. 
 - replaced `arrow-ipc::encode()` sink from `IpcBodySink::Write()` to `IpcBodySink::collect()`
 - ideally all RecordBatch buffers are written in O(1) time with no need to re-allocate and `memcpy` to new vectors.
 - - [extend_from_slice](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.extend_from_slice) boils down to a very fast `memcpy`. **this is also why the profile shows alot of memcpy or _platform_memmove on mac**. 
 - - [All buffers are written at once](https://github.com/apache/arrow-rs/pull/10137/changes/37c72319592a9fc9649e1409f33f6b41838dd022#diff-e063d8ae2302328512f4cb22fc378f2903f88a250d64d270075f4892d62a2b60R576) into a pre-sized destination, which improves branch prediction and allows the CPU to use SIMD for the copy.

### output buffer size changes
This PR also changes the size of buffers being output by `split_batch_for_grpc_response()`
The **old** algorithm computed n_batches first via ceiling division, then derived rows_per_batch from that:
```
n_batches    = ceil(size / max)
rows_per_batch = num_rows / n_batches
```
This evenly distributes rows across chunks, meaning each buffer ends up smaller than max on average. Thus leaving capacity unused.

The **new** algorithm works directly from the target size:
```
rows_per_batch = max * num_rows / size
```
This packs each buffer as close to max as possible before moving on.

This matters because the output buffers are pre-allocated to max_flight_data_size. Since the allocation cost is already paid upfront, the only cost of filling a buffer is the memcpy itself. As the profiles show, most time is spent serializing RecordBatches to IPC format, doing that for as many rows as possible in one pass, followed by a single large memcpy, is faster than multiple smaller serializations and copies. Leaving pre-allocated capacity unused means splitting work across more messages than necessary, each carrying its own network and serialization overhead.

**note**: I expect to have to tune this a bit. this is because the size that is used to determine the total size of the record batch isn't exact. strings vary from row to row, so its hard to get the math 100% correct. but the closer we can get to the max_size the better

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
