### PR TITLE
chore: formalize the default map field names to match default arrow spec

### DIFF
--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -347,9 +347,13 @@ impl MapArray {
         let entry_offsets_buffer = Buffer::from(entry_offsets.to_byte_slice());
         let keys_data = StringArray::from_iter_values(keys);
 
-        let keys_field = Arc::new(Field::new("key", DataType::Utf8, false));
+        let keys_field = Arc::new(Field::new(
+            Field::MAP_KEY_FIELD_DEFAULT_NAME,
+            DataType::Utf8,
+            false,
+        ));
         let values_field = Arc::new(Field::new(
-            "value",
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
             values.data_type().clone(),
             values.null_count() > 0,
         ));
@@ -838,8 +842,8 @@ mod tests {
         // A DictionaryArray has similar buffer layout to a MapArray
         // but the meaning of the values differs
         let struct_t = DataType::Struct(Fields::from(vec![
-            Field::new("key", DataType::Int32, true),
-            Field::new("value", DataType::UInt32, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, true),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, true),
         ]));
         let dict_t = DataType::Dictionary(Box::new(DataType::Int32), Box::new(struct_t));
         let _ = MapArray::from(ArrayData::new_empty(&dict_t));
@@ -870,8 +874,16 @@ mod tests {
 
         let key_array = Arc::new(StringArray::from(vec!["a", "b", "c"])) as ArrayRef;
         let value_array = Arc::new(UInt32Array::from(vec![0u32, 10, 20])) as ArrayRef;
-        let keys_field = Arc::new(Field::new("key", DataType::Utf8, false));
-        let values_field = Arc::new(Field::new("value", DataType::UInt32, false));
+        let keys_field = Arc::new(Field::new(
+            Field::MAP_KEY_FIELD_DEFAULT_NAME,
+            DataType::Utf8,
+            false,
+        ));
+        let values_field = Arc::new(Field::new(
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::UInt32,
+            false,
+        ));
         let struct_array =
             StructArray::from(vec![(keys_field, key_array), (values_field, value_array)]);
         assert_eq!(

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -347,9 +347,9 @@ impl MapArray {
         let entry_offsets_buffer = Buffer::from(entry_offsets.to_byte_slice());
         let keys_data = StringArray::from_iter_values(keys);
 
-        let keys_field = Arc::new(Field::new("keys", DataType::Utf8, false));
+        let keys_field = Arc::new(Field::new("key", DataType::Utf8, false));
         let values_field = Arc::new(Field::new(
-            "values",
+            "value",
             values.data_type().clone(),
             values.null_count() > 0,
         ));
@@ -361,7 +361,7 @@ impl MapArray {
 
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 entry_struct.data_type().clone(),
                 false,
             )),
@@ -606,8 +606,8 @@ mod tests {
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
         let entry_offsets = Buffer::from([0, 3, 6, 8].to_byte_slice());
 
-        let keys = Arc::new(Field::new("keys", DataType::Int32, false));
-        let values = Arc::new(Field::new("values", DataType::UInt32, false));
+        let keys = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false));
+        let values = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, false));
         let entry_struct = StructArray::from(vec![
             (keys, make_array(keys_data)),
             (values, make_array(values_data)),
@@ -616,7 +616,7 @@ mod tests {
         // Construct a map array from the above two
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 entry_struct.data_type().clone(),
                 false,
             )),
@@ -652,8 +652,8 @@ mod tests {
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
         let entry_offsets = Buffer::from([0, 3, 6, 8].to_byte_slice());
 
-        let keys_field = Arc::new(Field::new("keys", DataType::Int32, false));
-        let values_field = Arc::new(Field::new("values", DataType::UInt32, true));
+        let keys_field = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false));
+        let values_field = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, true));
         let entry_struct = StructArray::from(vec![
             (keys_field.clone(), make_array(key_data)),
             (values_field.clone(), make_array(value_data.clone())),
@@ -662,7 +662,7 @@ mod tests {
         // Construct a map array from the above two
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 entry_struct.data_type().clone(),
                 false,
             )),
@@ -773,8 +773,8 @@ mod tests {
         //  [[3, 4, 5], [6, 7]]
         let entry_offsets = Buffer::from([0, 3, 5].to_byte_slice());
 
-        let keys = Arc::new(Field::new("keys", DataType::Int32, false));
-        let values = Arc::new(Field::new("values", DataType::UInt32, false));
+        let keys = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false));
+        let values = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, false));
         let entry_struct = StructArray::from(vec![
             (keys, make_array(keys_data)),
             (values, make_array(values_data)),
@@ -783,7 +783,7 @@ mod tests {
         // Construct a map array from the above two
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 entry_struct.data_type().clone(),
                 false,
             )),
@@ -814,8 +814,8 @@ mod tests {
         // A DictionaryArray has similar buffer layout to a MapArray
         // but the meaning of the values differs
         let struct_t = DataType::Struct(Fields::from(vec![
-            Field::new("keys", DataType::Int32, true),
-            Field::new("values", DataType::UInt32, true),
+            Field::new("key", DataType::Int32, true),
+            Field::new("value", DataType::UInt32, true),
         ]));
         let dict_t = DataType::Dictionary(Box::new(DataType::Int32), Box::new(struct_t));
         let _ = MapArray::from(ArrayData::new_empty(&dict_t));
@@ -846,8 +846,8 @@ mod tests {
 
         let key_array = Arc::new(StringArray::from(vec!["a", "b", "c"])) as ArrayRef;
         let value_array = Arc::new(UInt32Array::from(vec![0u32, 10, 20])) as ArrayRef;
-        let keys_field = Arc::new(Field::new("keys", DataType::Utf8, false));
-        let values_field = Arc::new(Field::new("values", DataType::UInt32, false));
+        let keys_field = Arc::new(Field::new("key", DataType::Utf8, false));
+        let values_field = Arc::new(Field::new("value", DataType::UInt32, false));
         let struct_array =
             StructArray::from(vec![(keys_field, key_array), (values_field, value_array)]);
         assert_eq!(
@@ -871,8 +871,8 @@ mod tests {
     fn test_try_new() {
         let offsets = OffsetBuffer::new(vec![0, 1, 4, 5].into());
         let fields = Fields::from(vec![
-            Field::new("key", DataType::Int32, false),
-            Field::new("values", DataType::Int32, false),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, false),
         ]);
         let columns = vec![
             Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])) as _,
@@ -880,7 +880,7 @@ mod tests {
         ];
 
         let entries = StructArray::new(fields.clone(), columns, None);
-        let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
+        let field = Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, DataType::Struct(fields), false));
 
         MapArray::new(field.clone(), offsets.clone(), entries.clone(), None, false);
 
@@ -933,7 +933,7 @@ mod tests {
         ];
 
         let s = StructArray::new(fields.clone(), columns, None);
-        let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
+        let field = Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, DataType::Struct(fields), false));
         let err = MapArray::try_new(field, offsets, s, None, false).unwrap_err();
 
         assert_eq!(
@@ -948,12 +948,12 @@ mod tests {
         let keys = Int32Array::from(vec![Some(1), None]);
         let values = Int32Array::from(vec![None, Some(2)]);
         let fields = Fields::from(vec![
-            Field::new("keys", DataType::Int32, true),
-            Field::new("values", DataType::Int32, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, true),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
         ]);
         let entries =
             StructArray::new(fields.clone(), vec![Arc::new(keys), Arc::new(values)], None);
-        let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
+        let field = Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, DataType::Struct(fields), false));
 
         let err = MapArray::try_new(field, OffsetBuffer::from_lengths([2]), entries, None, false)
             .unwrap_err();

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -606,8 +606,16 @@ mod tests {
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
         let entry_offsets = Buffer::from([0, 3, 6, 8].to_byte_slice());
 
-        let keys = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false));
-        let values = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, false));
+        let keys = Arc::new(Field::new(
+            Field::MAP_KEY_FIELD_DEFAULT_NAME,
+            DataType::Int32,
+            false,
+        ));
+        let values = Arc::new(Field::new(
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::UInt32,
+            false,
+        ));
         let entry_struct = StructArray::from(vec![
             (keys, make_array(keys_data)),
             (values, make_array(values_data)),
@@ -652,8 +660,16 @@ mod tests {
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
         let entry_offsets = Buffer::from([0, 3, 6, 8].to_byte_slice());
 
-        let keys_field = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false));
-        let values_field = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, true));
+        let keys_field = Arc::new(Field::new(
+            Field::MAP_KEY_FIELD_DEFAULT_NAME,
+            DataType::Int32,
+            false,
+        ));
+        let values_field = Arc::new(Field::new(
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::UInt32,
+            true,
+        ));
         let entry_struct = StructArray::from(vec![
             (keys_field.clone(), make_array(key_data)),
             (values_field.clone(), make_array(value_data.clone())),
@@ -773,8 +789,16 @@ mod tests {
         //  [[3, 4, 5], [6, 7]]
         let entry_offsets = Buffer::from([0, 3, 5].to_byte_slice());
 
-        let keys = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false));
-        let values = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, false));
+        let keys = Arc::new(Field::new(
+            Field::MAP_KEY_FIELD_DEFAULT_NAME,
+            DataType::Int32,
+            false,
+        ));
+        let values = Arc::new(Field::new(
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::UInt32,
+            false,
+        ));
         let entry_struct = StructArray::from(vec![
             (keys, make_array(keys_data)),
             (values, make_array(values_data)),
@@ -880,7 +904,11 @@ mod tests {
         ];
 
         let entries = StructArray::new(fields.clone(), columns, None);
-        let field = Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, DataType::Struct(fields), false));
+        let field = Arc::new(Field::new(
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            DataType::Struct(fields),
+            false,
+        ));
 
         MapArray::new(field.clone(), offsets.clone(), entries.clone(), None, false);
 
@@ -933,7 +961,11 @@ mod tests {
         ];
 
         let s = StructArray::new(fields.clone(), columns, None);
-        let field = Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, DataType::Struct(fields), false));
+        let field = Arc::new(Field::new(
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            DataType::Struct(fields),
+            false,
+        ));
         let err = MapArray::try_new(field, offsets, s, None, false).unwrap_err();
 
         assert_eq!(
@@ -953,7 +985,11 @@ mod tests {
         ]);
         let entries =
             StructArray::new(fields.clone(), vec![Arc::new(keys), Arc::new(values)], None);
-        let field = Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, DataType::Struct(fields), false));
+        let field = Arc::new(Field::new(
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            DataType::Struct(fields),
+            false,
+        ));
 
         let err = MapArray::try_new(field, OffsetBuffer::from_lengths([2]), entries, None, false)
             .unwrap_err();

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -1178,10 +1178,10 @@ mod tests {
     fn test_null_map() {
         let data_type = DataType::Map(
             Arc::new(Field::new(
-                "entry",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 DataType::Struct(Fields::from(vec![
-                    Field::new("key", DataType::Utf8, false),
-                    Field::new("value", DataType::Int32, true),
+                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
                 ])),
                 false,
             )),

--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -398,7 +398,11 @@ mod tests {
                     Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                     DataType::Struct(
                         vec![
-                            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false)),
+                            Arc::new(Field::new(
+                                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                                DataType::Int32,
+                                false
+                            )),
                             value_field.clone()
                         ]
                         .into()
@@ -422,7 +426,11 @@ mod tests {
                     Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                     DataType::Struct(
                         vec![
-                            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false)),
+                            Arc::new(Field::new(
+                                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                                DataType::Int32,
+                                false
+                            )),
                             value_field
                         ]
                         .into()
@@ -460,7 +468,11 @@ mod tests {
                                 Field::new("other", DataType::Int32, false)
                                     .with_metadata(key_metadata)
                             ),
-                            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true))
+                            Arc::new(Field::new(
+                                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                                DataType::Int32,
+                                true
+                            ))
                         ]
                         .into()
                     ),

--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -523,7 +523,11 @@ mod tests {
     #[should_panic(expected = "Keys field must not be nullable")]
     fn test_with_nullable_keys_field() {
         let mut builder = MapBuilder::new(None, Int32Builder::new(), Int32Builder::new())
-            .with_keys_field(Arc::new(Field::new("key", DataType::Int32, true)));
+            .with_keys_field(Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Int32,
+                true,
+            )));
 
         builder.keys().append_value(1);
         builder.values().append_value(2);
@@ -536,7 +540,11 @@ mod tests {
     #[should_panic(expected = "Incorrect datatype")]
     fn test_keys_field_type_mismatch() {
         let mut builder = MapBuilder::new(None, Int32Builder::new(), Int32Builder::new())
-            .with_keys_field(Arc::new(Field::new("key", DataType::Utf8, false)));
+            .with_keys_field(Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Utf8,
+                false,
+            )));
 
         builder.keys().append_value(1);
         builder.values().append_value(2);

--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -447,7 +447,7 @@ mod tests {
         let mut key_metadata = HashMap::new();
         key_metadata.insert("foo".to_string(), "bar".to_string());
         let key_field = Arc::new(
-            Field::new("other", DataType::Int32, false).with_metadata(key_metadata.clone()),
+            Field::new("other_key", DataType::Int32, false).with_metadata(key_metadata.clone()),
         );
         let mut builder = MapBuilder::new(None, Int32Builder::new(), Int32Builder::new())
             .with_keys_field(key_field.clone());
@@ -465,7 +465,7 @@ mod tests {
                     DataType::Struct(
                         vec![
                             Arc::new(
-                                Field::new("other", DataType::Int32, false)
+                                Field::new("other_key", DataType::Int32, false)
                                     .with_metadata(key_metadata)
                             ),
                             Arc::new(Field::new(

--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -79,9 +79,9 @@ pub struct MapFieldNames {
 impl Default for MapFieldNames {
     fn default() -> Self {
         Self {
-            entry: "entries".to_string(),
-            key: "keys".to_string(),
-            value: "values".to_string(),
+            entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
+            key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
+            value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
         }
     }
 }
@@ -395,10 +395,10 @@ mod tests {
             map.data_type(),
             &DataType::Map(
                 Arc::new(Field::new(
-                    "entries",
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                     DataType::Struct(
                         vec![
-                            Arc::new(Field::new("keys", DataType::Int32, false)),
+                            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false)),
                             value_field.clone()
                         ]
                         .into()
@@ -419,10 +419,10 @@ mod tests {
             map.data_type(),
             &DataType::Map(
                 Arc::new(Field::new(
-                    "entries",
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                     DataType::Struct(
                         vec![
-                            Arc::new(Field::new("keys", DataType::Int32, false)),
+                            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false)),
                             value_field
                         ]
                         .into()
@@ -439,7 +439,7 @@ mod tests {
         let mut key_metadata = HashMap::new();
         key_metadata.insert("foo".to_string(), "bar".to_string());
         let key_field = Arc::new(
-            Field::new("keys", DataType::Int32, false).with_metadata(key_metadata.clone()),
+            Field::new("other", DataType::Int32, false).with_metadata(key_metadata.clone()),
         );
         let mut builder = MapBuilder::new(None, Int32Builder::new(), Int32Builder::new())
             .with_keys_field(key_field.clone());
@@ -453,14 +453,14 @@ mod tests {
             map.data_type(),
             &DataType::Map(
                 Arc::new(Field::new(
-                    "entries",
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                     DataType::Struct(
                         vec![
                             Arc::new(
-                                Field::new("keys", DataType::Int32, false)
+                                Field::new("other", DataType::Int32, false)
                                     .with_metadata(key_metadata)
                             ),
-                            Arc::new(Field::new("values", DataType::Int32, true))
+                            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true))
                         ]
                         .into()
                     ),
@@ -511,7 +511,7 @@ mod tests {
     #[should_panic(expected = "Keys field must not be nullable")]
     fn test_with_nullable_keys_field() {
         let mut builder = MapBuilder::new(None, Int32Builder::new(), Int32Builder::new())
-            .with_keys_field(Arc::new(Field::new("keys", DataType::Int32, true)));
+            .with_keys_field(Arc::new(Field::new("key", DataType::Int32, true)));
 
         builder.keys().append_value(1);
         builder.values().append_value(2);
@@ -524,7 +524,7 @@ mod tests {
     #[should_panic(expected = "Incorrect datatype")]
     fn test_keys_field_type_mismatch() {
         let mut builder = MapBuilder::new(None, Int32Builder::new(), Int32Builder::new())
-            .with_keys_field(Arc::new(Field::new("keys", DataType::Utf8, false)));
+            .with_keys_field(Arc::new(Field::new("key", DataType::Utf8, false)));
 
         builder.keys().append_value(1);
         builder.values().append_value(2);

--- a/arrow-avro/benches/avro_writer.rs
+++ b/arrow-avro/benches/avro_writer.rs
@@ -623,10 +623,10 @@ static DECIMAL256_DATA: Lazy<Vec<RecordBatch>> = Lazy::new(|| {
 static MAP_DATA: Lazy<Vec<RecordBatch>> = Lazy::new(|| {
     use arrow_array::builder::{MapBuilder, StringBuilder};
 
-    let key_field = Arc::new(Field::new("keys", DataType::Utf8, false));
-    let value_field = Arc::new(Field::new("values", DataType::Utf8, true));
+    let key_field = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false));
+    let value_field = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true));
     let entry_struct = Field::new(
-        "entries",
+        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
         DataType::Struct(vec![key_field.as_ref().clone(), value_field.as_ref().clone()].into()),
         false,
     );

--- a/arrow-avro/benches/avro_writer.rs
+++ b/arrow-avro/benches/avro_writer.rs
@@ -623,8 +623,16 @@ static DECIMAL256_DATA: Lazy<Vec<RecordBatch>> = Lazy::new(|| {
 static MAP_DATA: Lazy<Vec<RecordBatch>> = Lazy::new(|| {
     use arrow_array::builder::{MapBuilder, StringBuilder};
 
-    let key_field = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false));
-    let value_field = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true));
+    let key_field = Arc::new(Field::new(
+        Field::MAP_KEY_FIELD_DEFAULT_NAME,
+        DataType::Utf8,
+        false,
+    ));
+    let value_field = Arc::new(Field::new(
+        Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+        DataType::Utf8,
+        true,
+    ));
     let entry_struct = Field::new(
         Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
         DataType::Struct(vec![key_field.as_ref().clone(), value_field.as_ref().clone()].into()),

--- a/arrow-avro/src/codec.rs
+++ b/arrow-avro/src/codec.rs
@@ -931,12 +931,12 @@ impl Codec {
             }
             Self::Struct(f) => DataType::Struct(f.iter().map(|x| x.field()).collect()),
             Self::Map(value_type) => {
-                let val_field = value_type.field_with_name("value");
+                let val_field = value_type.field_with_name(Field::MAP_VALUE_FIELD_DEFAULT_NAME);
                 DataType::Map(
                     Arc::new(Field::new(
-                        "entries",
+                        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                         DataType::Struct(Fields::from(vec![
-                            Field::new("key", DataType::Utf8, false),
+                            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
                             val_field,
                         ])),
                         false,

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -3040,12 +3040,16 @@ mod test {
             list_builder.append(true);
         }
         arrays.push(Arc::new(list_builder.finish()));
-        let values_field = Arc::new(Field::new("value", DataType::Int64, false));
+        let values_field = Arc::new(Field::new(
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::Int64,
+            false,
+        ));
         let mut map_builder = MapBuilder::new(
             Some(builder::MapFieldNames {
-                entry: "entries".to_string(),
-                key: "key".to_string(),
-                value: "value".to_string(),
+                entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
+                key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
+                value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
             }),
             StringBuilder::new(),
             Int64Builder::new(),
@@ -6270,9 +6274,9 @@ mod test {
         iaa_builder.append(true);
         let int_array_array = iaa_builder.finish();
         let field_names = MapFieldNames {
-            entry: "entries".to_string(),
-            key: "key".to_string(),
-            value: "value".to_string(),
+            entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
+            key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
+            value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
         };
         let mut int_map_builder =
             MapBuilder::new(Some(field_names), StringBuilder::new(), Int32Builder::new());
@@ -6284,9 +6288,9 @@ mod test {
         int_map_builder.append(true).unwrap(); // finalize map for row 0
         let int_map = int_map_builder.finish();
         let field_names2 = MapFieldNames {
-            entry: "entries".to_string(),
-            key: "key".to_string(),
-            value: "value".to_string(),
+            entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
+            key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
+            value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
         };
         let mut ima_builder = ListBuilder::new(MapBuilder::new(
             Some(field_names2),
@@ -6372,17 +6376,17 @@ mod test {
             .with_metadata(meta_h.clone());
         // G.value : Struct<{ h: ... }> with metadata (G)
         let g_value_struct_field = Field::new(
-            "value",
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
             DataType::Struct(vec![h_field.clone()].into()),
             true,
         )
         .with_metadata(meta_g_value.clone());
         // entries struct for Map G
         let entries_struct_field = Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(
                 vec![
-                    Field::new("key", DataType::Utf8, false),
+                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
                     g_value_struct_field.clone(),
                 ]
                 .into(),
@@ -6441,9 +6445,9 @@ mod test {
                 },
                 {
                     let map_field_names = MapFieldNames {
-                        entry: "entries".to_string(),
-                        key: "key".to_string(),
-                        value: "value".to_string(),
+                        entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
+                        key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
+                        value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
                     };
                     let i_list_builder = ListBuilder::new(Float64Builder::new());
                     let h_struct_builder = StructBuilder::new(
@@ -6469,7 +6473,7 @@ mod test {
                     )
                     .with_values_field(Arc::new(
                         Field::new(
-                            "value",
+                            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
                             DataType::Struct(vec![h_field.clone()].into()),
                             true,
                         )
@@ -8703,11 +8707,11 @@ mod test {
         )
         .unwrap();
         let map_entries_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(Fields::from(vec![
-                Field::new("key", DataType::Utf8, false),
+                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
                 Field::new(
-                    "value",
+                    Field::MAP_VALUE_FIELD_DEFAULT_NAME,
                     DataType::Union(uf_map_vals.clone(), UnionMode::Dense),
                     true,
                 ),
@@ -8737,10 +8741,10 @@ mod test {
             Field::new("y", DataType::Binary, false),
         ]);
         let union_map_entries = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(Fields::from(vec![
-                Field::new("key", DataType::Utf8, false),
-                Field::new("value", DataType::Utf8, false),
+                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, false),
             ])),
             false,
         ));
@@ -8919,10 +8923,10 @@ mod test {
             Field::new(item_name, DataType::Struct(kv_fields.clone()), false).with_metadata(kv_md),
         );
         let map_int_entries = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(Fields::from(vec![
-                Field::new("key", DataType::Utf8, false),
-                Field::new("value", DataType::Int32, false),
+                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, false),
             ])),
             false,
         ));
@@ -9165,8 +9169,8 @@ mod test {
                 let vals = Int32Array::from(vec![1, 2, 10]);
                 let entries = StructArray::new(
                     Fields::from(vec![
-                        Field::new("key", DataType::Utf8, false),
-                        Field::new("value", DataType::Int32, false),
+                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                        Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, false),
                     ]),
                     vec![Arc::new(keys) as ArrayRef, Arc::new(vals) as ArrayRef],
                     None,
@@ -9314,8 +9318,8 @@ mod test {
                     let vals = StringArray::from(vec!["v"]);
                     let entries = StructArray::new(
                         Fields::from(vec![
-                            Field::new("key", DataType::Utf8, false),
-                            Field::new("value", DataType::Utf8, false),
+                            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, false),
                         ]),
                         vec![Arc::new(keys) as ArrayRef, Arc::new(vals) as ArrayRef],
                         None,
@@ -9393,9 +9397,9 @@ mod test {
             });
             let entries = StructArray::new(
                 Fields::from(vec![
-                    Field::new("key", DataType::Utf8, false),
+                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
                     Field::new(
-                        "value",
+                        Field::MAP_VALUE_FIELD_DEFAULT_NAME,
                         DataType::Union(uf_map_vals.clone(), UnionMode::Dense),
                         true,
                     ),

--- a/arrow-avro/src/reader/record.rs
+++ b/arrow-avro/src/reader/record.rs
@@ -505,11 +505,15 @@ impl Decoder {
                 Self::Record(arrow_fields.into(), encodings, field_defaults, projector)
             }
             (Codec::Map(child), _) => {
-                let val_field = child.field_with_name("value");
+                let val_field = child.field_with_name(ArrowField::MAP_VALUE_FIELD_DEFAULT_NAME);
                 let map_field = Arc::new(ArrowField::new(
-                    "entries",
+                    ArrowField::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                     DataType::Struct(Fields::from(vec![
-                        ArrowField::new("key", DataType::Utf8, false),
+                        ArrowField::new(
+                            ArrowField::MAP_KEY_FIELD_DEFAULT_NAME,
+                            DataType::Utf8,
+                            false,
+                        ),
                         val_field,
                     ])),
                     false,

--- a/arrow-avro/src/schema.rs
+++ b/arrow-avro/src/schema.rs
@@ -2991,11 +2991,11 @@ mod tests {
         let avro_list = AvroSchema::try_from(&list_schema).unwrap();
         assert_json_contains(&avro_list.json_string, "\"type\":\"array\"");
         assert_json_contains(&avro_list.json_string, "\"items\"");
-        let value_field = ArrowField::new("value", DataType::Boolean, true);
+        let value_field = ArrowField::new(arrow_schema::Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Boolean, true);
         let entries_struct = ArrowField::new(
-            "entries",
+            arrow_schema::Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(Fields::from(vec![
-                ArrowField::new("key", DataType::Utf8, false),
+                ArrowField::new(arrow_schema::Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
                 value_field.clone(),
             ])),
             false,
@@ -3244,11 +3244,11 @@ mod tests {
         );
         let expected_b = ArrowField::new("b", DataType::List(Arc::new(expected_list_item)), false);
 
-        let expected_map_value = ArrowField::new("value", DataType::Float64, false);
+        let expected_map_value = ArrowField::new(arrow_schema::Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Float64, false);
         let expected_entries = ArrowField::new(
-            "entries",
+            arrow_schema::Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(Fields::from(vec![
-                ArrowField::new("key", DataType::Utf8, false),
+                ArrowField::new(arrow_schema::Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
                 expected_map_value,
             ])),
             false,

--- a/arrow-avro/src/schema.rs
+++ b/arrow-avro/src/schema.rs
@@ -3201,11 +3201,19 @@ mod tests {
     #[cfg(feature = "avro_custom_types")]
     #[test]
     fn test_map_duration_value_extra() {
-        let val_field = ArrowField::new("value", DataType::Duration(TimeUnit::Second), true);
+        let val_field = ArrowField::new(
+            ArrowField::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::Duration(TimeUnit::Second),
+            true,
+        );
         let entries_struct = ArrowField::new(
-            "entries",
+            ArrowField::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(Fields::from(vec![
-                ArrowField::new("key", DataType::Utf8, false),
+                ArrowField::new(
+                    ArrowField::MAP_KEY_FIELD_DEFAULT_NAME,
+                    DataType::Utf8,
+                    false,
+                ),
                 val_field,
             ])),
             false,

--- a/arrow-avro/src/schema.rs
+++ b/arrow-avro/src/schema.rs
@@ -2991,11 +2991,19 @@ mod tests {
         let avro_list = AvroSchema::try_from(&list_schema).unwrap();
         assert_json_contains(&avro_list.json_string, "\"type\":\"array\"");
         assert_json_contains(&avro_list.json_string, "\"items\"");
-        let value_field = ArrowField::new(arrow_schema::Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Boolean, true);
+        let value_field = ArrowField::new(
+            arrow_schema::Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::Boolean,
+            true,
+        );
         let entries_struct = ArrowField::new(
             arrow_schema::Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(Fields::from(vec![
-                ArrowField::new(arrow_schema::Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                ArrowField::new(
+                    arrow_schema::Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                    DataType::Utf8,
+                    false,
+                ),
                 value_field.clone(),
             ])),
             false,
@@ -3244,11 +3252,19 @@ mod tests {
         );
         let expected_b = ArrowField::new("b", DataType::List(Arc::new(expected_list_item)), false);
 
-        let expected_map_value = ArrowField::new(arrow_schema::Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Float64, false);
+        let expected_map_value = ArrowField::new(
+            arrow_schema::Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::Float64,
+            false,
+        );
         let expected_entries = ArrowField::new(
             arrow_schema::Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(Fields::from(vec![
-                ArrowField::new(arrow_schema::Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                ArrowField::new(
+                    arrow_schema::Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                    DataType::Utf8,
+                    false,
+                ),
                 expected_map_value,
             ])),
             false,

--- a/arrow-avro/src/writer/encoder.rs
+++ b/arrow-avro/src/writer/encoder.rs
@@ -1011,7 +1011,7 @@ fn find_struct_child_index(fields: &arrow_schema::Fields, name: &str) -> Option<
 
 fn find_map_value_field_index(fields: &arrow_schema::Fields) -> Option<usize> {
     // Prefer common Arrow field names; fall back to second child if exactly two
-    find_struct_child_index(fields, "value")
+    find_struct_child_index(fields, Field::MAP_VALUE_FIELD_DEFAULT_NAME)
         .or_else(|| find_struct_child_index(fields, "values"))
         .or_else(|| if fields.len() == 2 { Some(1) } else { None })
 }
@@ -2893,8 +2893,8 @@ mod tests {
         let keys = StringArray::from(vec!["k1", "k2"]);
         let values = Int32Array::from(vec![1, 2]);
         let entries_fields = Fields::from(vec![
-            Field::new("key", DataType::Utf8, false),
-            Field::new("value", DataType::Int32, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
         ]);
         let entries = StructArray::new(
             entries_fields,
@@ -2903,7 +2903,7 @@ mod tests {
         );
         let offsets = arrow_buffer::OffsetBuffer::new(vec![0i32, 2, 2].into());
         let map = MapArray::new(
-            Field::new("entries", entries.data_type().clone(), false).into(),
+            Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, entries.data_type().clone(), false).into(),
             offsets,
             entries,
             None,
@@ -3378,8 +3378,8 @@ mod tests {
         let values = Int32Array::from(vec![Some(7), None]);
 
         let entries_fields = Fields::from(vec![
-            Field::new("key", DataType::Utf8, false),
-            Field::new("value", DataType::Int32, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
         ]);
         let entries = StructArray::new(
             entries_fields,
@@ -3390,7 +3390,7 @@ mod tests {
         // Single row -> offsets [0, 2]
         let offsets = arrow_buffer::OffsetBuffer::new(vec![0i32, 2].into());
         let map = MapArray::new(
-            Field::new("entries", entries.data_type().clone(), false).into(),
+            Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, entries.data_type().clone(), false).into(),
             offsets,
             entries,
             None,

--- a/arrow-avro/src/writer/encoder.rs
+++ b/arrow-avro/src/writer/encoder.rs
@@ -2903,7 +2903,12 @@ mod tests {
         );
         let offsets = arrow_buffer::OffsetBuffer::new(vec![0i32, 2, 2].into());
         let map = MapArray::new(
-            Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, entries.data_type().clone(), false).into(),
+            Field::new(
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                entries.data_type().clone(),
+                false,
+            )
+            .into(),
             offsets,
             entries,
             None,
@@ -3390,7 +3395,12 @@ mod tests {
         // Single row -> offsets [0, 2]
         let offsets = arrow_buffer::OffsetBuffer::new(vec![0i32, 2].into());
         let map = MapArray::new(
-            Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, entries.data_type().clone(), false).into(),
+            Field::new(
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                entries.data_type().clone(),
+                false,
+            )
+            .into(),
             offsets,
             entries,
             None,

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -10142,11 +10142,7 @@ mod tests {
     fn test_cast_map_dont_allow_change_of_order() {
         let string_builder = StringBuilder::new();
         let value_builder = StringBuilder::new();
-        let mut builder = MapBuilder::new(
-            None,
-            string_builder,
-            value_builder,
-        );
+        let mut builder = MapBuilder::new(None, string_builder, value_builder);
 
         builder.keys().append_value("0");
         builder.values().append_value("test_val_1");
@@ -10189,11 +10185,7 @@ mod tests {
     fn test_cast_map_dont_allow_when_container_cant_cast() {
         let string_builder = StringBuilder::new();
         let value_builder = IntervalDayTimeArray::builder(2);
-        let mut builder = MapBuilder::new(
-            None,
-            string_builder,
-            value_builder,
-        );
+        let mut builder = MapBuilder::new(None, string_builder, value_builder);
 
         builder.keys().append_value("0");
         builder.values().append_value(IntervalDayTime::new(1, 1));
@@ -10311,11 +10303,7 @@ mod tests {
     fn test_cast_map_contained_values() {
         let string_builder = StringBuilder::new();
         let value_builder = Int8Builder::new();
-        let mut builder = MapBuilder::new(
-            None,
-            string_builder,
-            value_builder,
-        );
+        let mut builder = MapBuilder::new(None, string_builder, value_builder);
 
         builder.keys().append_value("0");
         builder.values().append_value(44);

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -10143,11 +10143,7 @@ mod tests {
         let string_builder = StringBuilder::new();
         let value_builder = StringBuilder::new();
         let mut builder = MapBuilder::new(
-            Some(MapFieldNames {
-                entry: "entries".to_string(),
-                key: "key".to_string(),
-                value: "value".to_string(),
-            }),
+            None,
             string_builder,
             value_builder,
         );
@@ -10165,11 +10161,11 @@ mod tests {
         let new_ordered = true;
         let new_type = DataType::Map(
             Arc::new(Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 DataType::Struct(
                     vec![
-                        Field::new("key", DataType::Utf8, false),
-                        Field::new("value", DataType::Utf8, false),
+                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                        Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, false),
                     ]
                     .into(),
                 ),
@@ -10194,11 +10190,7 @@ mod tests {
         let string_builder = StringBuilder::new();
         let value_builder = IntervalDayTimeArray::builder(2);
         let mut builder = MapBuilder::new(
-            Some(MapFieldNames {
-                entry: "entries".to_string(),
-                key: "key".to_string(),
-                value: "value".to_string(),
-            }),
+            None,
             string_builder,
             value_builder,
         );
@@ -10246,6 +10238,7 @@ mod tests {
         let value_builder = StringBuilder::new();
         let mut builder = MapBuilder::new(
             Some(MapFieldNames {
+                // Explicitly writing the name so it will be apparent from what names to what names are we converting to
                 entry: "entries".to_string(),
                 key: "key".to_string(),
                 value: "value".to_string(),
@@ -10319,11 +10312,7 @@ mod tests {
         let string_builder = StringBuilder::new();
         let value_builder = Int8Builder::new();
         let mut builder = MapBuilder::new(
-            Some(MapFieldNames {
-                entry: "entries".to_string(),
-                key: "key".to_string(),
-                value: "value".to_string(),
-            }),
+            None,
             string_builder,
             value_builder,
         );
@@ -10339,11 +10328,11 @@ mod tests {
 
         let new_type = DataType::Map(
             Arc::new(Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 DataType::Struct(
                     vec![
-                        Field::new("key", DataType::Utf8, false),
-                        Field::new("value", DataType::Utf8, false),
+                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                        Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, false),
                     ]
                     .into(),
                 ),

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -9138,10 +9138,10 @@ mod tests {
         // Cast null from and to map
         let data_type = DataType::Map(
             Arc::new(Field::new_struct(
-                "entry",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 vec![
-                    Field::new("key", DataType::Utf8, false),
-                    Field::new("value", DataType::Int32, true),
+                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
                 ],
                 false,
             )),
@@ -10200,11 +10200,15 @@ mod tests {
         let new_ordered = true;
         let new_type = DataType::Map(
             Arc::new(Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 DataType::Struct(
                     vec![
-                        Field::new("key", DataType::Utf8, false),
-                        Field::new("value", DataType::Duration(TimeUnit::Second), false),
+                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                        Field::new(
+                            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                            DataType::Duration(TimeUnit::Second),
+                            false,
+                        ),
                     ]
                     .into(),
                 ),
@@ -10231,9 +10235,9 @@ mod tests {
         let mut builder = MapBuilder::new(
             Some(MapFieldNames {
                 // Explicitly writing the name so it will be apparent from what names to what names are we converting to
-                entry: "entries".to_string(),
-                key: "key".to_string(),
-                value: "value".to_string(),
+                entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
+                key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
+                value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
             }),
             string_builder,
             value_builder,

--- a/arrow-cast/src/pretty.rs
+++ b/arrow-cast/src/pretty.rs
@@ -1486,7 +1486,7 @@ mod tests {
             Int32Builder::new(),
         )
         .with_values_field(
-            Field::new("values", DataType::Int32, true).with_metadata(money_metadata.clone()),
+            Field::new("my_values", DataType::Int32, true).with_metadata(money_metadata.clone()),
         );
         array
             .keys()

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -2834,7 +2834,7 @@ mod tests {
     #[test]
     fn should_fail_validation_when_having_map_entries_only_have_1_field() {
         let struct_data_type = DataType::Struct(Fields::from(vec![Field::new(
-            "key",
+            Field::MAP_KEY_FIELD_DEFAULT_NAME,
             DataType::Int32,
             false,
         )]));
@@ -2851,7 +2851,7 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(Field::new("entries", struct_data_type, false).into(), false),
+            DataType::Map(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_data_type, false).into(), false),
             1,
             None,
             0,
@@ -2881,8 +2881,8 @@ mod tests {
     #[test]
     fn should_fail_validation_when_having_map_entries_have_3_fields() {
         let struct_data_type = DataType::Struct(Fields::from(vec![
-            Field::new("key", DataType::Int32, false),
-            Field::new("values", DataType::Utf8, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
             Field::new("other", DataType::Int32, true),
         ]));
 
@@ -2902,7 +2902,7 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(Field::new("entries", struct_data_type, false).into(), false),
+            DataType::Map(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_data_type, false).into(), false),
             1,
             None,
             0,
@@ -2932,8 +2932,8 @@ mod tests {
     #[test]
     fn should_fail_validation_when_having_nullable_map_keys() {
         let struct_data_type = DataType::Struct(Fields::from(vec![
-            Field::new("key", DataType::Int32, true),
-            Field::new("values", DataType::Utf8, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, true),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
         ]));
 
         let key_array_data = valid_non_nullable_int32_array_data(2);
@@ -2949,7 +2949,7 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(Field::new("entries", struct_data_type, false).into(), false),
+            DataType::Map(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_data_type, false).into(), false),
             1,
             None,
             0,
@@ -2976,8 +2976,8 @@ mod tests {
     #[test]
     fn should_fail_validation_when_having_entries_is_nullable_for_map() {
         let struct_data_type = DataType::Struct(Fields::from(vec![
-            Field::new("key", DataType::Int32, false),
-            Field::new("values", DataType::Utf8, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
         ]));
 
         let key_array_data = valid_non_nullable_int32_array_data(2);
@@ -2994,7 +2994,7 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(Field::new("entries", struct_data_type, true).into(), false),
+            DataType::Map(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_data_type, true).into(), false),
             1,
             None,
             0,
@@ -3022,8 +3022,8 @@ mod tests {
     #[test]
     fn should_allow_to_create_map_from_data() {
         let struct_data_type = DataType::Struct(Fields::from(vec![
-            Field::new("key", DataType::Int32, false),
-            Field::new("values", DataType::Utf8, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
         ]));
 
         let key_array_data = valid_non_nullable_int32_array_data(2);
@@ -3039,7 +3039,7 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(Field::new("entries", struct_data_type, false).into(), false),
+            DataType::Map(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_data_type, false).into(), false),
             1,
             None,
             0,
@@ -3085,10 +3085,10 @@ mod tests {
     fn empty_and_null_map_array_should_pass_validation() {
         let dt = DataType::Map(
             Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 DataType::Struct(Fields::from(vec![
-                    Field::new("key", DataType::Int32, false),
-                    Field::new("values", DataType::Utf8, true),
+                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
+                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
                 ])),
                 false,
             )

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -2851,7 +2851,15 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_data_type, false).into(), false),
+            DataType::Map(
+                Field::new(
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    struct_data_type,
+                    false,
+                )
+                .into(),
+                false,
+            ),
             1,
             None,
             0,
@@ -2902,7 +2910,15 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_data_type, false).into(), false),
+            DataType::Map(
+                Field::new(
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    struct_data_type,
+                    false,
+                )
+                .into(),
+                false,
+            ),
             1,
             None,
             0,
@@ -2949,7 +2965,15 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_data_type, false).into(), false),
+            DataType::Map(
+                Field::new(
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    struct_data_type,
+                    false,
+                )
+                .into(),
+                false,
+            ),
             1,
             None,
             0,
@@ -2994,7 +3018,15 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_data_type, true).into(), false),
+            DataType::Map(
+                Field::new(
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    struct_data_type,
+                    true,
+                )
+                .into(),
+                false,
+            ),
             1,
             None,
             0,
@@ -3039,7 +3071,15 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_data_type, false).into(), false),
+            DataType::Map(
+                Field::new(
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    struct_data_type,
+                    false,
+                )
+                .into(),
+                false,
+            ),
             1,
             None,
             0,

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -1500,9 +1500,9 @@ mod tests {
 
         let schema = Arc::new(Schema::new(vec![Field::new_map(
             "dict_map",
-            "entries",
-            Field::new_dictionary("keys", DataType::UInt16, DataType::Utf8, false),
-            Field::new_dictionary("values", DataType::UInt16, DataType::Utf8, true),
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            Field::new_dictionary(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::UInt16, DataType::Utf8, false),
+            Field::new_dictionary(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt16, DataType::Utf8, true),
             false,
             false,
         )]));
@@ -1517,9 +1517,9 @@ mod tests {
         let mut decoder = FlightDataDecoder::new(encoder);
         let expected_schema = Schema::new(vec![Field::new_map(
             "dict_map",
-            "entries",
-            Field::new("keys", DataType::Utf8, false),
-            Field::new("values", DataType::Utf8, true),
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
             false,
             false,
         )]);
@@ -1596,9 +1596,9 @@ mod tests {
 
         let schema = Arc::new(Schema::new(vec![Field::new_map(
             "dict_map",
-            "entries",
-            Field::new_dictionary("keys", DataType::UInt16, DataType::Utf8, false),
-            Field::new_dictionary("values", DataType::UInt16, DataType::Utf8, true),
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            Field::new_dictionary(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::UInt16, DataType::Utf8, false),
+            Field::new_dictionary(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt16, DataType::Utf8, true),
             false,
             false,
         )]));

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -1501,8 +1501,18 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new_map(
             "dict_map",
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            Field::new_dictionary(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::UInt16, DataType::Utf8, false),
-            Field::new_dictionary(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt16, DataType::Utf8, true),
+            Field::new_dictionary(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::UInt16,
+                DataType::Utf8,
+                false,
+            ),
+            Field::new_dictionary(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                DataType::UInt16,
+                DataType::Utf8,
+                true,
+            ),
             false,
             false,
         )]));
@@ -1597,8 +1607,18 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new_map(
             "dict_map",
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            Field::new_dictionary(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::UInt16, DataType::Utf8, false),
-            Field::new_dictionary(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt16, DataType::Utf8, true),
+            Field::new_dictionary(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::UInt16,
+                DataType::Utf8,
+                false,
+            ),
+            Field::new_dictionary(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                DataType::UInt16,
+                DataType::Utf8,
+                true,
+            ),
             false,
             false,
         )]));

--- a/arrow-flight/src/sql/metadata/sql_info.rs
+++ b/arrow-flight/src/sql/metadata/sql_info.rs
@@ -179,11 +179,11 @@ static UNION_TYPE: Lazy<DataType> = Lazy::new(|| {
             "int32_to_int32_list_map",
             DataType::Map(
                 Arc::new(Field::new(
-                    "entries",
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                     DataType::Struct(Fields::from(vec![
-                        Field::new("keys", DataType::Int32, false),
+                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
                         Field::new(
-                            "values",
+                            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
                             DataType::List(Arc::new(Field::new_list_field(DataType::Int32, true))),
                             true,
                         ),

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -87,17 +87,17 @@ pub fn canonicalize_schema(schema: &Schema) -> Schema {
                 DataType::Struct(fields) if fields.len() == 2 => {
                     let first_field = &fields[0];
                     let key_field =
-                        Arc::new(Field::new("key", first_field.data_type().clone(), false));
+                        Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, first_field.data_type().clone(), false));
                     let second_field = &fields[1];
                     let value_field = Arc::new(Field::new(
-                        "value",
+                        Field::MAP_VALUE_FIELD_DEFAULT_NAME,
                         second_field.data_type().clone(),
                         second_field.is_nullable(),
                     ));
 
                     let fields = Fields::from([key_field, value_field]);
                     let struct_type = DataType::Struct(fields);
-                    let child_field = Field::new("entries", struct_type, false);
+                    let child_field = Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_type, false);
 
                     Arc::new(Field::new(
                         field.name().as_str(),

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -86,8 +86,11 @@ pub fn canonicalize_schema(schema: &Schema) -> Schema {
             DataType::Map(child_field, sorted) => match child_field.data_type() {
                 DataType::Struct(fields) if fields.len() == 2 => {
                     let first_field = &fields[0];
-                    let key_field =
-                        Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, first_field.data_type().clone(), false));
+                    let key_field = Arc::new(Field::new(
+                        Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                        first_field.data_type().clone(),
+                        false,
+                    ));
                     let second_field = &fields[1];
                     let value_field = Arc::new(Field::new(
                         Field::MAP_VALUE_FIELD_DEFAULT_NAME,
@@ -97,7 +100,8 @@ pub fn canonicalize_schema(schema: &Schema) -> Schema {
 
                     let fields = Fields::from([key_field, value_field]);
                     let struct_type = DataType::Struct(fields);
-                    let child_field = Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_type, false);
+                    let child_field =
+                        Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_type, false);
 
                     Arc::new(Field::new(
                         field.name().as_str(),

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -2747,7 +2747,7 @@ mod tests {
 
         #[allow(deprecated)]
         let keys_field = Arc::new(Field::new_dict(
-            "keys",
+            Field::MAP_KEY_FIELD_DEFAULT_NAME,
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
             false,
             1,
@@ -2755,7 +2755,7 @@ mod tests {
         ));
         #[allow(deprecated)]
         let values_field = Arc::new(Field::new_dict(
-            "values",
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
             true,
             2,
@@ -2767,7 +2767,7 @@ mod tests {
         ]);
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 entry_struct.data_type().clone(),
                 false,
             )),
@@ -2958,7 +2958,7 @@ mod tests {
         let key_dict_array = DictionaryArray::new(key_dict_keys, utf8_view_array.clone());
         #[allow(deprecated)]
         let keys_field = Arc::new(Field::new_dict(
-            "keys",
+            Field::MAP_KEY_FIELD_DEFAULT_NAME,
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8View)),
             false,
             1,
@@ -2969,7 +2969,7 @@ mod tests {
         let value_dict_array = DictionaryArray::new(value_dict_keys, bin_view_array);
         #[allow(deprecated)]
         let values_field = Arc::new(Field::new_dict(
-            "values",
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::BinaryView)),
             true,
             2,
@@ -2982,7 +2982,7 @@ mod tests {
 
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 entry_struct.data_type().clone(),
                 false,
             )),

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -3692,9 +3692,24 @@ mod tests {
 
     #[test]
     fn encode_map_array() {
-        let keys = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::UInt32, false));
-        let values = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, true));
-        let map_field = Field::new_map("map", Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, keys, values, false, true);
+        let keys = Arc::new(Field::new(
+            Field::MAP_KEY_FIELD_DEFAULT_NAME,
+            DataType::UInt32,
+            false,
+        ));
+        let values = Arc::new(Field::new(
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::UInt32,
+            true,
+        ));
+        let map_field = Field::new_map(
+            "map",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            keys,
+            values,
+            false,
+            true,
+        );
         let schema = Arc::new(Schema::new(vec![map_field]));
 
         let values = Arc::new(generate_map_array_data());
@@ -4053,7 +4068,11 @@ mod tests {
                 Arc::new(dict_keys) as ArrayRef,
             ),
             (
-                Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true)),
+                Arc::new(Field::new(
+                    Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                    DataType::Int32,
+                    true,
+                )),
                 Arc::new(values) as ArrayRef,
             ),
         ]);
@@ -4113,7 +4132,11 @@ mod tests {
 
         let entries = StructArray::from(vec![
             (
-                Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
+                Arc::new(Field::new(
+                    Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                    DataType::Utf8,
+                    false,
+                )),
                 Arc::new(keys) as ArrayRef,
             ),
             (

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -3692,9 +3692,9 @@ mod tests {
 
     #[test]
     fn encode_map_array() {
-        let keys = Arc::new(Field::new("keys", DataType::UInt32, false));
-        let values = Arc::new(Field::new("values", DataType::UInt32, true));
-        let map_field = Field::new_map("map", "entries", keys, values, false, true);
+        let keys = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::UInt32, false));
+        let values = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, true));
+        let map_field = Field::new_map("map", Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, keys, values, false, true);
         let schema = Arc::new(Schema::new(vec![map_field]));
 
         let values = Arc::new(generate_map_array_data());
@@ -4026,17 +4026,17 @@ mod tests {
 
         #[allow(deprecated)]
         let entries_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(
                 vec![
                     Field::new_dict(
-                        "key",
+                        Field::MAP_KEY_FIELD_DEFAULT_NAME,
                         DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
                         false,
                         1,
                         false,
                     ),
-                    Field::new("value", DataType::Int32, true),
+                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
                 ]
                 .into(),
             ),
@@ -4046,14 +4046,14 @@ mod tests {
         let entries = StructArray::from(vec![
             (
                 Arc::new(Field::new(
-                    "key",
+                    Field::MAP_KEY_FIELD_DEFAULT_NAME,
                     DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
                     false,
                 )),
                 Arc::new(dict_keys) as ArrayRef,
             ),
             (
-                Arc::new(Field::new("value", DataType::Int32, true)),
+                Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true)),
                 Arc::new(values) as ArrayRef,
             ),
         ]);
@@ -4094,12 +4094,12 @@ mod tests {
 
         #[allow(deprecated)]
         let entries_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(
                 vec![
-                    Field::new("key", DataType::Utf8, false),
+                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
                     Field::new_dict(
-                        "value",
+                        Field::MAP_VALUE_FIELD_DEFAULT_NAME,
                         DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
                         true,
                         2,
@@ -4113,12 +4113,12 @@ mod tests {
 
         let entries = StructArray::from(vec![
             (
-                Arc::new(Field::new("key", DataType::Utf8, false)),
+                Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
                 Arc::new(keys) as ArrayRef,
             ),
             (
                 Arc::new(Field::new(
-                    "value",
+                    Field::MAP_VALUE_FIELD_DEFAULT_NAME,
                     DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
                     true,
                 )),

--- a/arrow-json/benches/json_reader.rs
+++ b/arrow-json/benches/json_reader.rs
@@ -363,11 +363,11 @@ fn build_map_values(rows: usize, entries: usize) -> Vec<Value> {
 
 fn build_map_schema() -> Arc<Schema> {
     let entries_field = Arc::new(Field::new(
-        "entries",
+        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
         DataType::Struct(
             vec![
-                Field::new("keys", DataType::Utf8, false),
-                Field::new("values", DataType::Int64, true),
+                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int64, true),
             ]
             .into(),
         ),

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -1289,7 +1289,11 @@ mod tests {
             "map",
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new_list(Field::MAP_VALUE_FIELD_DEFAULT_NAME, Field::new("element", DataType::Utf8, true), true),
+            Field::new_list(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                Field::new("element", DataType::Utf8, true),
+                true,
+            ),
             false,
             true,
         );

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -1287,9 +1287,9 @@ mod tests {
         "#;
         let map = Field::new_map(
             "map",
-            "entries",
-            Field::new("key", DataType::Utf8, false),
-            Field::new_list("value", Field::new("element", DataType::Utf8, true), true),
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+            Field::new_list(Field::MAP_VALUE_FIELD_DEFAULT_NAME, Field::new("element", DataType::Utf8, true), true),
             false,
             true,
         );
@@ -2993,9 +2993,9 @@ mod tests {
             Field::new("b", DataType::new_list(DataType::Int32, true), true),
             Field::new_map(
                 "c",
-                "entries",
-                Field::new("keys", DataType::Utf8, false),
-                Field::new("values", DataType::Int32, true),
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
                 false,
                 false,
             ),
@@ -3183,10 +3183,10 @@ mod tests {
                 "map",
                 DataType::Map(
                     Arc::new(Field::new(
-                        "entries",
+                        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                         DataType::Struct(Fields::from(vec![
-                            Field::new("keys", DataType::Utf8, false),
-                            Field::new("values", DataType::Utf8, true),
+                            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
                         ])),
                         false, // not nullable
                     )),
@@ -3441,10 +3441,10 @@ mod tests {
                 "map",
                 DataType::Map(
                     Arc::new(Field::new(
-                        "entries",
+                        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                         DataType::Struct(Fields::from(vec![
-                            Field::new("keys", DataType::Utf8, false),
-                            Field::new("values", DataType::Utf8, true),
+                            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
                         ])),
                         false, // not nullable
                     )),
@@ -3502,10 +3502,10 @@ mod tests {
                 "map",
                 DataType::Map(
                     Arc::new(Field::new(
-                        "entries",
+                        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                         DataType::Struct(Fields::from(vec![
-                            Field::new("keys", DataType::Utf8, false),
-                            Field::new("values", DataType::Utf8, true),
+                            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
                         ])),
                         false, // not nullable
                     )),

--- a/arrow-json/src/writer/mod.rs
+++ b/arrow-json/src/writer/mod.rs
@@ -1421,8 +1421,16 @@ mod tests {
     fn run_json_writer_map_with_keys(keys_array: ArrayRef) {
         let values_array = super::Int64Array::from(vec![10, 20, 30, 40, 50]);
 
-        let keys_field = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, keys_array.data_type().clone(), false));
-        let values_field = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int64, false));
+        let keys_field = Arc::new(Field::new(
+            Field::MAP_KEY_FIELD_DEFAULT_NAME,
+            keys_array.data_type().clone(),
+            false,
+        ));
+        let values_field = Arc::new(Field::new(
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::Int64,
+            false,
+        ));
         let entry_struct = StructArray::from(vec![
             (keys_field, keys_array.clone()),
             (values_field, Arc::new(values_array) as ArrayRef),

--- a/arrow-json/src/writer/mod.rs
+++ b/arrow-json/src/writer/mod.rs
@@ -1421,15 +1421,15 @@ mod tests {
     fn run_json_writer_map_with_keys(keys_array: ArrayRef) {
         let values_array = super::Int64Array::from(vec![10, 20, 30, 40, 50]);
 
-        let keys_field = Arc::new(Field::new("keys", keys_array.data_type().clone(), false));
-        let values_field = Arc::new(Field::new("values", DataType::Int64, false));
+        let keys_field = Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, keys_array.data_type().clone(), false));
+        let values_field = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int64, false));
         let entry_struct = StructArray::from(vec![
             (keys_field, keys_array.clone()),
             (values_field, Arc::new(values_array) as ArrayRef),
         ]);
 
         let entries_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             entry_struct.data_type().clone(),
             false,
         ));

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -4406,7 +4406,7 @@ mod tests {
     #[test]
     fn test_single_map_with_non_nullable_values() {
         // Use `with_values_field` on `MapBuilder` to set the values are not nullable
-        let value_field = Arc::new(Field::new("values", DataType::Int32, false));
+        let value_field = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, false));
         let mut builder = MapBuilder::new(None, StringBuilder::new(), Int32Builder::new())
             .with_values_field(value_field);
         // Entry 0: {"a": 1, "b": 2}
@@ -4444,7 +4444,7 @@ mod tests {
     #[test]
     fn test_single_map_with_non_nullable_map_but_with_nullable_values() {
         // Map column is non-nullable, but values are nullable
-        let value_field = Arc::new(Field::new("values", DataType::Int32, true));
+        let value_field = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true));
         let mut builder = MapBuilder::new(None, StringBuilder::new(), Int32Builder::new())
             .with_values_field(value_field);
 
@@ -4825,9 +4825,9 @@ mod tests {
         let nulls = NullBuffer::from_iter((0..len).map(|_| rng.random_bool(valid_percent)));
         let field = Arc::new(Field::new_map(
             "",
-            "entries",
-            Field::new("keys", keys.data_type().clone(), false),
-            Field::new("values", values.data_type().clone(), true),
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, keys.data_type().clone(), false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, values.data_type().clone(), true),
             false,
             true,
         ));
@@ -6280,11 +6280,11 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 1, 1, 3].into());
         let entries_fields = vec![
-            Arc::new(Field::new("keys", DataType::Utf8, false)),
-            Arc::new(Field::new("values", DataType::Null, true)),
+            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
+            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6311,11 +6311,11 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 1, 1, 3].into());
         let entries_fields = vec![
-            Arc::new(Field::new("keys", DataType::Utf8, false)),
-            Arc::new(Field::new("values", DataType::Null, true)),
+            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
+            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6341,11 +6341,11 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0i32].into());
         let entries_fields = vec![
-            Arc::new(Field::new("keys", DataType::Utf8, false)),
-            Arc::new(Field::new("values", DataType::Null, true)),
+            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
+            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6369,11 +6369,11 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 1, 1, 3].into());
         let entries_fields = vec![
-            Arc::new(Field::new("keys", DataType::Utf8, false)),
-            Arc::new(Field::new("values", DataType::Null, true)),
+            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
+            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6399,11 +6399,11 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 0, 0, 0].into());
         let entries_fields = vec![
-            Arc::new(Field::new("keys", DataType::Utf8, false)),
-            Arc::new(Field::new("values", DataType::Null, true)),
+            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
+            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6432,11 +6432,11 @@ mod tests {
         let inner_null_values = Arc::new(NullArray::new(3)) as ArrayRef;
 
         let inner_entries_fields = vec![
-            Arc::new(Field::new("keys", DataType::Utf8, false)),
-            Arc::new(Field::new("values", DataType::Null, true)),
+            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
+            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
         ];
         let inner_struct_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(inner_entries_fields.clone().into()),
             false,
         ));
@@ -6460,11 +6460,11 @@ mod tests {
 
         let inner_map_type = DataType::Map(inner_struct_field.clone(), false);
         let outer_entries_fields = vec![
-            Arc::new(Field::new("keys", DataType::Utf8, false)),
-            Arc::new(Field::new("values", inner_map_type, true)),
+            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
+            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, inner_map_type, true)),
         ];
         let outer_struct_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(outer_entries_fields.clone().into()),
             false,
         ));
@@ -6499,11 +6499,11 @@ mod tests {
         let null_values = Arc::new(NullArray::new(3)) as ArrayRef;
 
         let entries_fields = vec![
-            Arc::new(Field::new("keys", DataType::Utf8, false)),
-            Arc::new(Field::new("values", DataType::Null, true)),
+            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
+            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6550,11 +6550,11 @@ mod tests {
 
         let list_type = list_array.data_type().clone();
         let entries_fields = vec![
-            Arc::new(Field::new("keys", DataType::Utf8, false)),
-            Arc::new(Field::new("values", list_type, true)),
+            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
+            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, list_type, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -4406,7 +4406,11 @@ mod tests {
     #[test]
     fn test_single_map_with_non_nullable_values() {
         // Use `with_values_field` on `MapBuilder` to set the values are not nullable
-        let value_field = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, false));
+        let value_field = Arc::new(Field::new(
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::Int32,
+            false,
+        ));
         let mut builder = MapBuilder::new(None, StringBuilder::new(), Int32Builder::new())
             .with_values_field(value_field);
         // Entry 0: {"a": 1, "b": 2}
@@ -4444,7 +4448,11 @@ mod tests {
     #[test]
     fn test_single_map_with_non_nullable_map_but_with_nullable_values() {
         // Map column is non-nullable, but values are nullable
-        let value_field = Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true));
+        let value_field = Arc::new(Field::new(
+            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            DataType::Int32,
+            true,
+        ));
         let mut builder = MapBuilder::new(None, StringBuilder::new(), Int32Builder::new())
             .with_values_field(value_field);
 
@@ -4826,8 +4834,16 @@ mod tests {
         let field = Arc::new(Field::new_map(
             "",
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, keys.data_type().clone(), false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, values.data_type().clone(), true),
+            Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                keys.data_type().clone(),
+                false,
+            ),
+            Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                values.data_type().clone(),
+                true,
+            ),
             false,
             true,
         ));
@@ -6280,8 +6296,16 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 1, 1, 3].into());
         let entries_fields = vec![
-            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
-            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
+            Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Utf8,
+                false,
+            )),
+            Arc::new(Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                DataType::Null,
+                true,
+            )),
         ];
         let struct_field = Arc::new(Field::new(
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
@@ -6311,8 +6335,16 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 1, 1, 3].into());
         let entries_fields = vec![
-            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
-            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
+            Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Utf8,
+                false,
+            )),
+            Arc::new(Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                DataType::Null,
+                true,
+            )),
         ];
         let struct_field = Arc::new(Field::new(
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
@@ -6341,8 +6373,16 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0i32].into());
         let entries_fields = vec![
-            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
-            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
+            Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Utf8,
+                false,
+            )),
+            Arc::new(Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                DataType::Null,
+                true,
+            )),
         ];
         let struct_field = Arc::new(Field::new(
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
@@ -6369,8 +6409,16 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 1, 1, 3].into());
         let entries_fields = vec![
-            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
-            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
+            Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Utf8,
+                false,
+            )),
+            Arc::new(Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                DataType::Null,
+                true,
+            )),
         ];
         let struct_field = Arc::new(Field::new(
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
@@ -6399,8 +6447,16 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 0, 0, 0].into());
         let entries_fields = vec![
-            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
-            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
+            Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Utf8,
+                false,
+            )),
+            Arc::new(Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                DataType::Null,
+                true,
+            )),
         ];
         let struct_field = Arc::new(Field::new(
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
@@ -6432,8 +6488,16 @@ mod tests {
         let inner_null_values = Arc::new(NullArray::new(3)) as ArrayRef;
 
         let inner_entries_fields = vec![
-            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
-            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
+            Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Utf8,
+                false,
+            )),
+            Arc::new(Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                DataType::Null,
+                true,
+            )),
         ];
         let inner_struct_field = Arc::new(Field::new(
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
@@ -6460,8 +6524,16 @@ mod tests {
 
         let inner_map_type = DataType::Map(inner_struct_field.clone(), false);
         let outer_entries_fields = vec![
-            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
-            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, inner_map_type, true)),
+            Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Utf8,
+                false,
+            )),
+            Arc::new(Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                inner_map_type,
+                true,
+            )),
         ];
         let outer_struct_field = Arc::new(Field::new(
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
@@ -6499,8 +6571,16 @@ mod tests {
         let null_values = Arc::new(NullArray::new(3)) as ArrayRef;
 
         let entries_fields = vec![
-            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
-            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Null, true)),
+            Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Utf8,
+                false,
+            )),
+            Arc::new(Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                DataType::Null,
+                true,
+            )),
         ];
         let struct_field = Arc::new(Field::new(
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
@@ -6550,8 +6630,16 @@ mod tests {
 
         let list_type = list_array.data_type().clone();
         let entries_fields = vec![
-            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false)),
-            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, list_type, true)),
+            Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Utf8,
+                false,
+            )),
+            Arc::new(Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                list_type,
+                true,
+            )),
         ];
         let struct_field = Arc::new(Field::new(
             Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,

--- a/arrow-schema/src/datatype_display.rs
+++ b/arrow-schema/src/datatype_display.rs
@@ -432,11 +432,11 @@ mod tests {
     #[test]
     fn test_display_map() {
         let entry_field = Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(
                 vec![
-                    Field::new("key", DataType::Utf8, false),
-                    Field::new("value", DataType::Int32, true),
+                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
                 ]
                 .into(),
             ),
@@ -450,11 +450,11 @@ mod tests {
 
         // Test with metadata
         let mut entry_field_with_metadata = Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(
                 vec![
-                    Field::new("key", DataType::Utf8, false),
-                    Field::new("value", DataType::Int32, true),
+                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
                 ]
                 .into(),
             ),

--- a/arrow-schema/src/datatype_parse.rs
+++ b/arrow-schema/src/datatype_parse.rs
@@ -1209,9 +1209,9 @@ mod test {
             DataType::Map(
                 Arc::new(Field::new_map(
                     "nested_map",
-                    "entries",
-                    Field::new("key", DataType::Utf8, false),
-                    Field::new("value", DataType::Int32, true),
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
                     false,
                     true,
                 )),

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -950,13 +950,13 @@ mod tests {
 
     #[test]
     fn test_map_keys_sorted() {
-        let keys = Field::new("keys", DataType::Int32, false);
-        let values = Field::new("values", DataType::UInt32, false);
+        let keys = Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false);
+        let values = Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, false);
         let entry_struct = DataType::Struct(vec![keys, values].into());
 
         // Construct a map array from the above two
         let map_data_type =
-            DataType::Map(Arc::new(Field::new("entries", entry_struct, false)), true);
+            DataType::Map(Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, entry_struct, false)), true);
 
         let arrow_schema = FFI_ArrowSchema::try_from(map_data_type).unwrap();
         assert!(arrow_schema.map_keys_sorted());

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -955,8 +955,14 @@ mod tests {
         let entry_struct = DataType::Struct(vec![keys, values].into());
 
         // Construct a map array from the above two
-        let map_data_type =
-            DataType::Map(Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, entry_struct, false)), true);
+        let map_data_type = DataType::Map(
+            Arc::new(Field::new(
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                entry_struct,
+                false,
+            )),
+            true,
+        );
 
         let arrow_schema = FFI_ArrowSchema::try_from(map_data_type).unwrap();
         assert!(arrow_schema.map_keys_sorted());

--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -183,15 +183,15 @@ impl Field {
     pub const LIST_FIELD_DEFAULT_NAME: &'static str = "item";
     /// Default field name for the entries field for Map
     ///
-    /// See https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138
+    /// See [Arrow Spec](https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138))
     pub const MAP_ENTRIES_FIELD_DEFAULT_NAME: &'static str = "entries";
     /// Default field name for the key field for Map
     ///
-    /// See https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138
+    /// See [Arrow Spec](https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138))
     pub const MAP_KEY_FIELD_DEFAULT_NAME: &'static str = "key";
     /// Default field name for the value field for Map
     ///
-    /// See https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138
+    /// See [Arrow Spec](https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138))
     pub const MAP_VALUE_FIELD_DEFAULT_NAME: &'static str = "value";
 
     /// Creates a new field with the given name, data type, and nullability

--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -181,6 +181,18 @@ impl AsRef<Field> for Field {
 impl Field {
     /// Default list member field name
     pub const LIST_FIELD_DEFAULT_NAME: &'static str = "item";
+    /// Default field name for the entries field for Map
+    ///
+    /// See https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138
+    pub const MAP_ENTRIES_FIELD_DEFAULT_NAME: &'static str = "entries";
+    /// Default field name for the key field for Map
+    ///
+    /// See https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138
+    pub const MAP_KEY_FIELD_DEFAULT_NAME: &'static str = "key";
+    /// Default field name for the value field for Map
+    ///
+    /// See https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138
+    pub const MAP_VALUE_FIELD_DEFAULT_NAME: &'static str = "value";
 
     /// Creates a new field with the given name, data type, and nullability
     ///

--- a/arrow-schema/src/fields.rs
+++ b/arrow-schema/src/fields.rs
@@ -675,9 +675,9 @@ mod tests {
             ),
             Field::new_map(
                 "g",
-                "entries",
-                Field::new("keys", DataType::LargeUtf8, false),
-                Field::new("values", DataType::Int32, true),
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::LargeUtf8, false),
+                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
                 false,
                 false,
             ),

--- a/arrow-schema/src/fields.rs
+++ b/arrow-schema/src/fields.rs
@@ -676,7 +676,11 @@ mod tests {
             Field::new_map(
                 "g",
                 Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::LargeUtf8, false),
+                Field::new(
+                    Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                    DataType::LargeUtf8,
+                    false,
+                ),
                 Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
                 false,
                 false,

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -819,9 +819,9 @@ mod tests {
     fn test_create_map_array() {
         let map_field = Field::new_map(
             "map",
-            "entries",
-            Field::new("key", DataType::Utf8, false),
-            Field::new("value", DataType::Utf8, true),
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
             false,
             false,
         );

--- a/arrow/tests/array_transform.rs
+++ b/arrow/tests/array_transform.rs
@@ -798,11 +798,19 @@ fn test_map_nulls_append() {
 
     let expected_entry_array = StructArray::from(vec![
         (
-            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int64, false)),
+            Arc::new(Field::new(
+                Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                DataType::Int64,
+                false,
+            )),
             Arc::new(expected_key_array) as ArrayRef,
         ),
         (
-            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int64, true)),
+            Arc::new(Field::new(
+                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                DataType::Int64,
+                true,
+            )),
             Arc::new(expected_value_array) as ArrayRef,
         ),
     ]);

--- a/arrow/tests/array_transform.rs
+++ b/arrow/tests/array_transform.rs
@@ -798,11 +798,11 @@ fn test_map_nulls_append() {
 
     let expected_entry_array = StructArray::from(vec![
         (
-            Arc::new(Field::new("keys", DataType::Int64, false)),
+            Arc::new(Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int64, false)),
             Arc::new(expected_key_array) as ArrayRef,
         ),
         (
-            Arc::new(Field::new("values", DataType::Int64, true)),
+            Arc::new(Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int64, true)),
             Arc::new(expected_value_array) as ArrayRef,
         ),
     ]);
@@ -812,10 +812,10 @@ fn test_map_nulls_append() {
     let expected_list_data = ArrayData::try_new(
         DataType::Map(
             Arc::new(Field::new(
-                "entries",
+                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                 DataType::Struct(Fields::from(vec![
-                    Field::new("keys", DataType::Int64, false),
-                    Field::new("values", DataType::Int64, true),
+                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int64, false),
+                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int64, true),
                 ])),
                 false,
             )),

--- a/parquet-variant-compute/src/arrow_to_variant.rs
+++ b/parquet-variant-compute/src/arrow_to_variant.rs
@@ -1378,8 +1378,8 @@ mod tests {
         let keys = StringArray::from(vec!["key1", "key2", "key3"]);
         let values = Int32Array::from(vec![1, 2, 3]);
         let entries_fields = Fields::from(vec![
-            Field::new("key", DataType::Utf8, false),
-            Field::new("value", DataType::Int32, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
         ]);
         let entries = StructArray::new(
             entries_fields.clone(),
@@ -1399,7 +1399,7 @@ mod tests {
 
         // Create the map field
         let map_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(entries_fields),
             false, // Keys are non-nullable
         ));

--- a/parquet-variant-compute/src/cast_to_variant.rs
+++ b/parquet-variant-compute/src/cast_to_variant.rs
@@ -1983,8 +1983,8 @@ mod tests {
         let keys = StringArray::from(vec!["key1", "key2", "key3"]);
         let values = Int32Array::from(vec![1, 2, 3]);
         let entries_fields = Fields::from(vec![
-            Field::new("key", DataType::Utf8, false),
-            Field::new("value", DataType::Int32, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
         ]);
         let entries = StructArray::new(
             entries_fields.clone(),
@@ -1999,7 +1999,7 @@ mod tests {
         let null_buffer = Some(NullBuffer::from(vec![true, true, false, true]));
 
         let map_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(entries_fields),
             false,
         ));
@@ -2039,8 +2039,8 @@ mod tests {
     fn test_cast_to_variant_map_with_non_string_keys() {
         let offsets = OffsetBuffer::new(vec![0, 1, 3].into());
         let fields = Fields::from(vec![
-            Field::new("key", DataType::Int32, false),
-            Field::new("values", DataType::Int32, false),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, false),
         ]);
         let columns = vec![
             Arc::new(Int32Array::from(vec![1, 2, 3])) as _,
@@ -2048,7 +2048,7 @@ mod tests {
         ];
 
         let entries = StructArray::new(fields.clone(), columns, None);
-        let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
+        let field = Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, DataType::Struct(fields), false));
 
         let map_array = MapArray::new(field.clone(), offsets.clone(), entries.clone(), None, false);
 

--- a/parquet-variant-compute/src/cast_to_variant.rs
+++ b/parquet-variant-compute/src/cast_to_variant.rs
@@ -2048,7 +2048,11 @@ mod tests {
         ];
 
         let entries = StructArray::new(fields.clone(), columns, None);
-        let field = Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, DataType::Struct(fields), false));
+        let field = Arc::new(Field::new(
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            DataType::Struct(fields),
+            false,
+        ));
 
         let map_array = MapArray::new(field.clone(), offsets.clone(), entries.clone(), None, false);
 

--- a/parquet-variant-compute/src/shred_variant.rs
+++ b/parquet-variant-compute/src/shred_variant.rs
@@ -1476,10 +1476,10 @@ mod tests {
             ),
             DataType::Map(
                 Arc::new(Field::new(
-                    "entries",
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                     DataType::Struct(Fields::from(vec![
-                        Field::new("key", DataType::Utf8, false),
-                        Field::new("value", DataType::Int32, true),
+                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                        Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
                     ])),
                     false,
                 )),

--- a/parquet-variant-compute/src/variant_to_arrow.rs
+++ b/parquet-variant-compute/src/variant_to_arrow.rs
@@ -1309,10 +1309,10 @@ mod tests {
         let item_field = Arc::new(Field::new("item", DataType::Int32, true));
         let struct_fields = Fields::from(vec![Field::new("child", DataType::Int32, true)]);
         let map_entries_field = Arc::new(Field::new(
-            "entries",
+            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
             DataType::Struct(Fields::from(vec![
-                Field::new("key", DataType::Utf8, false),
-                Field::new("value", DataType::Float64, true),
+                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Float64, true),
             ])),
             true,
         ));

--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -158,10 +158,10 @@ mod tests {
             "map",
             ArrowType::Map(
                 Arc::new(Field::new(
-                    "entries",
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
                     ArrowType::Struct(Fields::from(vec![
-                        Field::new("keys", ArrowType::Utf8, false),
-                        Field::new("values", ArrowType::Int32, true),
+                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, ArrowType::Utf8, false),
+                        Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, ArrowType::Int32, true),
                     ])),
                     false,
                 )),

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -1930,13 +1930,13 @@ mod tests {
         {"stocks":{"hedged": "$YYY", "long": null, "short": "$D"}}
         "#;
         let entries_struct_type = DataType::Struct(Fields::from(vec![
-            Field::new("key", DataType::Utf8, false),
-            Field::new("value", DataType::Utf8, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
         ]));
         let stocks_field = Field::new(
             "stocks",
             DataType::Map(
-                Arc::new(Field::new("entries", entries_struct_type, false)),
+                Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, entries_struct_type, false)),
                 false,
             ),
             // not nullable, so the keys have max level = 1

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -1936,7 +1936,11 @@ mod tests {
         let stocks_field = Field::new(
             "stocks",
             DataType::Map(
-                Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, entries_struct_type, false)),
+                Arc::new(Field::new(
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    entries_struct_type,
+                    false,
+                )),
                 false,
             ),
             // not nullable, so the keys have max level = 1

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2751,13 +2751,13 @@ mod tests {
         {"stocks":{"hedged": "$YYY", "long": null, "short": "$D"}}
         "#;
         let entries_struct_type = DataType::Struct(Fields::from(vec![
-            Field::new("key", DataType::Utf8, false),
-            Field::new("value", DataType::Utf8, true),
+            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
         ]));
         let stocks_field = Field::new(
             "stocks",
             DataType::Map(
-                Arc::new(Field::new("entries", entries_struct_type, false)),
+                Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, entries_struct_type, false)),
                 false,
             ),
             true,
@@ -3896,9 +3896,9 @@ mod tests {
             Field::new_list("my_list", Field::new("item", DataType::Int32, false), false);
         let map_field = Field::new_map(
             "my_map",
-            "entries",
-            Field::new("keys", DataType::Int32, false),
-            Field::new("values", DataType::Int32, true),
+            "my_entries",
+            Field::new("my_keys", DataType::Int32, false),
+            Field::new("my_values", DataType::Int32, true),
             false,
             true,
         );
@@ -3926,9 +3926,9 @@ mod tests {
         let map_field = &schema.get_fields()[1].get_fields()[0];
         // Coerced name of "entries" should be "key_value"
         assert_eq!(map_field.name(), "key_value");
-        // Coerced name of "keys" should be "key"
+        // Coerced name of "my_keys" should be "key"
         assert_eq!(map_field.get_fields()[0].name(), "key");
-        // Coerced name of "values" should be "value"
+        // Coerced name of "my_values" should be "value"
         assert_eq!(map_field.get_fields()[1].name(), "value");
 
         // Double check schema after reading from the file

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2757,7 +2757,11 @@ mod tests {
         let stocks_field = Field::new(
             "stocks",
             DataType::Map(
-                Arc::new(Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, entries_struct_type, false)),
+                Arc::new(Field::new(
+                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    entries_struct_type,
+                    false,
+                )),
                 false,
             ),
             true,

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -1731,9 +1731,9 @@ mod tests {
             ),
             Field::new_map(
                 "my_map",
-                "entries",
-                Field::new("keys", DataType::Utf8, false),
-                Field::new("values", DataType::Int32, true),
+                "my_entries",
+                Field::new("my_keys", DataType::Utf8, false),
+                Field::new("my_values", DataType::Int32, true),
                 false,
                 true,
             ),
@@ -1776,9 +1776,9 @@ mod tests {
                 }
             }
             OPTIONAL GROUP my_map (MAP) {
-                REPEATED GROUP entries {
-                    REQUIRED BINARY keys (STRING);
-                    OPTIONAL INT32 values;
+                REPEATED GROUP my_entries {
+                    REQUIRED BINARY my_keys (STRING);
+                    OPTIONAL INT32 my_values;
                 }
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

In some places we write `keys` and `values` and in some cases `key` and `value` (without the `s`)

so matching the names to match the default arrow spec names

this is also important as this is a source of common pitfalls when comparing data types from schema and actual data (where actual data might coming from another arrow impl like java which uses `key` and `value` and not `keys` and `values` - https://github.com/apache/arrow-java/blob/a9f0086090e649b83c89ea864c82ed7fcc84ab2f/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java#L47-L49) 

This is similar to what was done for list:
- #6785 

# What changes are included in this PR?
add constants for entries, key and value field name in `Field`, replace **manually** every place, left out places that test different names specifically or made it more explicit

I did it manually since I don't trust LLM that will do it correctly and might change tests that check that case specifically and did not want to use a script to change that  

# Are these changes tested?
Existing tests

# Are there any user-facing changes?
the default `MapFieldNames` is `key` and not `keys`, `value` and not `values`