### PR TITLE
fix: Rename parquet feature flag 'flate2-rust_backened' to 'flate2-rust_backend'

### DIFF
--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -117,8 +117,8 @@ jobs:
         run: cargo check -p parquet --no-default-features --features encryption --features async
       - name: Check compilation --no-default-features --features flate2, this is expected to fail
         run: if `cargo check -p parquet --no-default-features --features flate2 2>/dev/null`; then false; else true; fi
-      - name: Check compilation --no-default-features --features flate2 --features flate2-rust_backened
-        run: cargo check -p parquet --no-default-features --features flate2 --features flate2-rust_backened
+      - name: Check compilation --no-default-features --features flate2 --features flate2-rust_backend
+        run: cargo check -p parquet --no-default-features --features flate2 --features flate2-rust_backend
       - name: Check compilation --no-default-features --features flate2 --features flate2-zlib-rs
         run: cargo check -p parquet --no-default-features --features flate2 --features flate2-zlib-rs
       - name: Check compilation --no-default-features --features variant_experimental

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -54,7 +54,7 @@ object_store = { workspace = true, optional = true, features = ["tokio"] }
 bytes = { version = "1.1", default-features = false, features = ["std"] }
 snap = { version = "1.0", default-features = false, optional = true }
 brotli = { version = "8.0", default-features = false, features = ["std"], optional = true }
-# To use `flate2` you must enable either the `flate2-zlib-rs` or `flate2-rust_backened` backends
+# To use `flate2` you must enable either the `flate2-zlib-rs` or `flate2-rust_backend` backends
 flate2 = { version = "1.1", default-features = false, optional = true }
 lz4_flex = { version = "0.13", default-features = false, features = ["std", "frame"], optional = true }
 zstd = { version = "0.13", optional = true, default-features = false }
@@ -126,13 +126,16 @@ crc = ["dep:crc32fast"]
 simdutf8 = ["dep:simdutf8"]
 # Enable Parquet modular encryption support
 encryption = ["dep:ring"]
-# Explicitely enabling rust_backend and zlib-rs features for flate2
-flate2-rust_backened = ["flate2/rust_backend"]
+# Enable flate2's default Rust backend
+flate2-rust_backend = ["flate2/rust_backend"]
+# Enable flate2's zlib-rs backend
 flate2-zlib-rs = ["flate2/zlib-rs"]
 # Enable parquet variant support
 variant_experimental = ["arrow", "parquet-variant", "parquet-variant-json", "parquet-variant-compute"]
 # Enable geospatial support
 geospatial = ["parquet-geospatial"]
+# Alias for typo. TODO: Remove in future major version bump.
+flate2-rust_backened = ["flate2-rust_backend"]
 
 
 [[example]]

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -166,10 +166,10 @@ macro_rules! experimental {
 
 #[cfg(all(
     feature = "flate2",
-    not(any(feature = "flate2-zlib-rs", feature = "flate2-rust_backened"))
+    not(any(feature = "flate2-zlib-rs", feature = "flate2-rust_backend"))
 ))]
 compile_error!(
-    "When enabling `flate2` you must enable one of the features: `flate2-zlib-rs` or `flate2-rust_backened`."
+    "When enabling `flate2` you must enable one of the features: `flate2-zlib-rs` or `flate2-rust_backend`."
 );
 
 #[macro_use]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/9031.

# Rationale for this change

The original feature flag was misspelt. We should update it to use the correct spelling and maintain an alias until a breaking release is made.

There is no warning introduced yet for the removal of the old feature flag. It could be added using a build script, however I believe that adds unnecessary overhead when we have no other use for build scripts at this time in the `parquet` crate.

# What changes are included in this PR?

This change renames the feature flag including all code references. It also maintains an alias such that existing users aren't broken but the new feature flag can be adopted.

# Are these changes tested?

This change relies on existing CI tests.

# Are there any user-facing changes?

Yes, the feature flag is updated. To my knowledge, I've updated all references to it.
