### PR TITLE
fix(arrow-cast): make `b64_encode` reject invalid UTF-8 from misbehaving `Engine` impls

### DIFF
--- a/arrow-cast/src/base64.rs
+++ b/arrow-cast/src/base64.rs
@@ -27,11 +27,15 @@ use base64::engine::Config;
 
 pub use base64::prelude::*;
 
-/// Bas64 encode each element of `array` with the provided [`Engine`]
+/// Base64 encode each element of `array` with the provided [`Engine`]
+///
+/// Returns an error if the `Engine` emits output that is not valid UTF-8. A
+/// correct `Engine` never does, but it is a safe trait so a misbehaving impl
+/// could; validating keeps the returned [`GenericStringArray`] sound (#10284).
 pub fn b64_encode<E: Engine, O: OffsetSizeTrait>(
     engine: &E,
     array: &GenericBinaryArray<O>,
-) -> GenericStringArray<O> {
+) -> Result<GenericStringArray<O>, ArrowError> {
     let lengths = array.offsets().windows(2).map(|w| {
         let len = w[1].as_usize() - w[0].as_usize();
         encoded_len(len, engine.config().encode_padding()).unwrap()
@@ -49,10 +53,8 @@ pub fn b64_encode<E: Engine, O: OffsetSizeTrait>(
     }
     assert_eq!(offset, buffer_len);
 
-    // Safety: Base64 is valid UTF-8
-    unsafe {
-        GenericStringArray::new_unchecked(offsets, Buffer::from_vec(buffer), array.nulls().cloned())
-    }
+    // `try_new` validates UTF-8 instead of trusting the (safe-trait) Engine.
+    GenericStringArray::try_new(offsets, Buffer::from_vec(buffer), array.nulls().cloned())
 }
 
 /// Base64 decode each element of `array` with the provided [`Engine`]
@@ -89,7 +91,7 @@ mod tests {
     use rand::{Rng, rng};
 
     fn test_engine<E: Engine>(e: &E, a: &BinaryArray) {
-        let encoded = b64_encode(e, a);
+        let encoded = b64_encode(e, a).unwrap();
         encoded.to_data().validate_full().unwrap();
 
         let to_decode = encoded.into();
@@ -112,5 +114,50 @@ mod tests {
 
         test_engine(&BASE64_STANDARD, &data);
         test_engine(&BASE64_STANDARD_NO_PAD, &data);
+    }
+
+    /// Safe-Rust `Engine` that writes invalid UTF-8 into the encode buffer
+    /// (#10284). `b64_encode` must reject it rather than build an unsound
+    /// `StringArray`.
+    struct EvilEngine;
+
+    impl Engine for EvilEngine {
+        type Config = <base64::engine::GeneralPurpose as Engine>::Config;
+        type DecodeEstimate = <base64::engine::GeneralPurpose as Engine>::DecodeEstimate;
+
+        fn internal_encode(&self, input: &[u8], output: &mut [u8]) -> usize {
+            BASE64_STANDARD.internal_encode(input, output)
+        }
+        fn internal_decoded_len_estimate(&self, input_len: usize) -> Self::DecodeEstimate {
+            BASE64_STANDARD.internal_decoded_len_estimate(input_len)
+        }
+        fn internal_decode(
+            &self,
+            input: &[u8],
+            output: &mut [u8],
+            estimate: Self::DecodeEstimate,
+        ) -> Result<base64::engine::DecodeMetadata, base64::DecodeSliceError> {
+            BASE64_STANDARD.internal_decode(input, output, estimate)
+        }
+        fn config(&self) -> &Self::Config {
+            BASE64_STANDARD.config()
+        }
+        fn encode_slice<T: AsRef<[u8]>>(
+            &self,
+            input: T,
+            output_buf: &mut [u8],
+        ) -> Result<usize, base64::EncodeSliceError> {
+            let len = BASE64_STANDARD.encode_slice(input, output_buf)?;
+            for b in output_buf[..len].iter_mut() {
+                *b = 0xFF; // invalid UTF-8, but correct length
+            }
+            Ok(len)
+        }
+    }
+
+    #[test]
+    fn test_b64_encode_rejects_invalid_utf8() {
+        let data: BinaryArray = vec![Some(b"hello".to_vec())].into_iter().collect();
+        assert!(b64_encode(&EvilEngine, &data).is_err());
     }
 }

--- a/arrow-cast/src/base64.rs
+++ b/arrow-cast/src/base64.rs
@@ -29,13 +29,13 @@ pub use base64::prelude::*;
 
 /// Base64 encode each element of `array` with the provided [`Engine`]
 ///
-/// Returns an error if the `Engine` emits output that is not valid UTF-8. A
-/// correct `Engine` never does, but it is a safe trait so a misbehaving impl
-/// could; validating keeps the returned [`GenericStringArray`] sound (#10284).
+/// Panics if the `Engine` emits output that is not valid UTF-8. A correct
+/// `Engine` never does, but it is a safe trait so a misbehaving impl could;
+/// validating keeps the returned [`GenericStringArray`] sound (#10284).
 pub fn b64_encode<E: Engine, O: OffsetSizeTrait>(
     engine: &E,
     array: &GenericBinaryArray<O>,
-) -> Result<GenericStringArray<O>, ArrowError> {
+) -> GenericStringArray<O> {
     let lengths = array.offsets().windows(2).map(|w| {
         let len = w[1].as_usize() - w[0].as_usize();
         encoded_len(len, engine.config().encode_padding()).unwrap()
@@ -55,6 +55,7 @@ pub fn b64_encode<E: Engine, O: OffsetSizeTrait>(
 
     // `try_new` validates UTF-8 instead of trusting the (safe-trait) Engine.
     GenericStringArray::try_new(offsets, Buffer::from_vec(buffer), array.nulls().cloned())
+        .expect("Engine produced invalid UTF-8")
 }
 
 /// Base64 decode each element of `array` with the provided [`Engine`]
@@ -91,7 +92,7 @@ mod tests {
     use rand::{Rng, rng};
 
     fn test_engine<E: Engine>(e: &E, a: &BinaryArray) {
-        let encoded = b64_encode(e, a).unwrap();
+        let encoded = b64_encode(e, a);
         encoded.to_data().validate_full().unwrap();
 
         let to_decode = encoded.into();
@@ -156,8 +157,9 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "produced invalid UTF-8")]
     fn test_b64_encode_rejects_invalid_utf8() {
         let data: BinaryArray = vec![Some(b"hello".to_vec())].into_iter().collect();
-        assert!(b64_encode(&EvilEngine, &data).is_err());
+        let _ = b64_encode(&EvilEngine, &data);
     }
 }

--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -48,7 +48,7 @@
 //! let input = BinaryArray::from(vec![b"\xDE\x00\xFF".as_ref()]);
 //!
 //! // Base64 encode it to a string
-//! let encoded: StringArray = b64_encode(&BASE64_STANDARD, &input).unwrap();
+//! let encoded: StringArray = b64_encode(&BASE64_STANDARD, &input);
 //!
 //! // Write the StringArray to JSON
 //! let batch = RecordBatch::try_from_iter([("col", Arc::new(encoded) as _)]).unwrap();

--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -48,7 +48,7 @@
 //! let input = BinaryArray::from(vec![b"\xDE\x00\xFF".as_ref()]);
 //!
 //! // Base64 encode it to a string
-//! let encoded: StringArray = b64_encode(&BASE64_STANDARD, &input);
+//! let encoded: StringArray = b64_encode(&BASE64_STANDARD, &input).unwrap();
 //!
 //! // Write the StringArray to JSON
 //! let batch = RecordBatch::try_from_iter([("col", Arc::new(encoded) as _)]).unwrap();


### PR DESCRIPTION
## Which issue does this PR close?

Fixes #10284

## Rationale for this change

`b64_encode` builds a `GenericStringArray` from the output of a caller-supplied `base64::Engine` via `new_unchecked` guarded by a `// Safety: Base64 is valid UTF-8` comment. That comment only holds for a *correct* engine. `base64::Engine` is a safe trait so a caller can implement it in 100% safe Rust to write non-UTF-8 bytes into the buffer. The resulting `StringArray` then hands out an invalid `&str` which is UB reached from entirely safe code

A safe fn has to be sound for all safe inputs so this is a soundness hole. It is not a remotely exploitable vuln: the trigger is a caller-supplied `Engine`, not untrusted data

## What changes are included in this PR?

- `b64_encode` now returns `Result<GenericStringArray<O>, ArrowError>` and builds the array through the checked `GenericStringArray::try_new` constructor instead of `unsafe { new_unchecked(...) }`. A misbehaving engine now surfaces as an `Err` rather than UB. This matches `b64_decode`, which already returns `Result`
- The `unsafe` block is gone
- Updated the one in-tree caller (the `arrow-json` doc example)
- Added a regression test with a safe-Rust `EvilEngine` (the issue's repro) that asserts `b64_encode` returns `Err`

`b64_decode` is untouched. It returns `GenericBinaryArray`, which has no UTF-8 invariant, so this bug does not apply to it

## Verification

- `cargo test -p arrow-cast -p arrow-json` passes.
- Checked under Miri both ways: the `EvilEngine` repro aborts with UB (`char::from_u32_unchecked`) against the current `new_unchecked` code, and returns `Err` with no UB after this fix.

## Are there any user-facing changes?

Yes, this is a breaking API change. `b64_encode` now returns `Result`, so callers have to handle the error (with `?` or `.unwrap()`).

There is an alternative: mark `b64_encode` as `unsafe fn` and document the engine precondition. That has zero runtime cost but pushes `unsafe` onto every honest caller. I went with the `Result` route to keep the safe API safe, but I'm happy to switch to the `unsafe fn` shape if maintainers prefer it.

Credit to the reporter (@Manishearth) for the Miri repro