### PR TITLE
feat(arrow-array): Expose builder buffer capacity accessors

### DIFF
--- a/arrow-array/src/builder/generic_bytes_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_builder.rs
@@ -231,14 +231,29 @@ impl<T: ByteArrayType> GenericByteBuilder<T> {
         self.value_builder.as_slice()
     }
 
+    /// Returns the current values buffer capacity, in bytes.
+    pub fn values_capacity(&self) -> usize {
+        self.value_builder.capacity()
+    }
+
     /// Returns the current offsets buffer as a slice
     pub fn offsets_slice(&self) -> &[T::Offset] {
         self.offsets_builder.as_slice()
     }
 
+    /// Returns the current offsets buffer capacity, in offsets.
+    pub fn offsets_capacity(&self) -> usize {
+        self.offsets_builder.capacity()
+    }
+
     /// Returns the current null buffer as a slice
     pub fn validity_slice(&self) -> Option<&[u8]> {
         self.null_buffer_builder.as_slice()
+    }
+
+    /// Returns the current null buffer allocated capacity, in bytes.
+    pub fn validity_capacity(&self) -> usize {
+        self.null_buffer_builder.allocated_size()
     }
 
     /// Returns the current null buffer as a mutable slice

--- a/arrow-array/src/builder/generic_list_builder.rs
+++ b/arrow-array/src/builder/generic_list_builder.rs
@@ -355,9 +355,19 @@ where
         self.offsets_builder.as_slice()
     }
 
+    /// Returns the current offsets buffer capacity, in offsets.
+    pub fn offsets_capacity(&self) -> usize {
+        self.offsets_builder.capacity()
+    }
+
     /// Returns the current null buffer as a slice
     pub fn validity_slice(&self) -> Option<&[u8]> {
         self.null_buffer_builder.as_slice()
+    }
+
+    /// Returns the current null buffer allocated capacity, in bytes.
+    pub fn validity_capacity(&self) -> usize {
+        self.null_buffer_builder.allocated_size()
     }
 }
 

--- a/arrow-array/src/builder/primitive_builder.rs
+++ b/arrow-array/src/builder/primitive_builder.rs
@@ -361,6 +361,11 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
         self.null_buffer_builder.as_slice()
     }
 
+    /// Returns the current null buffer allocated capacity, in bytes.
+    pub fn validity_capacity(&self) -> usize {
+        self.null_buffer_builder.allocated_size()
+    }
+
     /// Returns the current null buffer as a mutable slice
     pub fn validity_slice_mut(&mut self) -> Option<&mut [u8]> {
         self.null_buffer_builder.as_slice_mut()

--- a/arrow-array/src/builder/struct_builder.rs
+++ b/arrow-array/src/builder/struct_builder.rs
@@ -314,6 +314,11 @@ impl StructBuilder {
     pub fn validity_slice(&self) -> Option<&[u8]> {
         self.null_buffer_builder.as_slice()
     }
+
+    /// Returns the current null buffer allocated capacity, in bytes.
+    pub fn validity_capacity(&self) -> usize {
+        self.null_buffer_builder.allocated_size()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10341.

# Rationale for this change

Downstream memory accounting sometimes needs to measure the allocated capacity currently retained by Arrow array builders, including allocation slack after buffer growth. Existing slice accessors expose initialized data, but not the underlying values, offsets, or validity-buffer capacity.

# What changes are included in this PR?

This adds read-only capacity accessors for existing builder internals:

- `GenericByteBuilder::{values_capacity, offsets_capacity, validity_capacity}`
- `GenericListBuilder::{offsets_capacity, validity_capacity}`
- `PrimitiveBuilder::validity_capacity`
- `StructBuilder::validity_capacity`

The methods only read existing builder state and do not change append, reserve, finish, or resize behavior.

# Are these changes tested?

No behavior-specific tests are added because these methods only expose existing capacity fields through read-only forwarding accessors. Existing arrow-array builder tests were run unchanged, and the new public API is compile-checked by the crate.

Validated with:

- `cargo fmt --all -- --check`
- `cargo test -p arrow-array builder --lib`
- `cargo test -p arrow-array --lib`
- `cargo +1.96.0 clippy -p arrow-array --all-targets --no-deps -- -D warnings`

# Are there any user-facing changes?

Yes. This adds public read-only capacity accessors on Arrow array builders.
