### PR TITLE
Fix `merge_kernels` benchmark panic due to not wrapping with `Scalar`

### DIFF
--- a/arrow/benches/merge_kernels.rs
+++ b/arrow/benches/merge_kernels.rs
@@ -188,14 +188,14 @@ fn bench_merge_on_input_generator(c: &mut Criterion, input_generator: &impl Inpu
         &mut group,
         &masks,
         &array_1_10pct_nulls,
-        &non_null_scalar_1,
+        &Scalar::new(non_null_scalar_1.clone()),
     );
 
     bench_merge_input_on_all_masks(
         "non_null_scalar_vs_array",
         &mut group,
         &masks,
-        &non_null_scalar_1,
+        &Scalar::new(non_null_scalar_1.clone()),
         &array_1_10pct_nulls,
     );
 


### PR DESCRIPTION
as identified by

- https://github.com/apache/arrow-rs/pull/9975

this benchmark was panicking when run, because it was passing a 1-len array as an `ArrayRef` instead of a `Scalar` and thus indexing the 2nd/3rd element was causing out of bounds panic; when wrapped in `Scalar` the single element will be repeated so it wouldn't index out of bounds it would just get the first element