### PR TITLE
chore: Fix clippy::useless_borrows_in_formatting

### DIFF
--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -1313,7 +1313,7 @@ impl Interval {
                     .map_err(|_| {
                         ArrowError::ParseError(format!(
                             "Unable to represent {} centuries as months in a signed 32-bit integer",
-                            &amount.integer
+                            amount.integer
                         ))
                     })?;
 
@@ -1329,7 +1329,7 @@ impl Interval {
                     .map_err(|_| {
                         ArrowError::ParseError(format!(
                             "Unable to represent {} decades as months in a signed 32-bit integer",
-                            &amount.integer
+                            amount.integer
                         ))
                     })?;
 
@@ -1344,7 +1344,7 @@ impl Interval {
                     .map_err(|_| {
                         ArrowError::ParseError(format!(
                             "Unable to represent {} years as months in a signed 32-bit integer",
-                            &amount.integer
+                            amount.integer
                         ))
                     })?;
 
@@ -1354,7 +1354,7 @@ impl Interval {
                 let months = amount.integer.try_into().map_err(|_| {
                     ArrowError::ParseError(format!(
                         "Unable to represent {} months in a signed 32-bit integer",
-                        &amount.integer
+                        amount.integer
                     ))
                 })?;
 
@@ -1376,7 +1376,7 @@ impl Interval {
                 let days = amount.integer.mul_checked(7)?.try_into().map_err(|_| {
                     ArrowError::ParseError(format!(
                         "Unable to represent {} weeks as days in a signed 32-bit integer",
-                        &amount.integer
+                        amount.integer
                     ))
                 })?;
 

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1052,7 +1052,7 @@ impl RowConverter {
                 if !row.is_empty() {
                     return Err(ArrowError::InvalidArgumentError(format!(
                         "Codecs {codecs:?} did not consume all bytes for row {i}, remaining bytes: {row:?}",
-                        codecs = &self.codecs
+                        codecs = self.codecs
                     )));
                 }
             }

--- a/arrow-schema/src/error.rs
+++ b/arrow-schema/src/error.rs
@@ -101,9 +101,9 @@ impl Display for ArrowError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ArrowError::NotYetImplemented(source) => {
-                write!(f, "Not yet implemented: {}", &source)
+                write!(f, "Not yet implemented: {source}")
             }
-            ArrowError::ExternalError(source) => write!(f, "External error: {}", &source),
+            ArrowError::ExternalError(source) => write!(f, "External error: {source}"),
             ArrowError::CastError(desc) => write!(f, "Cast error: {desc}"),
             ArrowError::MemoryError(desc) => write!(f, "Memory error: {desc}"),
             ArrowError::ParseError(desc) => write!(f, "Parser error: {desc}"),

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -82,7 +82,7 @@ pub fn print_file_metadata(out: &mut dyn io::Write, file_metadata: &FileMetaData
             writeln!(
                 out,
                 "  {}: {}",
-                &kv.key,
+                kv.key,
                 kv.value.as_ref().unwrap_or(&"".to_owned())
             );
         }
@@ -468,7 +468,7 @@ mod tests {
             let mut p = Printer::new(&mut s);
             p.print(&message);
         }
-        println!("{}", &s);
+        println!("{s}");
         let parsed = parse_message_type(&s).unwrap();
         assert_eq!(message, parsed);
     }


### PR DESCRIPTION
Automated `clippy --fix` of the `clippy::useless_borrows_in_formatting` lint