### PR TITLE
reduce noise in flight benchmarks [tokio-threads] [# of columns in benchmarks]

### DIFF
--- a/arrow-flight/benches/flight.rs
+++ b/arrow-flight/benches/flight.rs
@@ -29,11 +29,13 @@ mod common;
 use common::{DICT_TYPES, TYPES, build_batch, start_server};
 
 const ROWS: [usize; 2] = [8 * 1024, 64 * 1024];
-const COLS: [usize; 3] = [1, 4, 8];
+const COLS: [usize; 2] = [4, 8];
 const BATCHES: usize = 4;
 
 fn bench_encode(c: &mut Criterion) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
     let mut g = c.benchmark_group("encode");
 
     for &(name, build) in TYPES {
@@ -69,7 +71,9 @@ async fn roundtrip(channel: Channel, batch: RecordBatch) {
 }
 
 fn bench_decode(c: &mut Criterion) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
     let mut g = c.benchmark_group("decode");
 
     for &(name, build) in TYPES {
@@ -131,10 +135,10 @@ fn bench_roundtrip(c: &mut Criterion) {
     }
 }
 
-/// Decode a multi-batch stream covering both plain and dictionary types.
-/// Uses [`DictionaryHandling::Resend`] to exercise the replacement-dictionary path.
 fn bench_decode_dictionary_stream(c: &mut Criterion) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
     let mut g = c.benchmark_group("decode_stream");
 
     for &(name, build) in TYPES.iter().chain(DICT_TYPES) {

--- a/arrow-flight/benches/flight.rs
+++ b/arrow-flight/benches/flight.rs
@@ -182,7 +182,9 @@ fn bench_decode_dictionary_stream(c: &mut Criterion) {
 }
 
 fn bench_do_put_dictionary(c: &mut Criterion) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
     let (channel, _) = rt.block_on(start_server());
     let mut g = c.benchmark_group("do_put_dictionary");
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- works towards #10125


# Rationale for this change
see https://github.com/apache/arrow-rs/pull/10220#issuecomment-4818934211
attempting to remove as much noise from profile/benchmarks as possible
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- sets each tokio runtime builder to use [new_current_thread](https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.new_current_thread)
- remove [1] column case, trying to make benchmarks easier to read, reducing the size by 1/3 while keeping [4,8]

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
n/a
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
n/a