### PR TITLE
Replace conversion of binary->string in arrow-row from arraydata to direct construction

### DIFF
--- a/arrow-row/src/variable.rs
+++ b/arrow-row/src/variable.rs
@@ -401,14 +401,11 @@ pub unsafe fn decode_string<I: OffsetSizeTrait>(
         return GenericStringArray::from(decoded);
     }
 
-    let builder = decoded
-        .into_data()
-        .into_builder()
-        .data_type(GenericStringArray::<I>::DATA_TYPE);
+    let (offsets, values, nulls) = decoded.into_parts();
 
     // SAFETY:
     // Row data must have come from a valid UTF-8 array
-    GenericStringArray::from(unsafe { builder.build_unchecked() })
+    unsafe { GenericStringArray::new_unchecked(offsets, values, nulls) }
 }
 
 /// Decodes a string view array from `rows` with the provided `options`


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Part of #9298

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Missed by https://github.com/apache/arrow-rs/pull/10229 as it used the `into_data()` API (I was grepping just for `ArrayData`). Instead of roundtripping through arraydata to convert from a binary to string, just directly use `into_parts()` and `new_unchecked()` for optimization.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Remove arraydata roundtrip in favour of deconstructing with `into_parts()` and constructing with `new_unchecked()`

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

Existing tests

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->

No
