### PR TITLE
Remove flight-sql-experimental feature from arrow-flight

### DIFF
--- a/arrow-flight/Cargo.toml
+++ b/arrow-flight/Cargo.toml
@@ -63,8 +63,6 @@ all-features = true
 [features]
 default = []
 flight-sql = ["dep:arrow-arith", "dep:arrow-ord", "dep:arrow-row", "dep:arrow-select", "dep:arrow-string", "dep:once_cell", "dep:paste"]
-# TODO: Remove in the next release
-flight-sql-experimental = ["flight-sql"]
 tls-aws-lc= ["tonic/tls-aws-lc"]
 tls-native-roots = ["tonic/tls-native-roots"]
 tls-ring = ["tonic/tls-ring"]


### PR DESCRIPTION

- Closes #10276.
## Rationale for this change
The `flight-sql-experimental` feature in `arrow-flight` was previously renamed to `flight-sql` in #7498 and #7546. The `flight-sql-experimental` feature was kept as an alias for backwards compatibility, with a TODO note indicating it should be removed in the next release. Since this requires a major release, it is now time to remove it completely.
## What changes are included in this PR?
- Removed the `flight-sql-experimental` feature definition from `arrow-flight/Cargo.toml`.
## Are these changes tested?
Yes, existing CI tests will cover this (since it just removes an alias feature flag).
## Are there any user-facing changes?
Yes, any users still depending on the `flight-sql-experimental` feature flag will now need to update their `Cargo.toml` to use `flight-sql` instead.