### PR TITLE
Align parquet-geospatial crate docs with README

### DIFF
--- a/parquet-geospatial/src/lib.rs
+++ b/parquet-geospatial/src/lib.rs
@@ -19,13 +19,6 @@
 //!
 //! [Geometry and Geography Encoding]: https://github.com/apache/parquet-format/blob/master/Geospatial.md
 //! [Apache Parquet]: https://parquet.apache.org/
-//!
-//! ## 🚧 Work In Progress
-//!
-//! This crate is under active development and is not yet ready for production use.
-//! If you are interested in helping, you can find more information on the GitHub [Geometry issue]
-//!
-//! [Geometry issue]: https://github.com/apache/arrow-rs/issues/8373
 
 pub mod bounding;
 pub mod interval;


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10269.

# Rationale for this change

We closed the issue and updated the README for this crate; however, we never updated the module docs to remove the experimental bit.

# What changes are included in this PR?

The line declaring the crate experimental was removed

# Are these changes tested?

Docs-only change

# Are there any user-facing changes?

Docs-only change