### PR TITLE
[10125] Introduce mult-batch decode benchmarks

### DIFF
--- a/arrow-flight/benches/flight.rs
+++ b/arrow-flight/benches/flight.rs
@@ -30,6 +30,7 @@ use common::{DICT_TYPES, TYPES, build_batch, start_server};
 
 const ROWS: [usize; 2] = [8 * 1024, 64 * 1024];
 const COLS: [usize; 3] = [1, 4, 8];
+const BATCHES: usize = 4;
 
 fn bench_encode(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
@@ -74,16 +75,22 @@ fn bench_decode(c: &mut Criterion) {
     for &(name, build) in TYPES {
         for &rows in &ROWS {
             for &cols in &COLS {
-                let batch = build_batch(name, rows, cols, build);
+                let batches: Vec<RecordBatch> = (0..BATCHES)
+                    .map(|_| build_batch(name, rows, cols, build))
+                    .collect();
+                let total_bytes: u64 = batches
+                    .iter()
+                    .map(|b| b.get_array_memory_size() as u64)
+                    .sum();
                 let frames: Vec<FlightData> = rt
                     .block_on(
                         FlightDataEncoderBuilder::new()
-                            .build(futures::stream::iter([Ok(batch.clone())]))
+                            .build(futures::stream::iter(batches.into_iter().map(Ok)))
                             .try_collect(),
                     )
                     .unwrap();
                 let id = BenchmarkId::new(name, format!("{rows}x{cols}"));
-                g.throughput(Throughput::Bytes(batch.get_array_memory_size() as u64));
+                g.throughput(Throughput::Bytes(total_bytes));
                 g.bench_function(id, |b| {
                     b.to_async(&rt).iter_batched(
                         || frames.clone(),
@@ -118,6 +125,52 @@ fn bench_roundtrip(c: &mut Criterion) {
                 g.bench_with_input(id, &batch, |b, batch| {
                     b.to_async(&rt)
                         .iter(|| roundtrip(channel.clone(), batch.clone()));
+                });
+            }
+        }
+    }
+}
+
+/// Decode a multi-batch stream covering both plain and dictionary types.
+/// Uses [`DictionaryHandling::Resend`] to exercise the replacement-dictionary path.
+fn bench_decode_stream(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut g = c.benchmark_group("decode_stream");
+
+    for &(name, build) in TYPES.iter().chain(DICT_TYPES) {
+        for &rows in &ROWS {
+            for &cols in &COLS {
+                let batches: Vec<RecordBatch> = (0..BATCHES)
+                    .map(|_| build_batch(name, rows, cols, build))
+                    .collect();
+                let total_bytes: u64 = batches
+                    .iter()
+                    .map(|b| b.get_array_memory_size() as u64)
+                    .sum();
+                let frames: Vec<FlightData> = rt
+                    .block_on(
+                        FlightDataEncoderBuilder::new()
+                            .with_dictionary_handling(DictionaryHandling::Resend)
+                            .build(futures::stream::iter(batches.into_iter().map(Ok)))
+                            .try_collect(),
+                    )
+                    .unwrap();
+                let id = BenchmarkId::new(name, format!("{rows}x{cols}x{BATCHES}"));
+                g.throughput(Throughput::Bytes(total_bytes));
+                g.bench_function(id, |b| {
+                    b.to_async(&rt).iter_batched(
+                        || frames.clone(),
+                        |frames| async move {
+                            let _: Vec<RecordBatch> =
+                                FlightRecordBatchStream::new_from_flight_data(
+                                    futures::stream::iter(frames.into_iter().map(Ok)),
+                                )
+                                .try_collect()
+                                .await
+                                .unwrap();
+                        },
+                        criterion::BatchSize::SmallInput,
+                    );
                 });
             }
         }
@@ -173,6 +226,7 @@ criterion_group!(
     benches,
     bench_encode,
     bench_decode,
+    bench_decode_stream,
     bench_roundtrip,
     bench_do_put_dictionary
 );

--- a/arrow-flight/benches/flight.rs
+++ b/arrow-flight/benches/flight.rs
@@ -133,7 +133,7 @@ fn bench_roundtrip(c: &mut Criterion) {
 
 /// Decode a multi-batch stream covering both plain and dictionary types.
 /// Uses [`DictionaryHandling::Resend`] to exercise the replacement-dictionary path.
-fn bench_decode_stream(c: &mut Criterion) {
+fn bench_decode_dictionary_stream(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let mut g = c.benchmark_group("decode_stream");
 
@@ -226,7 +226,7 @@ criterion_group!(
     benches,
     bench_encode,
     bench_decode,
-    bench_decode_stream,
+    bench_decode_dictionary_stream,
     bench_roundtrip,
     bench_do_put_dictionary
 );


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

Follow up of  https://github.com/apache/arrow-rs/pull/10202 , see [comment](https://github.com/apache/arrow-rs/pull/10202#discussion_r3462450393)
works towards #10125 

# Rationale for this change
this provides more visibility to performances changes that occurs on the decode path. Multi batch decoding is more representative of real world work loads.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Added multi-batch decode benchmarks covering both plain and dictionary types, including the replacement-dictionary path,
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
n/a
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
no