### PR TITLE
deprecate flight_data_to_arrow_batch

### DIFF
--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -45,13 +45,36 @@ pub fn flight_data_to_batches(flight_data: &[FlightData]) -> Result<Vec<RecordBa
     let mut batches = vec![];
     let dictionaries_by_id = HashMap::new();
     for datum in flight_data[1..].iter() {
-        let batch = flight_data_to_arrow_batch(datum, schema.clone(), &dictionaries_by_id)?;
+        let message = root_as_message(&datum.data_header[..]).map_err(|err| {
+            ArrowError::ParseError(format!("Unable to get root as message: {err:?}"))
+        })?;
+        let batch = message
+            .header_as_record_batch()
+            .ok_or_else(|| {
+                ArrowError::ParseError(
+                    "Unable to convert flight data header to a record batch".to_string(),
+                )
+            })
+            .map(|batch| {
+                reader::read_record_batch(
+                    &Buffer::from(datum.data_body.as_ref()),
+                    batch,
+                    schema.clone(),
+                    &dictionaries_by_id,
+                    None,
+                    &message.version(),
+                )
+            })??;
         batches.push(batch);
     }
     Ok(batches)
 }
 
 /// Convert `FlightData` (with supplied schema and dictionaries) to an arrow `RecordBatch`.
+#[deprecated(
+    since = "59.1.0",
+    note = "Use `arrow_ipc::reader::read_record_batch` directly instead"
+)]
 pub fn flight_data_to_arrow_batch(
     data: &FlightData,
     schema: SchemaRef,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10249.

# Rationale for this change
after #10206 `flight_to_arrow_batch` was only used in one location, within  a test function. It served as a thin wrapper over `read_record_batch`. since #10206  made `read_record_batch` public callers should just call it directly
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Updates the two internal callsites of `flight_data_to_arrow_batch` to call `arrow_ipc::reader::read_record_batch` directly, and marks the function as deprecated since 59.1.0 pointing callers to do the same.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes. the changes are to test
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
yes, users will now receive a deprecated warning, guiding them to use `read_record_batch()` directly
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
