### PR TITLE
perf:  allow users to skip utf8 validation in arrow-row

### DIFF
--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1282,6 +1282,16 @@ impl RowParser {
             },
         }
     }
+    /// Like [`RowConverter::parser`] but lets the caller control UTF-8 validation on decode.
+    /// Pass `false` to skip validation when the bytes are already known to be valid UTF-8.
+    pub unsafe fn with_validate_utf8_flag(fields: Arc<[SortField]>, validate_utf8: bool) -> Self {
+        Self {
+            config: RowConfig {
+                fields,
+                validate_utf8,
+            },
+        }
+    }
 
     /// Creates a [`Row`] from the provided `bytes`.
     ///
@@ -6674,6 +6684,25 @@ mod tests {
         assert_eq!(rows_iter.next_back(), None);
         assert_eq!(rows_iter.next_back(), None);
         assert_eq!(rows_iter.next_back(), None);
+    }
+
+    /// Round-trip through `with_validate_utf8_flag(false)` confirms skipping validation
+    /// preserves values.
+    #[test]
+    fn test_row_parser_skip_utf8_validation_roundtrip() {
+        let converter = RowConverter::new(vec![SortField::new(DataType::Utf8)]).unwrap();
+        let array = StringArray::from(vec!["arrow", "rust"]);
+        let rows = converter.convert_columns(&[Arc::new(array) as _]).unwrap();
+        let binary = rows.try_into_binary().expect("fits in i32 offsets");
+
+        let parser =
+            unsafe { RowParser::with_validate_utf8_flag(Arc::clone(&converter.fields), false) };
+
+        let decoded = converter
+            .convert_rows(binary.iter().map(|b| parser.parse(b.unwrap())))
+            .unwrap();
+        let got: Vec<_> = decoded[0].as_string::<i32>().iter().flatten().collect();
+        assert_eq!(got, vec!["arrow", "rust"]);
     }
 
     #[test]

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -1256,6 +1256,14 @@ impl RowConverter {
         RowParser::new(Arc::clone(&self.fields))
     }
 
+    /// Like [`Self::parser`] but skips UTF-8 validation on decode.
+    ///
+    /// # Safety
+    /// The caller must ensure all row bytes contain valid UTF-8 for string columns.
+    pub unsafe fn parser_skip_utf8_validation(&self) -> RowParser {
+        unsafe { RowParser::with_skip_utf8_validate(Arc::clone(&self.fields)) }
+    }
+
     /// Returns the size of this instance in bytes
     ///
     /// Includes the size of `Self`.
@@ -1282,13 +1290,15 @@ impl RowParser {
             },
         }
     }
-    /// Like [`RowConverter::parser`] but lets the caller control UTF-8 validation on decode.
-    /// Pass `false` to skip validation when the bytes are already known to be valid UTF-8.
-    pub unsafe fn with_validate_utf8_flag(fields: Arc<[SortField]>, validate_utf8: bool) -> Self {
+    /// Like [`RowConverter::parser`] but skips UTF-8 validation on decode.
+    ///
+    /// # Safety
+    /// The caller must ensure all row bytes contain valid UTF-8 for string columns.
+    unsafe fn with_skip_utf8_validate(fields: Arc<[SortField]>) -> Self {
         Self {
             config: RowConfig {
                 fields,
-                validate_utf8,
+                validate_utf8: false,
             },
         }
     }
@@ -6686,8 +6696,7 @@ mod tests {
         assert_eq!(rows_iter.next_back(), None);
     }
 
-    /// Round-trip through `with_validate_utf8_flag(false)` confirms skipping validation
-    /// preserves values.
+    /// Round-trip through `with_skip_utf8_validate` confirms skipping validation preserves values.
     #[test]
     fn test_row_parser_skip_utf8_validation_roundtrip() {
         let converter = RowConverter::new(vec![SortField::new(DataType::Utf8)]).unwrap();
@@ -6695,8 +6704,8 @@ mod tests {
         let rows = converter.convert_columns(&[Arc::new(array) as _]).unwrap();
         let binary = rows.try_into_binary().expect("fits in i32 offsets");
 
-        let parser =
-            unsafe { RowParser::with_validate_utf8_flag(Arc::clone(&converter.fields), false) };
+        // SAFETY: bytes come from this RowConverter and are known-valid UTF-8.
+        let parser = unsafe { RowParser::with_skip_utf8_validate(Arc::clone(&converter.fields)) };
 
         let decoded = converter
             .convert_rows(binary.iter().map(|b| parser.parse(b.unwrap())))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10275.

# Rationale for this change

see #10275
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
adds  `with_validate_utf8_flag()` which allows callers to create `RowParser` with `validate_utf8` set to false
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes a test is included to validate a round-trip behaves as expected.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
`RowConverter` has a new method that skips utf8 checks.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
