### PR TITLE
chore: update workspace Rust toolchain to 1.96.1

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -30,6 +30,7 @@ on:
   pull_request:
     paths:
       - .github/**
+      - rust-toolchain.toml
       - arrow-arith/**
       - arrow-array/**
       - arrow-buffer/**

--- a/.github/workflows/arrow_flight.yml
+++ b/.github/workflows/arrow_flight.yml
@@ -30,6 +30,7 @@ on:
       - main
   pull_request:
     paths:
+      - rust-toolchain.toml
       - arrow-array/**
       - arrow-buffer/**
       - arrow-cast/**

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,6 +30,7 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - rust-toolchain.toml
 
 jobs:
   cargo-audit:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,6 +29,7 @@ on:
   pull_request:
     paths:
       - .github/**
+      - rust-toolchain.toml
       - arrow-array/**
       - arrow-buffer/**
       - arrow-cast/**

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -29,6 +29,7 @@ on:
   pull_request:
     paths:
       - .github/**
+      - rust-toolchain.toml
       - arrow-array/**
       - arrow-buffer/**
       - arrow-cast/**

--- a/.github/workflows/parquet-geospatial.yml
+++ b/.github/workflows/parquet-geospatial.yml
@@ -31,6 +31,7 @@ on:
   pull_request:
     paths:
       - parquet-geospatial/**
+      - rust-toolchain.toml
       - .github/**
 
 jobs:

--- a/.github/workflows/parquet-variant.yml
+++ b/.github/workflows/parquet-variant.yml
@@ -33,6 +33,7 @@ on:
       - parquet-variant/**
       - parquet-variant-json/**
       - parquet-variant-compute/**
+      - rust-toolchain.toml
       - .github/**
 
 jobs:

--- a/.github/workflows/parquet.yml
+++ b/.github/workflows/parquet.yml
@@ -30,6 +30,7 @@ on:
       - main
   pull_request:
     paths:
+      - rust-toolchain.toml
       - arrow/**
       - arrow-array/**
       - arrow-buffer/**

--- a/.github/workflows/parquet_derive.yml
+++ b/.github/workflows/parquet_derive.yml
@@ -33,6 +33,7 @@ on:
       - parquet/**
       - parquet_derive/**
       - parquet_derive_test/**
+      - rust-toolchain.toml
       - .github/**
 
 jobs:

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -1183,7 +1183,7 @@ mod tests {
 
             // create run array using input_array
             let mut builder = PrimitiveRunBuilder::<Int32Type, Int32Type>::new();
-            builder.extend(input_array.clone().into_iter());
+            builder.extend(input_array.clone());
 
             let run_array = builder.finish();
             let physical_values_array = run_array.values().as_primitive::<Int32Type>();

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -6808,14 +6808,8 @@ mod test {
             .unwrap();
 
         // First row should be "ACTIVE", second row should be "PENDING"
-        assert_eq!(
-            status_values.value(status_col.key(0).unwrap() as usize),
-            "ACTIVE"
-        );
-        assert_eq!(
-            status_values.value(status_col.key(1).unwrap() as usize),
-            "PENDING"
-        );
+        assert_eq!(status_values.value(status_col.key(0).unwrap()), "ACTIVE");
+        assert_eq!(status_values.value(status_col.key(1).unwrap()), "PENDING");
 
         // Get backupStatus enum values (same as status)
         let backup_status_col = batch
@@ -6831,11 +6825,11 @@ mod test {
 
         // First row should be "INACTIVE", second row should be "ACTIVE"
         assert_eq!(
-            backup_status_values.value(backup_status_col.key(0).unwrap() as usize),
+            backup_status_values.value(backup_status_col.key(0).unwrap()),
             "INACTIVE"
         );
         assert_eq!(
-            backup_status_values.value(backup_status_col.key(1).unwrap() as usize),
+            backup_status_values.value(backup_status_col.key(1).unwrap()),
             "ACTIVE"
         );
 
@@ -6862,15 +6856,15 @@ mod test {
         // First row: ["PENDING", "ACTIVE", "INACTIVE"]
         assert_eq!(first_array_dict_array.len(), 3);
         assert_eq!(
-            first_array_values.value(first_array_dict_array.key(0).unwrap() as usize),
+            first_array_values.value(first_array_dict_array.key(0).unwrap()),
             "PENDING"
         );
         assert_eq!(
-            first_array_values.value(first_array_dict_array.key(1).unwrap() as usize),
+            first_array_values.value(first_array_dict_array.key(1).unwrap()),
             "ACTIVE"
         );
         assert_eq!(
-            first_array_values.value(first_array_dict_array.key(2).unwrap() as usize),
+            first_array_values.value(first_array_dict_array.key(2).unwrap()),
             "INACTIVE"
         );
     }

--- a/arrow-flight/src/sql/metadata/mod.rs
+++ b/arrow-flight/src/sql/metadata/mod.rs
@@ -57,7 +57,7 @@ fn lexsort_to_indices(arrays: &[ArrayRef]) -> UInt32Array {
     let converter = RowConverter::new(fields).unwrap();
     let rows = converter.convert_columns(arrays).unwrap();
     let mut sort: Vec<_> = rows.iter().enumerate().collect();
-    sort.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));
+    sort.sort_unstable_by_key(|(_, a)| *a);
     UInt32Array::from_iter_values(sort.iter().map(|(i, _)| *i as u32))
 }
 

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -691,7 +691,7 @@ impl Iterator for BufIter<'_> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let s = self.buf.len().checked_sub(self.pos).unwrap_or_default();
+        let s = self.buf.len().saturating_sub(self.pos);
         (s, Some(s))
     }
 }

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -5292,7 +5292,6 @@ mod tests {
                 let remaining = length - current_len;
                 for _ in 0..remaining {
                     result.push(rng.random_range('a'..='z'));
-                    current_len += 1;
                 }
                 break;
             }

--- a/arrow/benches/lexsort.rs
+++ b/arrow/benches/lexsort.rs
@@ -141,7 +141,7 @@ fn do_bench(c: &mut Criterion, columns: &[Column], len: usize) {
                 let converter = RowConverter::new(fields).unwrap();
                 let rows = converter.convert_columns(&arrays).unwrap();
                 let mut sort: Vec<_> = rows.iter().enumerate().collect();
-                sort.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));
+                sort.sort_unstable_by_key(|(_, a)| *a);
                 UInt32Array::from_iter_values(sort.iter().map(|(i, _)| *i as u32))
             })
         })

--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -43,7 +43,7 @@ macro_rules! make_reader {
             $(($key_arrow:pat, $value_arrow:pat) => ($key_type:ty, $value_type:ty),)+
         }
     ) => {
-        match (($k, $v)) {
+        match ($k, $v) {
             $(
                 ($key_arrow, $value_arrow) => {
                     let reader = GenericRecordReader::new($column_desc, $batch_size);

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -389,11 +389,13 @@ impl<W: Write + Send> ArrowWriter<W> {
                     return self.write(batch);
                 }
 
-                let avg_row_bytes = current_bytes / in_progress.buffered_rows;
-                if avg_row_bytes > 0 {
+                if let Some(avg_row_bytes) = current_bytes
+                    .checked_div(in_progress.buffered_rows)
+                    .filter(|avg_row_bytes| *avg_row_bytes > 0)
+                {
                     // At this point, `current_bytes < max_bytes` (checked above)
                     let remaining_bytes = max_bytes - current_bytes;
-                    let rows_that_fit = remaining_bytes / avg_row_bytes;
+                    let rows_that_fit = remaining_bytes.checked_div(avg_row_bytes).unwrap_or(0);
 
                     if batch.num_rows() > rows_that_fit {
                         if rows_that_fit > 0 {
@@ -4356,7 +4358,7 @@ mod tests {
         // check values roundtrip through parquet
         let src = [
             u32::MIN,
-            u32::MIN + 1,
+            1,
             (i32::MAX as u32) - 1,
             i32::MAX as u32,
             (i32::MAX as u32) + 1,
@@ -4402,7 +4404,7 @@ mod tests {
         // check values roundtrip through parquet
         let src = [
             u64::MIN,
-            u64::MIN + 1,
+            1,
             (i64::MAX as u64) - 1,
             i64::MAX as u64,
             (i64::MAX as u64) + 1,

--- a/parquet/src/arrow/in_memory_row_group.rs
+++ b/parquet/src/arrow/in_memory_row_group.rs
@@ -165,7 +165,7 @@ impl InMemoryRowGroup<'_> {
                         data: offsets
                             .into_iter()
                             .map(|x| x as usize)
-                            .zip(chunks.into_iter())
+                            .zip(chunks)
                             .collect(),
                     }))
                 }

--- a/parquet/src/encryption/decrypt.rs
+++ b/parquet/src/encryption/decrypt.rs
@@ -507,7 +507,7 @@ impl DecryptionPropertiesBuilder {
                 keys.len()
             ));
         }
-        for (column_name, key) in column_names.into_iter().zip(keys.into_iter()) {
+        for (column_name, key) in column_names.into_iter().zip(keys) {
             self.column_keys.insert(column_name.to_string(), key);
         }
         Ok(self)

--- a/parquet/src/file/page_index/column_index.rs
+++ b/parquet/src/file/page_index/column_index.rs
@@ -278,25 +278,15 @@ impl<T: ParquetValueType> WriteThrift for PrimitiveColumnIndex<T> {
             max.write_thrift(writer)?;
         }
         let mut last_field_id = self.boundary_order.write_thrift_field(writer, 4, 3)?;
-        if self.null_counts.is_some() {
+        if let Some(null_counts) = &self.null_counts {
+            last_field_id = null_counts.write_thrift_field(writer, 5, last_field_id)?;
+        }
+        if let Some(repetition_level_histograms) = &self.repetition_level_histograms {
             last_field_id =
-                self.null_counts
-                    .as_ref()
-                    .unwrap()
-                    .write_thrift_field(writer, 5, last_field_id)?;
+                repetition_level_histograms.write_thrift_field(writer, 6, last_field_id)?;
         }
-        if self.repetition_level_histograms.is_some() {
-            last_field_id = self
-                .repetition_level_histograms
-                .as_ref()
-                .unwrap()
-                .write_thrift_field(writer, 6, last_field_id)?;
-        }
-        if self.definition_level_histograms.is_some() {
-            self.definition_level_histograms
-                .as_ref()
-                .unwrap()
-                .write_thrift_field(writer, 7, last_field_id)?;
+        if let Some(definition_level_histograms) = &self.definition_level_histograms {
+            definition_level_histograms.write_thrift_field(writer, 7, last_field_id)?;
         }
         writer.write_struct_end()
     }
@@ -487,25 +477,15 @@ impl WriteThrift for ByteArrayColumnIndex {
             max.write_thrift(writer)?;
         }
         let mut last_field_id = self.boundary_order.write_thrift_field(writer, 4, 3)?;
-        if self.null_counts.is_some() {
+        if let Some(null_counts) = &self.null_counts {
+            last_field_id = null_counts.write_thrift_field(writer, 5, last_field_id)?;
+        }
+        if let Some(repetition_level_histograms) = &self.repetition_level_histograms {
             last_field_id =
-                self.null_counts
-                    .as_ref()
-                    .unwrap()
-                    .write_thrift_field(writer, 5, last_field_id)?;
+                repetition_level_histograms.write_thrift_field(writer, 6, last_field_id)?;
         }
-        if self.repetition_level_histograms.is_some() {
-            last_field_id = self
-                .repetition_level_histograms
-                .as_ref()
-                .unwrap()
-                .write_thrift_field(writer, 6, last_field_id)?;
-        }
-        if self.definition_level_histograms.is_some() {
-            self.definition_level_histograms
-                .as_ref()
-                .unwrap()
-                .write_thrift_field(writer, 7, last_field_id)?;
+        if let Some(definition_level_histograms) = &self.definition_level_histograms {
+            definition_level_histograms.write_thrift_field(writer, 7, last_field_id)?;
         }
         writer.write_struct_end()
     }

--- a/parquet/src/util/push_buffers.rs
+++ b/parquet/src/util/push_buffers.rs
@@ -99,7 +99,7 @@ impl PushBuffers {
             buffers.len(),
             "Number of ranges must match number of buffers"
         );
-        for (range, buffer) in ranges.into_iter().zip(buffers.into_iter()) {
+        for (range, buffer) in ranges.into_iter().zip(buffers) {
             self.push_range(range, buffer);
         }
     }

--- a/parquet/tests/encryption/encryption.rs
+++ b/parquet/tests/encryption/encryption.rs
@@ -594,7 +594,7 @@ fn uniform_encryption_roundtrip(
 
     let mut writer = ArrowWriter::try_new(file.try_clone()?, schema.clone(), Some(props))?;
 
-    for (x0, x1) in x0_arrays.into_iter().zip(x1_arrays.into_iter()) {
+    for (x0, x1) in x0_arrays.into_iter().zip(x1_arrays) {
         let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(x0), Arc::new(x1)])?;
         writer.write(&batch)?;
     }
@@ -698,7 +698,7 @@ fn uniform_encryption_page_skipping(page_index: bool) -> parquet::errors::Result
 
     let mut writer = ArrowWriter::try_new(file.try_clone()?, schema.clone(), Some(props))?;
 
-    for (x0, x1) in x0_arrays.into_iter().zip(x1_arrays.into_iter()) {
+    for (x0, x1) in x0_arrays.into_iter().zip(x1_arrays) {
         let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(x0), Arc::new(x1)])?;
         writer.write(&batch)?;
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,5 +16,5 @@
 # under the License.
 
 [toolchain]
-channel = "1.91"
+channel = "1.96.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

The repository toolchain pin was still on Rust 1.91, while the current stable toolchain is Rust 1.96.1.

Changes to `rust-toolchain.toml` also affect the full workspace, but the path-filtered crate workflows did not run for toolchain-only PRs. Those workflow filters should treat toolchain changes as broad CI-impacting changes.

# What changes are included in this PR?

Updates `rust-toolchain.toml` from `1.91` to `1.96.1`.

Adds `rust-toolchain.toml` to the `pull_request.paths` filters for the crate and audit workflows so toolchain updates trigger the full suite instead of only the unfiltered workflows.

Addresses Clippy lints surfaced by Rust 1.96.1.

# Are these changes tested?

No tests added; this updates CI metadata and the pinned Rust toolchain.

# Are there any user-facing changes?

No runtime or API behavior changes.
