### PR TITLE
chore: group minor/patch dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,17 @@ updates:
         applies-to: version-updates
         patterns:
           - "tonic*"
+      all-other-cargo-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "prost*"
+          - "tonic*"
+          - "object_store"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
similar to what datafusion did

- https://github.com/apache/datafusion/pull/20457

i recently kicked off dependabot job for cargo updates (not sure why it wasn't running before) and it spammed PRs before hitting the limit; grouping them should make it more manageable