### PR TITLE
fix: casting list to fixedsizelist didn't respect input length

### DIFF
--- a/arrow-cast/src/cast/list.rs
+++ b/arrow-cast/src/cast/list.rs
@@ -67,19 +67,6 @@ pub(crate) fn cast_values_to_list_view<O: OffsetSizeTrait>(
     Ok(Arc::new(list))
 }
 
-/// Same as [`cast_values_to_list`] but output fixed size list array with element
-/// size 1.
-pub(crate) fn cast_values_to_fixed_size_list(
-    array: &dyn Array,
-    to: &FieldRef,
-    size: i32,
-    cast_options: &CastOptions,
-) -> Result<ArrayRef, ArrowError> {
-    let values = cast_with_options(array, to.data_type(), cast_options)?;
-    let list = FixedSizeListArray::try_new(to.clone(), size, values, None)?;
-    Ok(Arc::new(list))
-}
-
 /// Cast fixed size list array to inner values type, essentially flattening the
 /// lists.
 ///
@@ -226,7 +213,14 @@ where
     // Cast the inner values if necessary
     let values = cast_with_options(values.as_ref(), field.data_type(), cast_options)?;
 
-    let array = FixedSizeListArray::try_new(field.clone(), size, values, null_builder.build())?;
+    let nulls = null_builder.build();
+    // Degenerate case where we may lose length information if there isn't a null
+    // buffer to infer length from
+    let array = if size == 0 && nulls.is_none() {
+        FixedSizeListArray::try_new_with_length(field.clone(), size, values, nulls, array.len())?
+    } else {
+        FixedSizeListArray::try_new(field.clone(), size, values, nulls)?
+    };
     Ok(Arc::new(array))
 }
 
@@ -277,7 +271,14 @@ pub(crate) fn cast_list_view_to_fixed_size_list<O: OffsetSizeTrait>(
     let values = make_array(mutable.freeze());
     let values = cast_with_options(values.as_ref(), field.data_type(), cast_options)?;
 
-    let array = FixedSizeListArray::try_new(field.clone(), size, values, null_builder.build())?;
+    let nulls = null_builder.build();
+    // Degenerate case where we may lose length information if there isn't a null
+    // buffer to infer length from
+    let array = if size == 0 && nulls.is_none() {
+        FixedSizeListArray::try_new_with_length(field.clone(), size, values, nulls, array.len())?
+    } else {
+        FixedSizeListArray::try_new(field.clone(), size, values, nulls)?
+    };
     Ok(Arc::new(array))
 }
 

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -938,7 +938,9 @@ pub fn cast_with_options(
         (_, ListView(to)) => cast_values_to_list_view::<i32>(array, to, cast_options),
         (_, LargeListView(to)) => cast_values_to_list_view::<i64>(array, to, cast_options),
         (_, FixedSizeList(to, size)) if *size == 1 => {
-            cast_values_to_fixed_size_list(array, to, *size, cast_options)
+            let values = cast_with_options(array, to.data_type(), cast_options)?;
+            let list = FixedSizeListArray::try_new(to.clone(), 1, values, None)?;
+            Ok(Arc::new(list))
         }
         // Map
         (Map(_, ordered1), Map(_, ordered2)) if ordered1 == ordered2 => {
@@ -9640,6 +9642,41 @@ mod tests {
         assert!(can_cast_types(input.data_type(), expected.data_type()));
         let actual = cast(&input, expected.data_type()).unwrap();
         assert_eq!(actual.as_ref(), &expected);
+    }
+
+    #[test]
+    fn test_cast_list_to_zero_size_fsl() {
+        let field = Arc::new(Field::new("a", DataType::Null, true));
+        let length = 2;
+        let expected = Arc::new(
+            FixedSizeListArray::try_new_with_length(
+                field.clone(),
+                0,
+                new_empty_array(&DataType::Null),
+                None,
+                2,
+            )
+            .unwrap(),
+        ) as ArrayRef;
+
+        let list = Arc::new(ListArray::new(
+            field.clone(),
+            OffsetBuffer::from_repeated_length(0, length),
+            new_empty_array(&DataType::Null),
+            None,
+        ));
+        let fsl = cast(list.as_ref(), expected.data_type()).unwrap();
+        assert_eq!(&expected, &fsl);
+
+        let list = Arc::new(ListViewArray::new(
+            field.clone(),
+            vec![0; length].into(),
+            vec![0; length].into(),
+            new_empty_array(&DataType::Null),
+            None,
+        ));
+        let fsl = cast(list.as_ref(), expected.data_type()).unwrap();
+        assert_eq!(&expected, &fsl);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10227

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

When casting from list[view] to degenerate fixedsizelist (0 size), if output has no nulls then it'll incorrectly output an array of length 0 which is mismatched with input array length. This can cause problems for downstream like DataFusion, since they expect input length = output length for cast kernel.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Special path for degenerate fixedsizelist cast if we don't have a null buffer to infer length from.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

Yes

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

No
