### PR TITLE
chore: Fix audit CI run by ignore quick-xml audit advisories

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -41,4 +41,7 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run audit check
-        run: cargo audit
+        # Waiting on an object_store release with quick-xml >=0.41.0.
+        # https://rustsec.org/advisories/RUSTSEC-2026-0194
+        # https://rustsec.org/advisories/RUSTSEC-2026-0195
+        run: cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195


### PR DESCRIPTION
## Which issue does this PR close?

N/A

## Rationale for this change

The audit workflow is failing on main: https://github.com/apache/arrow-rs/actions/runs/28591575622/job/84776210875


```shell
Run cargo audit
    Fetching advisory database from `[https://github.com/RustSec/advisory-db.git`](https://github.com/RustSec/advisory-db.git%60)
      Loaded 1149 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (447 crate dependencies)
Crate:     quick-xml
Version:   0.39.4
Title:     Quadratic run time when checking a start tag for duplicate attribute names
Date:      2026-06-29
ID:        RUSTSEC-2026-0194
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0194
Severity:  7.5 (high)
Solution:  Upgrade to >=0.41.0

Crate:     quick-xml
error: 2 vulnerabilities found!
warning: 1 allowed warning found
Version:   0.39.4
Title:     Unbounded namespace-declaration allocation in `NsReader` enables memory-exhaustion denial of service
Date:      2026-06-29
ID:        RUSTSEC-2026-0195
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0195
Severity:  7.5 (high)
Solution:  Upgrade to >=0.41.0

Crate:     paste
Version:   1.0.15
Warning:   unmaintained
Title:     paste - no longer maintained
Date:      2024-10-07
ID:        RUSTSEC-2024-0436
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0436

Error: Process completed with exit code 1.
```

quick-xml advisories RUSTSEC-2026-0194 and RUSTSEC-2026-0195. quick-xml is pulled in transitively through object_store, and the released object_store versions available to arrow-rs do not yet depend on quick-xml >=0.41.0.

## What changes are included in this PR?

This temporarily ignores the two quick-xml RustSec advisories in the audit workflow and documents the upstream dependency release needed to remove the ignore.

## Are there any user-facing changes?

No.

## Validation

Inspected the failing GitHub Actions audit job and verified the dependency path with cargo tree.