### PR TITLE
Add validated row decode benchmark

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1221,7 +1221,7 @@ struct RowConfig {
 /// A row-oriented representation of arrow data, that is normalized for comparison.
 ///
 /// See the [module level documentation](self) and [`RowConverter`] for more details.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Rows {
     /// Underlying row bytes
     buffer: Vec<u8>,

--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -69,13 +69,11 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
         b.iter(|| hint::black_box(converter.convert_rows(&rows).unwrap()));
     });
 
-    // Benchmark parsing strings (which may need utf8 validation),
-    let no_nulls =  cols
-        .iter()
-        .all(|array| array.null_count() == 0);
-
-    if is_string_like(array.data_type()) && no_nulls
-    {
+    // Benchmark parsing strings, which may need utf8 validation.
+    fn non_null_string(array: &ArrayRef) -> bool {
+        array.null_count() == 0 && is_string_like(array.data_type())
+    }
+    if cols.iter().all(non_null_string) {
         // RowParser marks rows as requiring UTF-8 validation when they are decoded
         // back into Arrow arrays by RowConverter::convert_rows.
         let parser = converter.parser();

--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -37,6 +37,14 @@ use arrow_schema::{DataType, Field};
 use criterion::Criterion;
 use std::{hint, sync::Arc};
 
+fn is_string_like(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => true,
+        DataType::Dictionary(_, values) => is_string_like(values),
+        _ => false,
+    }
+}
+
 fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
     let fields: Vec<_> = cols
         .iter()
@@ -61,24 +69,30 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
         b.iter(|| hint::black_box(converter.convert_rows(&rows).unwrap()));
     });
 
-    let binary_rows = rows.clone().try_into_binary().expect("reasonable size");
-    let parser = converter.parser();
-    // RowParser marks rows as requiring UTF-8 validation when they are decoded
-    // back into Arrow arrays by RowConverter::convert_rows.
-    let parsed_rows: Vec<_> = binary_rows
+    // Benchmark parsing strings (which may need utf8 validation),
+    let no_nulls =  cols
         .iter()
-        .flatten()
-        .map(|row| parser.parse(row).owned())
-        .collect();
-    c.bench_function(&format!("convert_rows_validated {name}"), |b| {
-        b.iter(|| {
-            hint::black_box(
-                converter
-                    .convert_rows(parsed_rows.iter().map(|row| row.row()))
-                    .unwrap(),
-            )
+        .all(|array| array.null_count() == 0);
+
+    if is_string_like(array.data_type()) && no_nulls
+    {
+        // RowParser marks rows as requiring UTF-8 validation when they are decoded
+        // back into Arrow arrays by RowConverter::convert_rows.
+        let parser = converter.parser();
+        let parsed_rows: Vec<_> = rows
+            .iter()
+            .map(|row| parser.parse(row.as_ref()).owned())
+            .collect();
+        c.bench_function(&format!("convert_rows_parsed {name}"), |b| {
+            b.iter(|| {
+                hint::black_box(
+                    converter
+                        .convert_rows(parsed_rows.iter().map(|row| row.row()))
+                        .unwrap(),
+                )
+            });
         });
-    });
+    }
 
     let mut rows = converter.empty_rows(0, 0);
     c.bench_function(&format!("append_rows {name}"), |b| {

--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -37,14 +37,6 @@ use arrow_schema::{DataType, Field};
 use criterion::Criterion;
 use std::{hint, sync::Arc};
 
-fn is_string_like(data_type: &DataType) -> bool {
-    match data_type {
-        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => true,
-        DataType::Dictionary(_, values) => is_string_like(values),
-        _ => false,
-    }
-}
-
 fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
     let fields: Vec<_> = cols
         .iter()
@@ -69,11 +61,11 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
         b.iter(|| hint::black_box(converter.convert_rows(&rows).unwrap()));
     });
 
-    // Benchmark parsing strings, which may need utf8 validation.
-    fn non_null_string(array: &ArrayRef) -> bool {
-        array.null_count() == 0 && is_string_like(array.data_type())
+    // Benchmark parsing strings which may need utf8 validation.
+    fn is_stringlike(array: &ArrayRef) -> bool {
+        matches!(array.data_type(), DataType::Utf8 | DataType::Utf8View)
     }
-    if cols.iter().all(non_null_string) {
+    if cols.iter().all(is_stringlike) {
         // RowParser marks rows as requiring UTF-8 validation when they are decoded
         // back into Arrow arrays by RowConverter::convert_rows.
         let parser = converter.parser();

--- a/arrow/benches/row_format.rs
+++ b/arrow/benches/row_format.rs
@@ -61,6 +61,25 @@ fn do_bench(c: &mut Criterion, name: &str, cols: Vec<ArrayRef>) {
         b.iter(|| hint::black_box(converter.convert_rows(&rows).unwrap()));
     });
 
+    let binary_rows = rows.clone().try_into_binary().expect("reasonable size");
+    let parser = converter.parser();
+    // RowParser marks rows as requiring UTF-8 validation when they are decoded
+    // back into Arrow arrays by RowConverter::convert_rows.
+    let parsed_rows: Vec<_> = binary_rows
+        .iter()
+        .flatten()
+        .map(|row| parser.parse(row).owned())
+        .collect();
+    c.bench_function(&format!("convert_rows_validated {name}"), |b| {
+        b.iter(|| {
+            hint::black_box(
+                converter
+                    .convert_rows(parsed_rows.iter().map(|row| row.row()))
+                    .unwrap(),
+            )
+        });
+    });
+
     let mut rows = converter.empty_rows(0, 0);
     c.bench_function(&format!("append_rows {name}"), |b| {
         let cols = cols.clone();


### PR DESCRIPTION
# Which issue does this PR close?

- related to https://github.com/apache/arrow-rs/pull/10250  from @Jefffrey 

# Rationale for this change

The existing row format benchmark measures `convert_rows` using rows created directly by `RowConverter::convert_columns`, which skips UTF-8 validation during decode.

# What changes are included in this PR?

This adds a `convert_rows_validated` benchmark that decodes rows parsed through `RowParser`, exercising the UTF-8 validation path. It also derives `Clone` for `Rows` so the benchmark setup can reuse the prepared rows when converting to binary.

# Are these changes tested?

CI.

I also ran it locally like
```shell
cargo bench --bench row_format -- convert_rows_validated
```


# Are there any user-facing changes?

No breaking changes. `Rows` now implements `Clone`.
