### PR TITLE
fix(arrow-data): allow full dictionary key range when concatenating

### DIFF
--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -195,7 +195,10 @@ impl std::fmt::Debug for MutableArrayData<'_> {
 fn build_extend_dictionary(array: &ArrayData, offset: usize, max: usize) -> Option<Extend<'_>> {
     macro_rules! validate_and_build {
         ($dt: ty) => {{
-            let _: $dt = max.try_into().ok()?;
+            // `max` is the merged dictionary length; the largest key index is
+            // `max - 1`, so the key type only needs to hold `max - 1` (e.g. 256
+            // values use keys 0..=255, which fit in u8).
+            let _: $dt = max.saturating_sub(1).try_into().ok()?;
             let offset: $dt = offset.try_into().ok()?;
             Some(primitive::build_extend_with_offset(array, offset))
         }};

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -645,6 +645,56 @@ mod tests {
     use std::fmt::Debug;
 
     #[test]
+    fn test_dict_overflow_9366() {
+        use arrow_schema::DataType;
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "a",
+            DataType::Dictionary(
+                Box::new(DataType::UInt8),
+                Box::new(DataType::FixedSizeBinary(8)),
+            ),
+            false,
+        )]));
+        let make = |vals: std::ops::Range<u64>| {
+            let dict = FixedSizeBinaryArray::try_from_iter(vals.map(|i| i.to_le_bytes())).unwrap();
+            let keys = UInt8Array::from_iter_values(0..128);
+            let arr = DictionaryArray::try_new(keys, Arc::new(dict)).unwrap();
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(arr)]).unwrap()
+        };
+        // 256 distinct values fit in u8 keys (0..=255): concat must succeed.
+        let out = concat_batches(&schema, &[make(0..128), make(128..256)]).unwrap();
+        assert_eq!(out.num_rows(), 256);
+        let dict = out.column(0).as_dictionary::<UInt8Type>();
+        assert_eq!(dict.values().len(), 256);
+    }
+
+    #[test]
+    fn test_dict_overflow_i8_9366() {
+        use arrow_schema::DataType;
+
+        // Same boundary for a signed key type: i8 holds 128 keys (0..=127).
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "a",
+            DataType::Dictionary(
+                Box::new(DataType::Int8),
+                Box::new(DataType::FixedSizeBinary(8)),
+            ),
+            false,
+        )]));
+        let make = |vals: std::ops::Range<u64>| {
+            let dict = FixedSizeBinaryArray::try_from_iter(vals.map(|i| i.to_le_bytes())).unwrap();
+            let keys = Int8Array::from_iter_values(0..64);
+            let arr = DictionaryArray::try_new(keys, Arc::new(dict)).unwrap();
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(arr)]).unwrap()
+        };
+        let out = concat_batches(&schema, &[make(0..64), make(64..128)]).unwrap();
+        assert_eq!(out.num_rows(), 128);
+        let dict = out.column(0).as_dictionary::<Int8Type>();
+        assert_eq!(dict.values().len(), 128);
+    }
+
+    #[test]
     fn test_concat_empty_vec() {
         let re = concat(&[]);
         assert!(re.is_err());


### PR DESCRIPTION
# Which issue does this PR close?

Closes #9366.

# Rationale for this change

Concatenating dictionary arrays whose merged dictionary length is exactly the key type's maximum value + 1 (e.g. 256 distinct values with `u8` keys) panics with `DictionaryKeyOverflowError`. The largest key index is `length - 1`, so 256 values use keys `0..=255`, which fit in `u8` — the overflow check was off by one.

# What changes are included in this PR?

`build_extend_dictionary` now checks that the key type can hold `max - 1` (the largest index) rather than `max` (the length).

# Are these changes tested?

Yes — added `test_dict_overflow_9366`, which concatenates two `Dictionary<u8, _>` arrays totaling 256 values and asserts it succeeds (panics before this change).

# Are there any user-facing changes?

No API change; a previously-panicking concat now succeeds.