### PR TITLE
chore: remove variant outdated Work In Progress comment

### DIFF
--- a/parquet-variant-compute/src/lib.rs
+++ b/parquet-variant-compute/src/lib.rs
@@ -28,16 +28,6 @@
 //! - [`variant_get()`]: Convert `VariantArray` (or an inner path) to a strongly-typed Arrow array.
 //! - [`shred_variant()`]: Shred a `VariantArray` according to the provided shredding schema
 //! - [`unshred_variant()`]: Unshred a `VariantArray` to pure binary variant.
-//!
-//! ## 🚧 Work In Progress
-//!
-//! This crate is under active development and is not yet ready for production use.
-//! If you are interested in helping, you can find more information on the GitHub [Variant issue]
-//!
-//! [Variant Binary Encoding]: https://github.com/apache/parquet-format/blob/master/VariantEncoding.md
-//! [Apache Parquet]: https://parquet.apache.org/
-//! [`VariantPath`]: parquet_variant::VariantPath
-//! [Variant issue]: https://github.com/apache/arrow-rs/issues/6736
 
 mod arrow_to_variant;
 mod cast_to_variant;

--- a/parquet-variant-json/src/lib.rs
+++ b/parquet-variant-json/src/lib.rs
@@ -23,13 +23,6 @@
 //!
 //! * See [`JsonToVariant`] trait for converting a JSON string to a Variant.
 //! * See [`VariantToJson`] trait for converting a Variant to a JSON string.
-//!
-//! ## 🚧 Work In Progress
-//!
-//! This crate is under active development and is not yet ready for production use.
-//! If you are interested in helping, you can find more information on the GitHub [Variant issue]
-//!
-//! [Variant issue]: https://github.com/apache/arrow-rs/issues/6736
 
 mod from_json;
 mod to_json;

--- a/parquet-variant/src/lib.rs
+++ b/parquet-variant/src/lib.rs
@@ -23,13 +23,6 @@
 //! ## Main APIs
 //! - [`Variant`]: Represents a variant value, which can be an object, list, or primitive.
 //! - [`VariantBuilder`]: For building `Variant` values.
-//!
-//! ## 🚧 Work In Progress
-//!
-//! This crate is under active development and is not yet ready for production use.
-//! If you are interested in helping, you can find more information on the GitHub [Variant issue]
-//!
-//! [Variant issue]: https://github.com/apache/arrow-rs/issues/6736
 
 mod builder;
 mod decoder;


### PR DESCRIPTION
# Which issue does this PR close?

No issue. A chore PR to remove some outdated comment.

# Rationale for this change

Variant epic https://github.com/apache/arrow-rs/issues/6736 is closed so we can remove the WIP comments.

# What changes are included in this PR?

Just removed some comments.

# Are these changes tested?

Yes.

# Are there any user-facing changes?

No.