### PR TITLE
nit: pyarrow: simplify class validation error creation

### DIFF
--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -724,20 +724,20 @@ def test_reject_other_classes():
     # Arbitrary type that is not a PyArrow type
     not_pyarrow = ["hello"]
 
-    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.Array, got builtins.list"):
+    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.Array, got list"):
         rust.round_trip_array(not_pyarrow)
 
-    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.Schema, got builtins.list"):
+    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.Schema, got list"):
         rust.round_trip_schema(not_pyarrow)
 
-    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.Field, got builtins.list"):
+    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.Field, got list"):
         rust.round_trip_field(not_pyarrow)
 
-    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.DataType, got builtins.list"):
+    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.DataType, got list"):
         rust.round_trip_type(not_pyarrow)
 
-    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.RecordBatch, got builtins.list"):
+    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.RecordBatch, got list"):
         rust.round_trip_record_batch(not_pyarrow)
 
-    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.RecordBatchReader, got builtins.list"):
+    with pytest.raises(TypeError, match="Expected instance of pyarrow.lib.RecordBatchReader, got list"):
         rust.round_trip_record_batch_reader(not_pyarrow)

--- a/arrow-pyarrow/src/lib.rs
+++ b/arrow-pyarrow/src/lib.rs
@@ -119,13 +119,10 @@ impl<T: ToPyArrow> IntoPyArrow for T {
 
 fn validate_class(expected: &Bound<PyType>, value: &Bound<PyAny>) -> PyResult<()> {
     if !value.is_instance(expected)? {
-        let expected_module = expected.getattr("__module__")?;
-        let expected_name = expected.getattr("__name__")?;
-        let found_class = value.get_type();
-        let found_module = found_class.getattr("__module__")?;
-        let found_name = found_class.getattr("__name__")?;
         return Err(PyTypeError::new_err(format!(
-            "Expected instance of {expected_module}.{expected_name}, got {found_module}.{found_name}",
+            "Expected instance of {}, got {}",
+            expected.fully_qualified_name()?,
+            value.get_type().fully_qualified_name()?
         )));
     }
     Ok(())


### PR DESCRIPTION
`fully_qualified_name` returns the fully qualified name of the type like `pyarrow.Table`. Hence, there should not be any visible change