### PR TITLE
docs: trim release schedule for released versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,20 +91,10 @@ Planned Release Schedule
 
 | Approximate Date | Version    | Notes                                   |
 | ---------------- | ---------- | --------------------------------------- |
-| May 2026         | [`58.3.0`] | Minor, NO breaking API changes          |
-| May 2026         | [`57.3.1`] | Patch, NO breaking API changes          |
-| May 2026         | [`56.2.1`] | Patch, NO breaking API changes          |
-| May 2026         | [`59.0.0`] | Major, potentially breaking API changes |
 | June 2026        | [`59.1.0`] | Minor, NO breaking API changes          |
 | July 2026        | [`59.2.0`] | Minor, NO breaking API changes          |
 | August 2026      | [`60.0.0`] | Major, potentially breaking API changes |
 
-[`58.1.0`]: https://github.com/apache/arrow-rs/issues/9108
-[`58.2.0`]: https://github.com/apache/arrow-rs/issues/9109
-[`58.3.0`]: https://github.com/apache/arrow-rs/issues/9859
-[`57.3.1`]: https://github.com/apache/arrow-rs/issues/9858
-[`56.2.1`]: https://github.com/apache/arrow-rs/issues/9857
-[`59.0.0`]: https://github.com/apache/arrow-rs/issues/9110
 [`59.1.0`]: https://github.com/apache/arrow-rs/issues/9878
 [`59.2.0`]: https://github.com/apache/arrow-rs/issues/9879
 [`60.0.0`]: https://github.com/apache/arrow-rs/issues/9880


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

Previously released versions no longer need to appear in the planned release schedule. Removing them keeps the README focused on current and upcoming releases.

# What changes are included in this PR?

This PR removes release schedule entries and link definitions for releases before 59.1.0, leaving 59.1.0 and later in the schedule.

# Are these changes tested?

Testing is covered by CI.

# Are there any user-facing changes?

No user-facing API changes. This is a README-only documentation update.