### PR TITLE
Perf: Introduce zero copy path when tonic returns an aligned buffer

### DIFF
--- a/arrow-flight/src/decode.rs
+++ b/arrow-flight/src/decode.rs
@@ -337,7 +337,6 @@ impl FlightDataDecoder {
                     )
                 })?;
                 let buffer = {
-                    // Arrow spec requires 64-byte buffer alignment for SIMD;
                     // see https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
                     // reuse the allocation if already aligned, otherwise copy into a fresh aligned buffer.
                     if data.data_body.as_ptr() as usize % 64 == 0 {

--- a/arrow-flight/src/decode.rs
+++ b/arrow-flight/src/decode.rs
@@ -336,8 +336,18 @@ impl FlightDataDecoder {
                         "Unable to convert flight data header to a record batch".to_string(),
                     )
                 })?;
+                let buffer = {
+                    // Arrow spec requires 64-byte buffer alignment for SIMD;
+                    // see https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
+                    // reuse the allocation  if already aligned, otherwise copy into a fresh aligned buffer.
+                    if data.data_body.as_ptr() as usize % 64 == 0 {
+                        &Buffer::from(data.data_body.clone())
+                    } else {
+                        &Buffer::from(data.data_body.as_ref())
+                    }
+                };
                 let batch = arrow_ipc::reader::RecordBatchDecoder::try_new(
-                    &Buffer::from(data.data_body.as_ref()),
+                    buffer,
                     record_batch,
                     Arc::clone(&state.schema),
                     &state.dictionaries_by_field,

--- a/arrow-flight/src/decode.rs
+++ b/arrow-flight/src/decode.rs
@@ -339,7 +339,7 @@ impl FlightDataDecoder {
                 let buffer = {
                     // Arrow spec requires 64-byte buffer alignment for SIMD;
                     // see https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
-                    // reuse the allocation  if already aligned, otherwise copy into a fresh aligned buffer.
+                    // reuse the allocation if already aligned, otherwise copy into a fresh aligned buffer.
                     if data.data_body.as_ptr() as usize % 64 == 0 {
                         &Buffer::from(data.data_body.clone())
                     } else {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- works towards https://github.com/apache/arrow-rs/issues/10125

# Rationale for this change
see https://github.com/apache/arrow-rs/pull/10206#issuecomment-4785443780

If the buffer Tonic returns happens to be 64-bit aligned ([as the Arrow spec requires](https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding)), we can wrap it directly via `Buffer::from(Bytes)`, a zero-copy path that just increments a reference count. If not, `Buffer::from(&[u8])` copies into a fresh aligned allocation. The check is cheap (a single pointer modulo), and can save a potentially very large buffer copy.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

this PR adds a pointer check for the data body. if the buffer is aligned to a 64 bit address no copy happens, otherwise copy the bytes as usual.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
existing test cover this. if the buffer isn't aligned we fallback to copying it.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
