### PR TITLE
feat: support uuid from fixed type of length 16

### DIFF
--- a/arrow-avro/src/codec.rs
+++ b/arrow-avro/src/codec.rs
@@ -1565,6 +1565,15 @@ impl<'a> Maker<'a> {
                                 resolution: None,
                             }
                         }
+                        Some("uuid") if size == 16 => {
+                            metadata.insert("logicalType".into(), "uuid".into());
+                            AvroDataType {
+                                nullability: None,
+                                metadata,
+                                codec: Codec::Fixed(size),
+                                resolution: None,
+                            }
+                        }
                         #[cfg(feature = "avro_custom_types")]
                         Some("arrow.uint64") if size == 8 => AvroDataType {
                             nullability: None,
@@ -2520,6 +2529,37 @@ mod tests {
             *c = Codec::Uuid;
         }
         assert!(matches!(codec, Codec::Uuid));
+    }
+
+    #[test]
+    fn test_fixed_uuid_logical_type_metadata() {
+        // Iceberg encodes UUID as fixed(16) + logicalType:uuid. Verify that arrow-avro
+        // preserves the logicalType in Arrow field metadata so callers can detect UUID fields.
+        // this is supported in avro starting from the 1.12.0 spec: https://avro.apache.org/docs/1.12.0/specification/#uuid
+        let schema = Schema::Complex(ComplexType::Fixed(Fixed {
+            name: "uuid_fixed",
+            namespace: None,
+            aliases: vec![],
+            size: 16,
+            attributes: Attributes {
+                logical_type: Some("uuid"),
+                additional: Default::default(),
+            },
+        }));
+
+        let mut maker = Maker::new(false, false, Tz::default());
+        let result = maker.make_data_type(&schema, None, None).unwrap();
+
+        assert!(
+            matches!(result.codec, Codec::Fixed(16)),
+            "codec should be Fixed(16), got {:?}",
+            result.codec
+        );
+        assert_eq!(
+            result.metadata.get("logicalType").map(|s| s.as_str()),
+            Some("uuid"),
+            "logicalType metadata should be 'uuid'"
+        );
     }
 
     #[test]

--- a/arrow-avro/src/codec.rs
+++ b/arrow-avro/src/codec.rs
@@ -1565,7 +1565,12 @@ impl<'a> Maker<'a> {
                                 resolution: None,
                             }
                         }
-                        Some("uuid") if size == 16 => {
+                        Some("uuid") => {
+                            if size != 16 {
+                                return Err(ArrowError::ParseError(format!(
+                                    "Invalid fixed size for UUID: {size}, must be 16"
+                                )));
+                            }
                             metadata.insert("logicalType".into(), "uuid".into());
                             AvroDataType {
                                 nullability: None,


### PR DESCRIPTION
# Which issue does this PR close?
Related to https://github.com/apache/arrow-rs/issues/8703


# Rationale for this change
In version 1.12.0 of the [spec](https://avro.apache.org/docs/1.12.0/specification/#uuid), uuid is allowed to be either an Avro string or fixed of length 16.

# What changes are included in this PR?


# Are these changes tested?
Added a unit test


# Are there any user-facing changes?
The uuid logical type is inserted into the arrow Field metadata if the uuid logical type is present as a logical annotation on the avro type.
