### PR TITLE
[WIP] fix: read `Dict(FixedSizeBinary)` from parquet without dict encoding

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2933,16 +2933,6 @@ mod tests {
             K::Native: FromPrimitive + ToPrimitive + TryFrom<u8>,
             <<K as arrow_array::ArrowPrimitiveType>::Native as TryFrom<u8>>::Error: std::fmt::Debug,
         {
-            let field = Field::new(
-                "a",
-                DataType::Dictionary(
-                    Box::new(K::DATA_TYPE),
-                    Box::new(DataType::FixedSizeBinary(4)),
-                ),
-                false,
-            );
-            let schema = Schema::new(vec![field]);
-
             let keys: Vec<K::Native> = vec![
                 K::Native::try_from(0u8).unwrap(),
                 K::Native::try_from(0u8).unwrap(),
@@ -2954,8 +2944,12 @@ mod tests {
             )
             .unwrap();
 
-            let data = DictionaryArray::<K>::new(keys, Arc::new(values));
-            let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(data)]).unwrap();
+            let data = Arc::new(DictionaryArray::<K>::new(keys, Arc::new(values))) as ArrayRef;
+            one_column_roundtrip(Arc::clone(&data), true);
+
+            let field = Field::new("a", data.data_type().clone(), false);
+            let schema = Schema::new(vec![field]);
+            let batch = RecordBatch::try_new(Arc::new(schema), vec![data]).unwrap();
             roundtrip(batch, None);
         }
 

--- a/parquet/src/arrow/buffer/dictionary_buffer.rs
+++ b/parquet/src/arrow/buffer/dictionary_buffer.rs
@@ -185,8 +185,18 @@ impl<K: ArrowNativeType + Ord, V: OffsetSizeTrait> DictionaryBuffer<K, V> {
                     ArrowType::Dictionary(k, v) => (k, v.as_ref().clone()),
                     _ => unreachable!(),
                 };
+                let array = if let ArrowType::FixedSizeBinary(size) = value_type {
+                    let array = values.into_array(null_buffer, ArrowType::Binary);
+                    let array = array.as_binary::<i32>();
+                    Arc::new(FixedSizeBinaryArray::new(
+                        size,
+                        array.values().clone(),
+                        array.nulls().cloned(),
+                    )) as _
+                } else {
+                    values.into_array(null_buffer, value_type)
+                };
 
-                let array = values.into_array(null_buffer, value_type);
                 pack_values(key_type, &array)
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9247

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

If a column `Dictionary(FixedSizeBinary)` was written to a parquet file, but with dictionary encoding turned off (so encoded only as `PLAIN`), then reading that file back into a `Dictionary(FixedSizeBinary)` lead to an unavoidable panic so roundtrip was not possible. Fixing this bug.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Coerce the binary values to fixedsizebinary when reading from non-dictionary encoded values to ensure array construction is respected.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

Yes, added new tests.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->


No.