### PR TITLE
Docs: fix mutableArrayData comments

### DIFF
--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -397,13 +397,12 @@ impl<'a> MutableArrayData<'a> {
     ///
     /// # Arguments
     /// * `arrays` - the source arrays to copy from
-    /// * `use_nulls` - a flag used to optimize insertions
-    ///   - `false` if the only source of nulls are the arrays themselves
-    ///   - `true` if the user plans to call [MutableArrayData::extend_nulls].
-    /// * capacity - the preallocated capacity of the output array, in bytes
+    /// * `use_nulls` - a flag indicating whether the caller intends to call `extend_nulls`.
+    ///   Note: null-handling is enabled automatically if any source array contains nulls.
+    /// * `capacity` - the preallocated capacity of the output array, in slots (number of elements)
     ///
-    /// Thus, if `use_nulls` is `false`, calling
-    /// [MutableArrayData::extend_nulls] should not be used.
+    /// Thus, if `use_nulls` is `false` and none of the source arrays contain nulls,
+    /// calling [MutableArrayData::extend_nulls] should not be used.
     pub fn new(arrays: Vec<&'a ArrayData>, use_nulls: bool, capacity: usize) -> Self {
         Self::with_capacities(arrays, use_nulls, Capacities::Array(capacity))
     }

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -117,11 +117,11 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits<
 /// use arrow_data::ArrayData;
 /// use arrow_data::transform::MutableArrayData;
 /// use arrow_schema::DataType;
-/// fn i32_array(values: &[i32],len: usize) -> ArrayData {
+/// fn i32_array(values: &[i32], len: usize) -> ArrayData {
 ///   ArrayData::try_new(DataType::Int32, len, None, 0, vec![Buffer::from_slice_ref(values)], vec![]).unwrap()
 /// }
-/// let arr1  = i32_array(&[1, 2, 3, 4, 5],5);
-/// let arr2  = i32_array(&[6, 7, 8, 9, 10],5);
+/// let arr1  = i32_array(&[1, 2, 3, 4, 5], 5);
+/// let arr2  = i32_array(&[6, 7, 8, 9, 10], 5);
 /// // Create a mutable array for copying values from arr1 and arr2, with a capacity for 6 elements
 /// let capacity = 3 * std::mem::size_of::<i32>();
 /// let mut mutable = MutableArrayData::new(vec![&arr1, &arr2], false, 10);
@@ -131,7 +131,7 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits<
 /// mutable.extend(1, 2, 5);
 /// // Complete the MutableArrayData into a new ArrayData
 /// let frozen = mutable.freeze();
-/// assert_eq!(frozen, i32_array(&[1, 2, 3, 8, 9, 10],6));
+/// assert_eq!(frozen, i32_array(&[1, 2, 3, 8, 9, 10], 6));
 /// ```
 pub struct MutableArrayData<'a> {
     /// Input arrays: the data being read FROM.

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -117,21 +117,21 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits<
 /// use arrow_data::ArrayData;
 /// use arrow_data::transform::MutableArrayData;
 /// use arrow_schema::DataType;
-/// fn i32_array(values: &[i32]) -> ArrayData {
-///   ArrayData::try_new(DataType::Int32, 5, None, 0, vec![Buffer::from_slice_ref(values)], vec![]).unwrap()
+/// fn i32_array(values: &[i32],len: usize) -> ArrayData {
+///   ArrayData::try_new(DataType::Int32, len, None, 0, vec![Buffer::from_slice_ref(values)], vec![]).unwrap()
 /// }
-/// let arr1  = i32_array(&[1, 2, 3, 4, 5]);
-/// let arr2  = i32_array(&[6, 7, 8, 9, 10]);
+/// let arr1  = i32_array(&[1, 2, 3, 4, 5],5);
+/// let arr2  = i32_array(&[6, 7, 8, 9, 10],5);
 /// // Create a mutable array for copying values from arr1 and arr2, with a capacity for 6 elements
 /// let capacity = 3 * std::mem::size_of::<i32>();
 /// let mut mutable = MutableArrayData::new(vec![&arr1, &arr2], false, 10);
 /// // Copy the first 3 elements from arr1
 /// mutable.extend(0, 0, 3);
 /// // Copy the last 3 elements from arr2
-/// mutable.extend(1, 2, 4);
+/// mutable.extend(1, 2, 5);
 /// // Complete the MutableArrayData into a new ArrayData
 /// let frozen = mutable.freeze();
-/// assert_eq!(frozen, i32_array(&[1, 2, 3, 8, 9, 10]));
+/// assert_eq!(frozen, i32_array(&[1, 2, 3, 8, 9, 10],6));
 /// ```
 pub struct MutableArrayData<'a> {
     /// Input arrays: the data being read FROM.

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -117,11 +117,11 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits<
 /// use arrow_data::ArrayData;
 /// use arrow_data::transform::MutableArrayData;
 /// use arrow_schema::DataType;
-/// fn i32_array(values: &[i32], len: usize) -> ArrayData {
-///   ArrayData::try_new(DataType::Int32, len, None, 0, vec![Buffer::from_slice_ref(values)], vec![]).unwrap()
+/// fn i32_array(values: &[i32]) -> ArrayData {
+///   ArrayData::try_new(DataType::Int32, values.len(), None, 0, vec![Buffer::from_slice_ref(values)], vec![]).unwrap()
 /// }
-/// let arr1  = i32_array(&[1, 2, 3, 4, 5], 5);
-/// let arr2  = i32_array(&[6, 7, 8, 9, 10], 5);
+/// let arr1  = i32_array(&[1, 2, 3, 4, 5]);
+/// let arr2  = i32_array(&[6, 7, 8, 9, 10]);
 /// // Create a mutable array for copying values from arr1 and arr2, with a capacity for 6 elements
 /// let capacity = 3 * std::mem::size_of::<i32>();
 /// let mut mutable = MutableArrayData::new(vec![&arr1, &arr2], false, 10);
@@ -131,7 +131,7 @@ fn build_extend_null_bits(array: &ArrayData, use_nulls: bool) -> ExtendNullBits<
 /// mutable.extend(1, 2, 5);
 /// // Complete the MutableArrayData into a new ArrayData
 /// let frozen = mutable.freeze();
-/// assert_eq!(frozen, i32_array(&[1, 2, 3, 8, 9, 10], 6));
+/// assert_eq!(frozen, i32_array(&[1, 2, 3, 8, 9, 10]));
 /// ```
 pub struct MutableArrayData<'a> {
     /// Input arrays: the data being read FROM.
@@ -401,8 +401,8 @@ impl<'a> MutableArrayData<'a> {
     ///   Note: null-handling is enabled automatically if any source array contains nulls.
     /// * `capacity` - the preallocated capacity of the output array, in slots (number of elements)
     ///
-    /// Thus, if `use_nulls` is `false` and none of the source arrays contain nulls,
-    /// calling [MutableArrayData::extend_nulls] should not be used.
+    /// if `use_nulls` is `false` and no source arrays contains nulls, calling
+    /// [MutableArrayData::extend_nulls] or [MutableArrayData::try_extend_nulls] will panic.
     pub fn new(arrays: Vec<&'a ArrayData>, use_nulls: bool, capacity: usize) -> Self {
         Self::with_capacities(arrays, use_nulls, Capacities::Array(capacity))
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9398.

# Rationale for this change
the comments on [arrow-rs/arrow-data/src/transform/mod.rs](https://github.com/apache/arrow-rs/blob/d6168e526aae79d6fbafe8c11062b5f834021052/arrow-data/src/transform/mod.rs#L389-L401) were misleading/incorrect
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- updated DocTest to be accurate
- updated `MutableArrayData::new()` to correctly use slots instead of bytes for allocation
- see comment on issue -> https://github.com/apache/arrow-rs/issues/9398#issuecomment-4950122420
 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
yes, users will have better doc comments.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
