### PR TITLE
parquet: report child field names and lengths in StructArrayReader length-mismatch error

### DIFF
--- a/parquet/src/arrow/array_reader/struct_array.rs
+++ b/parquet/src/arrow/array_reader/struct_array.rs
@@ -121,7 +121,26 @@ impl ArrayReader for StructArrayReader {
             .iter()
             .all(|arr| arr.len() == children_array_len);
         if !all_children_len_eq {
-            return Err(general_err!("Not all children array length are the same!"));
+            let lengths: Vec<usize> = children_array.iter().map(|arr| arr.len()).collect();
+            let detail = match &self.data_type {
+                DataType::Struct(fields) if fields.len() == lengths.len() => fields
+                    .iter()
+                    .zip(&lengths)
+                    .map(|(field, len)| format!("{}={len}", field.name()))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                _ => lengths
+                    .iter()
+                    .map(|len| len.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            };
+            return Err(general_err!(
+                "StructArrayReader children returned arrays of unequal length ({}). \
+                 This usually means the Parquet file is malformed, for example a page \
+                 that does not begin on a record boundary.",
+                detail
+            ));
         }
 
         let DataType::Struct(fields) = &self.data_type else {
@@ -267,6 +286,72 @@ mod tests {
         assert_eq!(
             Some(vec![0, 1, 1, 1, 1].as_slice()),
             struct_array_reader.get_rep_levels()
+        );
+    }
+
+    // Reader that yields a fixed-length Int32 array from `consume_batch`, used to
+    // simulate children that fall out of sync (e.g. a malformed file whose pages do
+    // not begin on a record boundary), which `read_records` does not catch.
+    struct FixedLenArrayReader {
+        len: usize,
+        data_type: ArrowType,
+    }
+
+    impl ArrayReader for FixedLenArrayReader {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn get_data_type(&self) -> &ArrowType {
+            &self.data_type
+        }
+        fn read_records(&mut self, _batch_size: usize) -> Result<usize> {
+            Ok(self.len)
+        }
+        fn consume_batch(&mut self) -> Result<ArrayRef> {
+            Ok(Arc::new(arrow_array::Int32Array::from(vec![0; self.len])))
+        }
+        fn skip_records(&mut self, _num_records: usize) -> Result<usize> {
+            Ok(0)
+        }
+        fn get_def_levels(&self) -> Option<&[i16]> {
+            None
+        }
+        fn get_rep_levels(&self) -> Option<&[i16]> {
+            None
+        }
+    }
+
+    #[test]
+    fn test_struct_array_reader_unequal_children_error() {
+        let struct_type = ArrowType::Struct(Fields::from(vec![
+            Field::new("f1", ArrowType::Int32, false),
+            Field::new("f2", ArrowType::Int32, false),
+        ]));
+        let mut reader = StructArrayReader::new(
+            struct_type,
+            vec![
+                Box::new(FixedLenArrayReader {
+                    len: 5,
+                    data_type: ArrowType::Int32,
+                }),
+                Box::new(FixedLenArrayReader {
+                    len: 3,
+                    data_type: ArrowType::Int32,
+                }),
+            ],
+            0,
+            0,
+            false,
+        );
+
+        let err = reader.consume_batch().unwrap_err().to_string();
+        // The message must name the diverging children and their lengths so the
+        // cause is diagnosable without instrumenting the reader by hand.
+        assert!(err.contains("f1=5"), "message missing child lengths: {err}");
+        assert!(err.contains("f2=3"), "message missing child lengths: {err}");
+        assert!(
+            err.contains("record boundary"),
+            "message missing malformed-file hint: {err}"
         );
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Relates to #10243.

# Rationale for this change

In #10243 a struct column read failed with `Not all children array length are the same!` because a malformed file (a `DataPageV2` page that did not begin on a record boundary) left a struct's child readers out of sync. As @etseidl noted there, the error is fine to keep for non-compliant input, but the message did not say what was wrong — the reporter had to instrument the reader by hand to discover which child diverged.

# What changes are included in this PR?

`StructArrayReader::consume_batch` now reports each child's field name and produced length when they disagree, along with a hint that the file may be malformed:

```
StructArrayReader children returned arrays of unequal length (f1=5, f2=3). This usually means the Parquet file is malformed, for example a page that does not begin on a record boundary.
```

Field names come from the reader's struct `DataType`; when the field count and child count somehow differ, it falls back to bare lengths. The formatting only runs on the error path.

# Are these changes tested?

Yes. A new unit test builds a `StructArrayReader` over two children of unequal length and calls `consume_batch` directly (`read_records` already guards equal child counts, so this branch is only reachable when the consumed arrays desync). It asserts the message names the diverging children and their lengths. Reverting the message change turns the test red.

# Are there any user-facing changes?

Only a clearer error message. No API or behavior change — non-compliant input still errors.