### PR TITLE
Update quinn-proto to fix cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10200

# Rationale for this change

`cargo audit` currently fails because `Cargo.lock` pins `quinn-proto` to `0.11.14`, which is affected by RUSTSEC-2026-0185:

> Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly

The advisory recommends upgrading to `quinn-proto >=0.11.15`.

# What changes are included in this PR?

This PR updates the locked `quinn-proto` dependency from `0.11.14` to `0.11.15`.

# Are these changes tested?

Yes. I ran:

```shell
cargo audit
```

It now completes successfully, reporting only the two existing allowed warnings for `paste` and `memmap2`.

# Are there any user-facing changes?

No. This is a lockfile-only dependency update.
