### PR TITLE
Return PyValueError for nullable PyArrow struct imports

### DIFF
--- a/arrow-pyarrow-testing/tests/pyarrow.rs
+++ b/arrow-pyarrow-testing/tests/pyarrow.rs
@@ -42,9 +42,9 @@ use arrow_array::{
     Array, ArrayRef, BinaryViewArray, Int32Array, RecordBatch, StringArray, StringViewArray,
 };
 use arrow_pyarrow::{FromPyArrow, ToPyArrow};
-use pyo3::exceptions::PyTypeError;
-use pyo3::types::{PyAnyMethods, PyModule};
 use pyo3::Python;
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::types::{PyAnyMethods, PyModule};
 use std::ffi::CString;
 use std::sync::Arc;
 
@@ -121,6 +121,35 @@ value = NotATuple()
         assert_eq!(
             err.to_string(),
             "TypeError: Expected __arrow_c_array__ to return a tuple of (schema, array) capsules."
+        );
+    });
+}
+
+#[test]
+fn test_from_pyarrow_nullable_struct_array() {
+    Python::initialize();
+
+    Python::attach(|py| {
+        let code = CString::new(
+            r#"
+import pyarrow as pa
+
+value = pa.array(
+    [{"a": 1}, None],
+    type=pa.struct([pa.field("a", pa.int32())]),
+)
+"#,
+        )
+        .unwrap();
+
+        let module = PyModule::from_code(py, code.as_c_str(), c"test.py", c"test_module").unwrap();
+        let value = module.getattr("value").unwrap();
+
+        let err = RecordBatch::from_pyarrow_bound(&value).unwrap_err();
+        assert!(err.is_instance_of::<PyValueError>(py));
+        assert_eq!(
+            err.to_string(),
+            "ValueError: Cannot convert nullable StructArray to RecordBatch, see StructArray documentation"
         );
     });
 }

--- a/arrow-pyarrow/src/lib.rs
+++ b/arrow-pyarrow/src/lib.rs
@@ -369,11 +369,11 @@ impl FromPyArrow for RecordBatch {
             let schema =
                 unsafe { Arc::new(Schema::try_from(schema_ptr.as_ref()).map_err(to_py_err)?) };
             let (_fields, columns, nulls) = array.into_parts();
-            assert_eq!(
-                nulls.map(|n| n.null_count()).unwrap_or_default(),
-                0,
-                "Cannot convert nullable StructArray to RecordBatch, see StructArray documentation"
-            );
+            if nulls.map(|n| n.null_count()).unwrap_or_default() != 0 {
+                return Err(PyValueError::new_err(
+                    "Cannot convert nullable StructArray to RecordBatch, see StructArray documentation",
+                ));
+            }
             return RecordBatch::try_new_with_options(schema, columns, &options).map_err(to_py_err);
         }
 


### PR DESCRIPTION
### What changed

`RecordBatch::from_pyarrow_bound` now returns a `PyValueError` when a PyArrow C array capsule contains a nullable top-level `StructArray`, instead of panicking via an internal assertion.

A regression test covers importing a nullable PyArrow struct array through the capsule path.

### Why

This conversion handles external Python input, so unsupported nullable struct arrays should surface as Python exceptions rather than aborting through a Rust panic.

### Validation

- `cargo fmt --package arrow-pyarrow`
- `cargo fmt --manifest-path arrow-pyarrow-testing/Cargo.toml`
- `cargo test --manifest-path arrow-pyarrow-testing/Cargo.toml test_from_pyarrow_nullable_struct_array`