### PR TITLE
test: cover signed integers and bool in BitReader::get_batch test

### DIFF
--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -1223,11 +1223,30 @@ mod tests {
         const SIZE: &[usize] = &[1, 31, 32, 33, 128, 129];
         for s in SIZE {
             for i in 0..=64 {
+                // `get_batch` is generic over all of these types, so exercise the
+                // signed integer types and `bool` alongside the unsigned types rather
+                // than relying on the unsigned coverage alone.
                 match i {
-                    0..=8 => test_get_batch_helper::<u8>(*s, i),
-                    9..=16 => test_get_batch_helper::<u16>(*s, i),
-                    17..=32 => test_get_batch_helper::<u32>(*s, i),
-                    _ => test_get_batch_helper::<u64>(*s, i),
+                    0..=8 => {
+                        test_get_batch_helper::<u8>(*s, i);
+                        test_get_batch_helper::<i8>(*s, i);
+                    }
+                    9..=16 => {
+                        test_get_batch_helper::<u16>(*s, i);
+                        test_get_batch_helper::<i16>(*s, i);
+                    }
+                    17..=32 => {
+                        test_get_batch_helper::<u32>(*s, i);
+                        test_get_batch_helper::<i32>(*s, i);
+                    }
+                    _ => {
+                        test_get_batch_helper::<u64>(*s, i);
+                        test_get_batch_helper::<i64>(*s, i);
+                    }
+                }
+                // `bool` only supports a bit width of 1.
+                if i == 1 {
+                    test_get_batch_helper::<bool>(*s, i);
                 }
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

- related to https://github.com/apache/arrow-rs/pull/10172#pullrequestreview-4547106475

# Rationale for this change

`test_get_batch` in `parquet/src/util/bit_util.rs` only exercised the unsigned
types (`u8`/`u16`/`u32`/`u64`). `BitReader::get_batch` is also generic over the
signed integer types (`i8`/`i16`/`i32`/`i64`) and `bool`, each with its own
`FromBitpacked` implementation, but none of those were covered by the test.


# What changes are included in this PR?

Extend `test_get_batch` to also run the signed counterpart of each width and
`bool` (at its only supported bit width of 1), reusing the existing
`test_get_batch_helper`.

# Are these changes tested?

it is all testes

# Are there any user-facing changes?

No.