### PR TITLE
fix: guard FFI schema metadata on empty schema

### DIFF
--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -187,6 +187,12 @@ impl FFI_ArrowSchema {
         I: IntoIterator<Item = (S, S)>,
         S: AsRef<str>,
     {
+        if self.private_data.is_null() {
+            return Err(ArrowError::CDataInterface(
+                "Cannot set metadata on FFI_ArrowSchema with null private_data".to_string(),
+            ));
+        }
+
         let metadata: Vec<(S, S)> = metadata.into_iter().collect();
         // https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowSchema.metadata
         let new_metadata = if !metadata.is_empty() {
@@ -1000,6 +1006,17 @@ mod tests {
             let field = Field::try_from(&schema).unwrap();
             assert_eq!(field.metadata(), &metadata);
         }
+    }
+
+    #[test]
+    fn test_set_metadata_on_empty_schema_errors() {
+        let err = FFI_ArrowSchema::empty()
+            .with_metadata([("key", "value")])
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ArrowError::CDataInterface(message) if message.contains("null private_data")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10286.

# Rationale for this change

`FFI_ArrowSchema::empty()` leaves `private_data` null. Calling the safe `with_metadata` builder on that value previously reached `Box::from_raw(self.private_data as *mut SchemaPrivateData)`, which is undefined behavior for a null pointer.

# What changes are included in this PR?

- Return a `CDataInterface` error from `FFI_ArrowSchema::with_metadata` when `private_data` is null.
- Add a regression test for calling `with_metadata` on `FFI_ArrowSchema::empty()`.

# Are these changes tested?

Yes:

- `cargo fmt -p arrow-schema -- --check`
- `cargo test -p arrow-schema --features ffi test_set_metadata_on_empty_schema_errors -- --nocapture`
- `cargo test -p arrow-schema --features ffi test_set_field_metadata -- --nocapture`
- `cargo test -p arrow-schema --features ffi ffi::tests::test_schema -- --nocapture`
- `cargo test -p arrow-schema --features ffi`
- `cargo clippy -p arrow-schema --features ffi --all-targets -- -D warnings`

# Are there any user-facing changes?

No API shape changes. Calling `with_metadata` on an empty/released FFI schema now returns an error instead of invoking undefined behavior.

# AI assistance

AI assistance was used to prepare this small patch; I reviewed the change and verified it with the commands listed above.
