### PR TITLE
chore: Fix clippy::byte_char_slices (use byte strings instead of explicit arrays)

### DIFF
--- a/arrow-array/src/array/binary_array.rs
+++ b/arrow-array/src/array/binary_array.rs
@@ -219,9 +219,7 @@ mod tests {
 
     #[test]
     fn test_binary_array() {
-        let values: [u8; 12] = [
-            b'h', b'e', b'l', b'l', b'o', b'p', b'a', b'r', b'q', b'u', b'e', b't',
-        ];
+        let values = b"helloparquet";
         let offsets: [i32; 4] = [0, 5, 5, 12];
 
         // Array data: ["hello", "", "parquet"]
@@ -257,9 +255,7 @@ mod tests {
 
     #[test]
     fn test_binary_array_with_offsets() {
-        let values: [u8; 12] = [
-            b'h', b'e', b'l', b'l', b'o', b'p', b'a', b'r', b'q', b'u', b'e', b't',
-        ];
+        let values = b"helloparquet";
         let offsets: [i32; 4] = [0, 5, 5, 12];
 
         // Test binary array with offset
@@ -283,9 +279,7 @@ mod tests {
 
     #[test]
     fn test_large_binary_array() {
-        let values: [u8; 12] = [
-            b'h', b'e', b'l', b'l', b'o', b'p', b'a', b'r', b'q', b'u', b'e', b't',
-        ];
+        let values = b"helloparquet";
         let offsets: [i64; 4] = [0, 5, 5, 12];
 
         // Array data: ["hello", "", "parquet"]
@@ -321,9 +315,7 @@ mod tests {
 
     #[test]
     fn test_large_binary_array_with_offsets() {
-        let values: [u8; 12] = [
-            b'h', b'e', b'l', b'l', b'o', b'p', b'a', b'r', b'q', b'u', b'e', b't',
-        ];
+        let values = b"helloparquet";
         let offsets: [i64; 4] = [0, 5, 5, 12];
 
         // Test binary array with offset

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -830,11 +830,11 @@ mod tests {
 
     #[test]
     fn test_fixed_size_binary_array() {
-        let values: [u8; 15] = *b"hellotherearrow";
+        let values = b"hellotherearrow";
 
         let array_data = ArrayData::builder(DataType::FixedSizeBinary(5))
             .len(3)
-            .add_buffer(Buffer::from(&values))
+            .add_buffer(Buffer::from(values))
             .build()
             .unwrap();
         let fixed_size_binary_array = FixedSizeBinaryArray::from(array_data);
@@ -862,7 +862,7 @@ mod tests {
         let array_data = ArrayData::builder(DataType::FixedSizeBinary(5))
             .len(2)
             .offset(1)
-            .add_buffer(Buffer::from(&values))
+            .add_buffer(Buffer::from(values))
             .build()
             .unwrap();
         let fixed_size_binary_array = FixedSizeBinaryArray::from(array_data);
@@ -963,11 +963,11 @@ mod tests {
 
     #[test]
     fn test_fixed_size_binary_array_fmt_debug() {
-        let values: [u8; 15] = *b"hellotherearrow";
+        let values = b"hellotherearrow";
 
         let array_data = ArrayData::builder(DataType::FixedSizeBinary(5))
             .len(3)
-            .add_buffer(Buffer::from(&values))
+            .add_buffer(Buffer::from(values))
             .build()
             .unwrap();
         let arr = FixedSizeBinaryArray::from(array_data);

--- a/arrow-array/src/array/string_array.rs
+++ b/arrow-array/src/array/string_array.rs
@@ -257,9 +257,7 @@ mod tests {
         expected = "Trying to access an element at index 4 from a StringArray of length 3"
     )]
     fn test_string_array_get_value_index_out_of_bound() {
-        let values: [u8; 12] = [
-            b'h', b'e', b'l', b'l', b'o', b'p', b'a', b'r', b'q', b'u', b'e', b't',
-        ];
+        let values = b"helloparquet";
         let offsets: [i32; 4] = [0, 5, 5, 12];
         let array_data = ArrayData::builder(DataType::Utf8)
             .len(3)

--- a/arrow-ipc/src/lib.rs
+++ b/arrow-ipc/src/lib.rs
@@ -69,7 +69,7 @@ pub use self::r#gen::Schema::*;
 pub use self::r#gen::SparseTensor::*;
 pub use self::r#gen::Tensor::*;
 
-const ARROW_MAGIC: [u8; 6] = [b'A', b'R', b'R', b'O', b'W', b'1'];
+const ARROW_MAGIC: [u8; 6] = *b"ARROW1";
 const CONTINUATION_MARKER: [u8; 4] = [0xff; 4];
 
 impl Endianness {

--- a/arrow-string/src/substring.rs
+++ b/arrow-string/src/substring.rs
@@ -654,7 +654,7 @@ mod tests {
 
     #[test]
     fn fixed_size_binary_with_non_zero_offset() {
-        let values: [u8; 15] = *b"hellotherearrow";
+        let values = b"hellotherearrow";
         // set the first and third element to be valid
         let bits_v = [0b101_u8];
 
@@ -664,7 +664,7 @@ mod tests {
             3,
         )));
         // array is `[null, "arrow"]`
-        let array = FixedSizeBinaryArray::new(5, Buffer::from(&values), nulls).slice(1, 2);
+        let array = FixedSizeBinaryArray::new(5, Buffer::from(values), nulls).slice(1, 2);
         // result is `[null, "rrow"]`
         let result = substring(&array, 1, None).unwrap();
         let result = result

--- a/arrow/examples/builders.rs
+++ b/arrow/examples/builders.rs
@@ -68,15 +68,13 @@ fn main() {
     // is a slice of an underlying buffer.
 
     // Array data: ["hello", null, "parquet"]
-    let values: [u8; 12] = [
-        b'h', b'e', b'l', b'l', b'o', b'p', b'a', b'r', b'q', b'u', b'e', b't',
-    ];
+    let values = b"helloparquet";
     let offsets: [i32; 4] = [0, 5, 5, 12];
 
     let array_data = ArrayData::builder(DataType::Utf8)
         .len(3)
         .add_buffer(Buffer::from(offsets.to_byte_slice()))
-        .add_buffer(Buffer::from(&values))
+        .add_buffer(Buffer::from(values))
         .null_bit_buffer(Some(Buffer::from([0b00000101])))
         .build()
         .unwrap();

--- a/arrow/tests/array_validation.rs
+++ b/arrow/tests/array_validation.rs
@@ -561,7 +561,7 @@ fn test_validate_large_utf8_char_boundary() {
 
 /// Test that the array of type `data_type` that has invalid indexes (out of bounds)
 fn check_index_out_of_bounds_validation<T: ArrowNativeType>(data_type: DataType) {
-    let data_buffer = Buffer::from_slice_ref([b'a', b'b', b'c', b'd']);
+    let data_buffer = Buffer::from_slice_ref(b"abcd");
     // First two offsets are fine, then 5 is out of bounds
     let offsets: Vec<T> = [0, 1, 2, 5, 2]
         .iter()
@@ -606,7 +606,7 @@ fn test_validate_large_binary_out_of_bounds() {
 
 // validate that indexes don't go bacwards check indexes that go backwards
 fn check_index_backwards_validation<T: ArrowNativeType>(data_type: DataType) {
-    let data_buffer = Buffer::from_slice_ref([b'a', b'b', b'c', b'd']);
+    let data_buffer = Buffer::from_slice_ref(b"abcd");
     // First three offsets are fine, then 1 goes backwards
     let offsets: Vec<T> = [0, 1, 2, 2, 1]
         .iter()

--- a/parquet-variant/src/decoder.rs
+++ b/parquet-variant/src/decoder.rs
@@ -587,15 +587,15 @@ mod tests {
 
     #[test]
     fn test_short_string_exact_length() {
-        let data = [b'H', b'e', b'l', b'l', b'o', b'o'];
-        let result = decode_short_string(1 | 5 << 2, &data).unwrap();
+        let data = b"Helloo";
+        let result = decode_short_string(1 | 5 << 2, data).unwrap();
         assert_eq!(result.0, "Hello");
     }
 
     #[test]
     fn test_short_string_truncated_length() {
-        let data = [b'H', b'e', b'l'];
-        let result = decode_short_string(1 | 5 << 2, &data);
+        let data = b"Hel";
+        let result = decode_short_string(1 | 5 << 2, data);
         assert!(matches!(result, Err(ArrowError::InvalidArgumentError(_))));
     }
 

--- a/parquet/src/file/mod.rs
+++ b/parquet/src/file/mod.rs
@@ -109,5 +109,5 @@ pub mod writer;
 
 /// The length of the parquet footer in bytes
 pub const FOOTER_SIZE: usize = 8;
-const PARQUET_MAGIC: [u8; 4] = [b'P', b'A', b'R', b'1'];
-const PARQUET_MAGIC_ENCR_FOOTER: [u8; 4] = [b'P', b'A', b'R', b'E'];
+const PARQUET_MAGIC: [u8; 4] = *b"PAR1";
+const PARQUET_MAGIC_ENCR_FOOTER: [u8; 4] = *b"PARE";


### PR DESCRIPTION
This lint is now stricter in Rust nightly and trigger new warnings, this MR is fixing them before it's reaching stable
