### PR TITLE
[Variant] add doc reference to `VariantArrayBuilder`

### DIFF
--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -37,6 +37,14 @@ use std::sync::Arc;
 /// This builder always creates a `VariantArray` using [`BinaryViewArray`] for both
 /// the metadata and value fields.
 ///
+/// `VariantArrayBuilder` implements [`VariantBuilderExt`], so you append values
+/// and nested objects or lists the same way as when building a single
+/// [`Variant`] value with [`VariantBuilder`], rather than constructing a
+/// `VariantBuilder` per row.
+///
+/// [`VariantBuilder`]: parquet_variant::VariantBuilder
+/// [`VariantBuilderExt`]: parquet_variant::VariantBuilderExt
+///
 /// # TODO
 /// 1. Support shredding: <https://github.com/apache/arrow-rs/issues/7895>
 ///

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -480,20 +480,8 @@ impl<S: BuilderSpecificState> Drop for ParentState<'_, S> {
 /// `VariantBuilder` builds a single, self-contained [`Variant`] value -- useful
 /// for one-off values and unit tests. To build an array (column) of variants,
 /// one per input row, use [`VariantArrayBuilder`] from the
-/// `parquet-variant-compute` crate rather than a `VariantBuilder` per row. It
-/// implements [`VariantBuilderExt`], so you append values and nested objects or
-/// lists the same way:
+/// `parquet-variant-compute` crate rather than a `VariantBuilder` per row.
 ///
-/// ```ignore
-/// // build each row directly on the array builder; no per-row VariantBuilder
-/// let mut builder = VariantArrayBuilder::new(num_rows);
-/// for row in rows {
-///     builder.new_object().with_field("id", row.id).finish();
-/// }
-/// let variant_array = builder.build();
-/// ```
-///
-/// [`VariantBuilderExt`]: crate::VariantBuilderExt
 /// [`VariantArrayBuilder`]: https://docs.rs/parquet-variant-compute/latest/parquet_variant_compute/struct.VariantArrayBuilder.html
 ///
 /// # Example: create a Primitive Int8

--- a/parquet-variant/src/builder.rs
+++ b/parquet-variant/src/builder.rs
@@ -477,6 +477,25 @@ impl<S: BuilderSpecificState> Drop for ParentState<'_, S> {
 
 /// Top level builder for [`Variant`] values
 ///
+/// `VariantBuilder` builds a single, self-contained [`Variant`] value -- useful
+/// for one-off values and unit tests. To build an array (column) of variants,
+/// one per input row, use [`VariantArrayBuilder`] from the
+/// `parquet-variant-compute` crate rather than a `VariantBuilder` per row. It
+/// implements [`VariantBuilderExt`], so you append values and nested objects or
+/// lists the same way:
+///
+/// ```ignore
+/// // build each row directly on the array builder; no per-row VariantBuilder
+/// let mut builder = VariantArrayBuilder::new(num_rows);
+/// for row in rows {
+///     builder.new_object().with_field("id", row.id).finish();
+/// }
+/// let variant_array = builder.build();
+/// ```
+///
+/// [`VariantBuilderExt`]: crate::VariantBuilderExt
+/// [`VariantArrayBuilder`]: https://docs.rs/parquet-variant-compute/latest/parquet_variant_compute/struct.VariantArrayBuilder.html
+///
 /// # Example: create a Primitive Int8
 /// ```
 /// # use parquet_variant::{Variant, VariantBuilder};


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9113.

# Rationale for this change

Users might go for `VariantBuilder` to manually build `VariantArray`s.

Instead they should use `VariantArrayBuilder`.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- adds an example and a doc reference to `VariantArrayBuilder` for `VariantBuilder`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

n/a
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?

doc change
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
