### PR TITLE
hoist calls for null_sentinel

### DIFF
--- a/arrow-row/src/fixed.rs
+++ b/arrow-row/src/fixed.rs
@@ -221,6 +221,7 @@ pub fn encode<T: FixedLengthEncoding>(
     nulls: &NullBuffer,
     opts: SortOptions,
 ) {
+    let null_sentinel = null_sentinel(opts);
     for (value_idx, is_valid) in nulls.iter().enumerate() {
         let offset = &mut offsets[value_idx + 1];
         let end_offset = *offset + T::ENCODED_LEN;
@@ -234,7 +235,7 @@ pub fn encode<T: FixedLengthEncoding>(
             }
             to_write[1..].copy_from_slice(encoded.as_ref())
         } else {
-            data[*offset] = null_sentinel(opts);
+            data[*offset] = null_sentinel;
         }
         *offset = end_offset;
     }
@@ -276,6 +277,7 @@ pub fn encode_boolean(
     nulls: &NullBuffer,
     opts: SortOptions,
 ) {
+    let null_sentinel = null_sentinel(opts);
     for (idx, is_valid) in nulls.iter().enumerate() {
         let offset = &mut offsets[idx + 1];
         let end_offset = *offset + bool::ENCODED_LEN;
@@ -289,7 +291,7 @@ pub fn encode_boolean(
             }
             to_write[1..].copy_from_slice(encoded.as_ref())
         } else {
-            data[*offset] = null_sentinel(opts);
+            data[*offset] = null_sentinel;
         }
         *offset = end_offset;
     }
@@ -327,6 +329,7 @@ pub fn encode_fixed_size_binary(
     opts: SortOptions,
 ) {
     let len = array.value_length() as usize;
+    let null_sentinel = null_sentinel(opts);
     for (offset, maybe_val) in offsets.iter_mut().skip(1).zip(array.iter()) {
         let end_offset = *offset + len + 1;
         if let Some(val) = maybe_val {
@@ -338,7 +341,7 @@ pub fn encode_fixed_size_binary(
                 to_write[1..1 + len].iter_mut().for_each(|v| *v = !*v)
             }
         } else {
-            data[*offset] = null_sentinel(opts);
+            data[*offset] = null_sentinel;
         }
         *offset = end_offset;
     }

--- a/arrow-row/src/list.rs
+++ b/arrow-row/src/list.rs
@@ -547,9 +547,10 @@ pub unsafe fn decode_list_view<O: OffsetSizeTrait>(
     }
     O::from_usize(child_count).expect("overflow");
 
+    let null_sentinel = null_sentinel(opts);
     let mut null_count = 0;
     let nulls = MutableBuffer::collect_bool(rows.len(), |x| {
-        let valid = rows[x][0] != null_sentinel(opts);
+        let valid = rows[x][0] != null_sentinel;
         null_count += !valid as usize;
         valid
     });

--- a/arrow-row/src/variable.rs
+++ b/arrow-row/src/variable.rs
@@ -336,6 +336,7 @@ fn decode_binary_view_inner<const VALIDATE_UTF8: bool>(
         Vec::new()
     };
 
+    let null_sentinel = null_sentinel(options);
     let mut views = vec![0_u128; len];
     for (i, row) in rows.iter_mut().enumerate() {
         let start_offset = values.len();
@@ -344,7 +345,7 @@ fn decode_binary_view_inner<const VALIDATE_UTF8: bool>(
         // overwrite short strings in the values buffer as we inline those to
         // views.
         let decoded_len = values.len() - start_offset;
-        if row[0] == null_sentinel(options) {
+        if row[0] == null_sentinel {
             debug_assert_eq!(offset, 1);
             debug_assert_eq!(start_offset, values.len());
         } else {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- works towards #10246.
- there are other optimizations I have in mind but this was low hanging fruit.

# Rationale for this change
hoist the call to `null_sentnel` when in a loop since the result wont change.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
hoist the call to `null_sentnel` when in a loop since the result wont change.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes, existing test
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
