### PR TITLE
chore: specify `--locked` when cargo installing `cargo-audit`

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -38,6 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        run: cargo install cargo-audit --locked
       - name: Run audit check
         run: cargo audit


### PR DESCRIPTION
same as we do elsewhere

https://github.com/apache/arrow-rs/blob/c8eba1a0b9e6c307109c9f69ac2aae728b4c8cd9/.github/workflows/miri.yaml#L63

https://github.com/apache/arrow-rs/blob/c8eba1a0b9e6c307109c9f69ac2aae728b4c8cd9/.github/workflows/rust.yml#L121-L123

- see reasoning in this comment; we're not failing right now, but its good to prevent any future issues