### PR TITLE
fix main: parquet test compilation failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,9 +2696,9 @@ checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.3"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",

--- a/parquet/src/arrow/arrow_reader/read_plan.rs
+++ b/parquet/src/arrow/arrow_reader/read_plan.rs
@@ -541,13 +541,13 @@ mod tests {
 
         let data: Vec<i32> = (0..TOTAL_ROWS as i32).collect();
         let levels = vec![0; TOTAL_ROWS];
-        let leaf = make_int32_page_reader(&data, &levels, &levels, 0, 0);
+        let leaf = make_int32_page_reader(&data, &levels, &levels, 0, 0, None);
         let struct_type = ArrowType::Struct(Fields::from(vec![Field::new(
             "c0",
             ArrowType::Int32,
             false,
         )]));
-        let struct_reader = StructArrayReader::new(struct_type, vec![leaf], 0, 0, false);
+        let struct_reader = StructArrayReader::new(struct_type, vec![leaf], 0, 0, false, None);
 
         let mut predicate = ArrowPredicateFn::new(ProjectionMask::all(), |batch| {
             Ok((0..batch.num_rows())


### PR DESCRIPTION
audit failing

```sh
Crate:     quick-xml
Version:   0.39.3
Title:     Unbounded namespace-declaration allocation in `NsReader` enables memory-exhaustion denial of service
Date:      2026-06-29
ID:        RUSTSEC-2026-0195
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0195
Severity:  7.5 (high)
Solution:  Upgrade to >=0.41.0
```

parquet test failing

```sh
error[E0061]: this function takes 6 arguments but 5 arguments were supplied
   --> parquet/src/arrow/arrow_reader/read_plan.rs:544:20
    |
544 |         let leaf = make_int32_page_reader(&data, &levels, &levels, 0, 0);
    |                    ^^^^^^^^^^^^^^^^^^^^^^------------------------------- argument #6 of type `Option<i16>` is missing
    |
note: function defined here
   --> parquet/src/arrow/array_reader/test_util.rs:102:8
    |
102 | pub fn make_int32_page_reader(
    |        ^^^^^^^^^^^^^^^^^^^^^^
...
108 |     padding_threshold: Option<i16>,
    |     ------------------------------
help: provide the argument
    |
544 |         let leaf = make_int32_page_reader(&data, &levels, &levels, 0, 0, /* Option<i16> */);
    |                                                                        +++++++++++++++++++

error[E0061]: this function takes 6 arguments but 5 arguments were supplied
   --> parquet/src/arrow/arrow_reader/read_plan.rs:550:29
    |
550 |         let struct_reader = StructArrayReader::new(struct_type, vec![leaf], 0, 0, false);
    |                             ^^^^^^^^^^^^^^^^^^^^^^-------------------------------------- argument #6 of type `Option<i16>` is missing
    |
note: associated function defined here
   --> parquet/src/arrow/array_reader/struct_array.rs:42:12
    |
 42 |     pub fn new(
    |            ^^^
...
 48 |         padding_threshold: Option<i16>,
    |         ------------------------------
help: provide the argument
    |
550 |         let struct_reader = StructArrayReader::new(struct_type, vec![leaf], 0, 0, false, /* Option<i16> */);
    |                                                                                        +++++++++++++++++++
```