### PR TITLE
Don't panic on invalid c ffi schema name

### DIFF
--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -171,7 +171,14 @@ impl FFI_ArrowSchema {
 
     /// Set the name of the schema
     pub fn with_name(mut self, name: &str) -> Result<Self, ArrowError> {
-        self.name = CString::new(name).unwrap().into_raw();
+        self.name = CString::new(name)
+            .map_err(|e| {
+                ArrowError::CDataInterface(format!(
+                    "Null byte at position {} not allowed in name",
+                    e.nul_position()
+                ))
+            })?
+            .into_raw();
         Ok(self)
     }
 
@@ -1000,6 +1007,16 @@ mod tests {
             let field = Field::try_from(&schema).unwrap();
             assert_eq!(field.metadata(), &metadata);
         }
+    }
+
+    #[test]
+    fn test_name_with_null_byte() {
+        let schema = FFI_ArrowSchema::try_new("i", vec![], None).unwrap();
+        let err = schema.with_name("ab\0cd").unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "C Data interface error: Null byte at position 2 not allowed in name"
+        );
     }
 
     #[test]

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -1012,11 +1012,7 @@ mod tests {
     #[test]
     fn test_name_with_null_byte() {
         let schema = FFI_ArrowSchema::try_new("i", vec![], None).unwrap();
-        let err = schema.with_name("ab\0cd").unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "C Data interface error: Null byte at position 2 not allowed in name"
-        );
+        assert!(schema.with_name("ab\0cd").is_err());
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

mailing list thread "Spec clarification on field names"  https://lists.apache.org/thread/v2fvqjtfrvsrbm133yc7yjrxvjh0x3l5

# Rationale for this change

Arrow supports names that are not valid c string names. Instead of having the caller validate themselves the ArrowSchema C FFI already validates on the rust side, instead of panicing propagate the error to the user

# What changes are included in this PR?

Propagate Cstring::new error to the user instead of panicing

# Are these changes tested?

Added tests

# Are there any user-facing changes?

Error instead of panic