### PR TITLE
variant: optimize variant object path access (79% lower latency)

### DIFF
--- a/parquet-variant-compute/benches/variant_kernels.rs
+++ b/parquet-variant-compute/benches/variant_kernels.rs
@@ -15,11 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow::array::{Array, ArrayRef, BinaryViewArray, StringArray, StructArray};
+use arrow::array::{Array, ArrayRef, BinaryViewArray, BinaryViewBuilder, StringArray, StructArray};
+use arrow::buffer::Buffer;
 use arrow::util::test_util::seedable_rng;
 use arrow_schema::{DataType, Field, FieldRef, Fields};
 use criterion::{Criterion, criterion_group, criterion_main};
-use parquet_variant::{EMPTY_VARIANT_METADATA_BYTES, Variant, VariantBuilder};
+use parquet_variant::{EMPTY_VARIANT_METADATA_BYTES, Variant, VariantBuilder, VariantPath};
 use parquet_variant_compute::{
     GetOptions, VariantArray, VariantArrayBuilder, json_to_variant, variant_get,
 };
@@ -31,6 +32,8 @@ use rand::rngs::StdRng;
 use serde_json::Value;
 use std::fmt::Write;
 use std::sync::Arc;
+
+const VARIANT_GET_UNSHREDDED_OBJECT_ROWS: usize = 262_144;
 
 fn benchmark_batch_json_string_to_variant(c: &mut Criterion) {
     let input_array = StringArray::from_iter_values(json_repeated_struct(8000));
@@ -170,10 +173,23 @@ pub fn variant_get_shredded_utf8_bench(c: &mut Criterion) {
     });
 }
 
+pub fn variant_get_unshredded_object_path_bench(c: &mut Criterion) {
+    let variant_array = create_unshredded_object_variant_array(VARIANT_GET_UNSHREDDED_OBJECT_ROWS);
+    let input = ArrayRef::from(variant_array);
+    let field: FieldRef = Arc::new(Field::new("typed_value", DataType::Int32, true));
+    let options = GetOptions::new_with_path(VariantPath::try_from("attr.140").unwrap())
+        .with_as_type(Some(field));
+
+    c.bench_function("variant_get_unshredded_object_path_262k_rows", |b| {
+        b.iter(|| variant_get(&input, options.clone()).unwrap())
+    });
+}
+
 criterion_group!(
     benches,
     variant_get_bench,
     variant_get_shredded_utf8_bench,
+    variant_get_unshredded_object_path_bench,
     benchmark_batch_json_string_to_variant
 );
 criterion_main!(benches);
@@ -221,6 +237,40 @@ fn create_shredded_utf8_variant_array(size: usize) -> VariantArray {
 
     VariantArray::try_new(struct_array_ref.as_ref())
         .expect("created struct should be a valid shredded variant")
+}
+
+fn create_unshredded_object_variant_array(size: usize) -> VariantArray {
+    let field_names = (0..300)
+        .map(|index| format!("attr.{index:03}"))
+        .collect::<Vec<_>>();
+    let mut builder =
+        VariantBuilder::new().with_field_names(field_names.iter().map(String::as_str));
+    let mut object = builder.new_object();
+    for index in (0..300).step_by(20) {
+        object.insert(&format!("attr.{index:03}"), index);
+    }
+    object.finish();
+    let (metadata, value) = builder.finish();
+
+    let repeated_view = |value: Vec<u8>| {
+        let len = u32::try_from(value.len()).unwrap();
+        let mut builder = BinaryViewBuilder::with_capacity(size);
+        let block = builder.append_block(Buffer::from(value));
+        for _ in 0..size {
+            builder.try_append_view(block, 0, len).unwrap();
+        }
+        builder.finish()
+    };
+    let metadata: ArrayRef = Arc::new(repeated_view(metadata));
+    let value: ArrayRef = Arc::new(repeated_view(value));
+    let fields = Fields::from(vec![
+        Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+        Arc::new(Field::new("value", DataType::BinaryView, false)),
+    ]);
+    let input: ArrayRef = Arc::new(StructArray::new(fields, vec![metadata, value], None));
+
+    VariantArray::try_new(input.as_ref())
+        .expect("created struct should be a valid unshredded variant")
 }
 
 /// Return an iterator off JSON strings, each representing a person

--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -25,9 +25,10 @@ use arrow::{
     error::Result,
 };
 use arrow_schema::{ArrowError, DataType, FieldRef};
-use parquet_variant::{VariantPath, VariantPathElement};
+use parquet_variant::{Variant, VariantMetadata, VariantPath, VariantPathElement};
 
 use crate::ShreddingState;
+use crate::variant_array::binary_array_value;
 use crate::variant_to_arrow::make_variant_to_arrow_row_builder;
 use crate::{VariantArray, VariantType, unshred_variant};
 
@@ -241,6 +242,7 @@ fn shredded_get_path(
             } else {
                 as_field.map(|f| f.data_type())
             };
+            let has_path = !path.is_empty();
             let mut builder = make_variant_to_arrow_row_builder(
                 target.metadata_column(),
                 path,
@@ -248,20 +250,64 @@ fn shredded_get_path(
                 cast_options,
                 target.len(),
             )?;
-            for i in 0..target.len() {
-                if target.is_null(i) {
-                    builder.append_null()?;
-                } else if !cast_options.safe {
-                    let value = target.try_value(i)?;
-                    builder.append_value(value)?;
-                } else {
-                    let _ = match target.try_value(i) {
-                        Ok(v) => builder.append_value(v)?,
-                        Err(_) => {
-                            builder.append_null()?;
-                            false // add this to make match arms have the same return type
+
+            if has_path
+                && target.typed_value_column().is_none()
+                && let Some(value_column) = target.value_column()
+            {
+                let metadata_column = target.metadata_column();
+                let mut cached_metadata = None::<((*const u8, usize), VariantMetadata<'_>)>;
+
+                for i in 0..target.len() {
+                    if target.is_null(i) || value_column.is_null(i) {
+                        builder.append_null()?;
+                        continue;
+                    }
+
+                    let metadata_bytes = binary_array_value(metadata_column.as_ref(), i)
+                        .ok_or_else(|| {
+                            ArrowError::InvalidArgumentError(format!(
+                                "variant metadata must be binary-like, got {}",
+                                metadata_column.data_type()
+                            ))
+                        })?;
+                    let metadata_identity = (metadata_bytes.as_ptr(), metadata_bytes.len());
+                    let metadata = match cached_metadata.as_ref() {
+                        Some((identity, metadata)) if *identity == metadata_identity => {
+                            metadata.clone()
+                        }
+                        _ => {
+                            let metadata = VariantMetadata::try_new(metadata_bytes)?;
+                            cached_metadata = Some((metadata_identity, metadata.clone()));
+                            metadata
                         }
                     };
+                    let value_bytes =
+                        binary_array_value(value_column.as_ref(), i).ok_or_else(|| {
+                            ArrowError::InvalidArgumentError(format!(
+                                "variant value must be binary-like, got {}",
+                                value_column.data_type()
+                            ))
+                        })?;
+                    let value = Variant::new_with_metadata(metadata, value_bytes);
+                    builder.append_value(value)?;
+                }
+            } else {
+                for i in 0..target.len() {
+                    if target.is_null(i) {
+                        builder.append_null()?;
+                    } else if !cast_options.safe {
+                        let value = target.try_value(i)?;
+                        builder.append_value(value)?;
+                    } else {
+                        let _ = match target.try_value(i) {
+                            Ok(v) => builder.append_value(v)?,
+                            Err(_) => {
+                                builder.append_null()?;
+                                false // add this to make match arms have the same return type
+                            }
+                        };
+                    }
                 }
             }
             builder.finish()
@@ -508,8 +554,8 @@ mod test {
     use arrow_schema::{DataType, Field, FieldRef, Fields, IntervalUnit, TimeUnit};
     use chrono::DateTime;
     use parquet_variant::{
-        EMPTY_VARIANT_METADATA_BYTES, Variant, VariantDecimal4, VariantDecimal8, VariantDecimal16,
-        VariantDecimalType, VariantPath,
+        EMPTY_VARIANT_METADATA_BYTES, Variant, VariantBuilder, VariantDecimal4, VariantDecimal8,
+        VariantDecimal16, VariantDecimalType, VariantPath,
     };
 
     fn single_variant_get_test(input_json: &str, path: VariantPath, expected_json: &str) {
@@ -564,6 +610,58 @@ mod test {
                 .unwrap()
                 .join("inner_field"),
             "1234",
+        );
+    }
+
+    #[test]
+    fn get_path_resolves_field_ids_for_each_metadata_dictionary() {
+        fn object_bytes(field_names: &[&str], fields: &[(&str, i32)]) -> (Vec<u8>, Vec<u8>) {
+            let mut builder = VariantBuilder::new().with_field_names(field_names.iter().copied());
+            let mut object = builder.new_object();
+            for (name, value) in fields {
+                object.insert(name, *value);
+            }
+            object.finish();
+            builder.finish()
+        }
+
+        // `target` has a different numeric field id in each metadata dictionary.
+        let (metadata_without_target, value_without_target) =
+            object_bytes(&["other"], &[("other", 5)]);
+        let (metadata_0, value_0) = object_bytes(&["target", "other"], &[("target", 10)]);
+        let (metadata_1, value_1) = object_bytes(&["other", "target"], &[("target", 20)]);
+        let (_, value_missing) = object_bytes(&["other", "target"], &[("other", 30)]);
+
+        let metadata: ArrayRef = Arc::new(BinaryArray::from(vec![
+            Some(metadata_without_target.as_slice()),
+            Some(metadata_0.as_slice()),
+            Some(metadata_1.as_slice()),
+            Some(metadata_1.as_slice()),
+            Some(metadata_0.as_slice()),
+        ]));
+        let value: ArrayRef = Arc::new(BinaryArray::from(vec![
+            Some(value_without_target.as_slice()),
+            Some(value_0.as_slice()),
+            Some(value_1.as_slice()),
+            Some(value_missing.as_slice()),
+            Some(value_0.as_slice()),
+        ]));
+        let input: ArrayRef = Arc::new(StructArray::new(
+            Fields::from(vec![
+                Field::new("metadata", DataType::Binary, false),
+                Field::new("value", DataType::Binary, false),
+            ]),
+            vec![metadata, value],
+            Some(NullBuffer::from(vec![true, true, true, true, false])),
+        ));
+        let options = GetOptions::new_with_path(VariantPath::try_from("target").unwrap())
+            .with_as_type(Some(Arc::new(Field::new("target", DataType::Int32, true))));
+
+        let result = variant_get(&input, options).unwrap();
+        let result = result.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(
+            result,
+            &Int32Array::from(vec![None, Some(10), Some(20), None, None])
         );
     }
 

--- a/parquet-variant-compute/src/variant_to_arrow.rs
+++ b/parquet-variant-compute/src/variant_to_arrow.rs
@@ -23,7 +23,7 @@ use crate::type_conversion::{
     PrimitiveFromVariant, TimestampFromVariant, variant_cast_with_options,
     variant_to_unscaled_decimal,
 };
-use crate::variant_array::ShreddedVariantFieldArray;
+use crate::variant_array::{ShreddedVariantFieldArray, binary_array_value};
 use crate::{VariantArray, VariantValueArrayBuilder};
 use arrow::array::{
     ArrayRef, ArrowNativeTypeOp, BinaryBuilder, BinaryLikeArrayBuilder, BinaryViewBuilder,
@@ -37,7 +37,7 @@ use arrow::compute::{CastOptions, DecimalCast, cast_with_options};
 use arrow::datatypes::{self, DataType, DecimalType};
 use arrow::error::{ArrowError, Result};
 use arrow_schema::{FieldRef, Fields, TimeUnit};
-use parquet_variant::{Variant, VariantPath};
+use parquet_variant::{Variant, VariantMetadata, VariantPath, VariantPathElement};
 use std::sync::Arc;
 
 /// Builder for converting variant values into strongly typed Arrow arrays.
@@ -177,7 +177,11 @@ pub(crate) fn make_variant_to_arrow_row_builder<'a>(
     if !path.is_empty() {
         builder = WithPath(VariantPathRowBuilder {
             builder: Box::new(builder),
+            metadata: metadata.clone(),
             path,
+            row_index: 0,
+            cached_metadata_identity: None,
+            resolved_path: None,
         })
     };
 
@@ -886,16 +890,69 @@ impl<'a> ArrayVariantToArrowRowBuilder<'a> {
 /// result to a nested builder.
 pub(crate) struct VariantPathRowBuilder<'a> {
     builder: Box<VariantToArrowRowBuilder<'a>>,
+    metadata: ArrayRef,
     path: VariantPath<'a>,
+    row_index: usize,
+    cached_metadata_identity: Option<(*const u8, usize)>,
+    resolved_path: Option<Vec<ResolvedVariantPathElement>>,
+}
+
+#[derive(Debug)]
+enum ResolvedVariantPathElement {
+    FieldId(u32),
+    FieldName(String),
+    Index(usize),
 }
 
 impl<'a> VariantPathRowBuilder<'a> {
     fn append_null(&mut self) -> Result<()> {
+        self.row_index += 1;
         self.builder.append_null()
     }
 
     fn append_value(&mut self, value: Variant<'_, '_>) -> Result<bool> {
-        if let Some(v) = value.get_path(&self.path) {
+        let row_index = self.row_index;
+        self.row_index += 1;
+
+        let Some(metadata_bytes) = binary_array_value(self.metadata.as_ref(), row_index) else {
+            self.builder.append_null()?;
+            return Ok(false);
+        };
+        let metadata_identity = (metadata_bytes.as_ptr(), metadata_bytes.len());
+        if self.cached_metadata_identity != Some(metadata_identity) {
+            let metadata = VariantMetadata::try_new(metadata_bytes)?;
+            self.resolved_path = self
+                .path
+                .iter()
+                .map(|element| match element {
+                    VariantPathElement::Field { name } => {
+                        metadata.get_entry(name).map(|(field_id, _)| {
+                            if metadata.is_sorted() {
+                                ResolvedVariantPathElement::FieldId(field_id)
+                            } else {
+                                ResolvedVariantPathElement::FieldName(name.to_string())
+                            }
+                        })
+                    }
+                    VariantPathElement::Index { index } => {
+                        Some(ResolvedVariantPathElement::Index(*index))
+                    }
+                })
+                .collect();
+            self.cached_metadata_identity = Some(metadata_identity);
+        }
+
+        let value = self.resolved_path.as_ref().and_then(|path| {
+            path.iter().try_fold(value, |value, element| match element {
+                ResolvedVariantPathElement::FieldId(field_id) => {
+                    value.get_object_field_by_id(*field_id)
+                }
+                ResolvedVariantPathElement::FieldName(name) => value.get_object_field(name),
+                ResolvedVariantPathElement::Index(index) => value.get_list_element(*index),
+            })
+        });
+
+        if let Some(v) = value {
             self.builder.append_value(v)
         } else {
             self.builder.append_null()?;

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -1505,6 +1505,19 @@ impl<'m, 'v> Variant<'m, 'v> {
         }
     }
 
+    /// If this is an object and the requested field id exists, retrieves the corresponding field
+    /// value. Otherwise, returns None.
+    ///
+    /// This is shorthand for [`Self::as_object`] followed by [`VariantObject::get_by_field_id`].
+    /// The field id must be resolved from this value's metadata dictionary, for example with
+    /// [`VariantMetadata::get_entry`].
+    pub fn get_object_field_by_id(&self, field_id: u32) -> Option<Self> {
+        match self {
+            Variant::Object(object) => object.get_by_field_id(field_id),
+            _ => None,
+        }
+    }
+
     /// Converts this variant to a `List` if it is a [`VariantList`].
     ///
     /// Returns `Some(&VariantList)` for list variants,

--- a/parquet-variant/src/variant/object.rs
+++ b/parquet-variant/src/variant/object.rs
@@ -359,10 +359,24 @@ impl<'m, 'v> VariantObject<'m, 'v> {
 
     /// Fallible version of `field_name`. Returns field name by index, capturing validation errors
     fn try_field_name(&self, i: usize) -> Result<&'m str, ArrowError> {
+        let field_id = self.try_field_id(i)?;
+        self.metadata.get(field_id as _)
+    }
+
+    /// Attempts to retrieve the ith field id from the field id region of the byte buffer.
+    fn try_field_id(&self, i: usize) -> Result<u32, ArrowError> {
         let byte_range = self.header.field_ids_start_byte() as _..self.first_field_offset_byte as _;
         let field_id_bytes = slice_from_slice(self.value, byte_range)?;
-        let field_id = self.header.field_id_size.unpack_u32(field_id_bytes, i)?;
-        self.metadata.get(field_id as _)
+        self.header.field_id_size.unpack_u32(field_id_bytes, i)
+    }
+
+    /// Returns the ith field id, or `None` if `i` is out of bounds.
+    fn field_id(&self, i: usize) -> Option<u32> {
+        if i >= self.len() {
+            return None;
+        }
+
+        self.try_field_id(i).ok()
     }
 
     /// Returns an iterator of (name, value) pairs over the fields of this object.
@@ -403,6 +417,26 @@ impl<'m, 'v> VariantObject<'m, 'v> {
         // and probing the dictionary for a field id is always O(1) work.
         let cmp = |i| Some(self.field_name(i)?.cmp(name));
         let i = try_binary_search_range_by(0..self.len(), cmp)?.ok()?;
+        self.field(i)
+    }
+
+    /// Returns the value of the field with the specified field id, if any.
+    ///
+    /// `field_id` must be resolved from this object's metadata dictionary, for example with
+    /// [`VariantMetadata::get_entry`]. A field id from a different metadata dictionary may refer
+    /// to a different field name.
+    ///
+    /// The search cost is logarithmic when the metadata dictionary is sorted and linear otherwise.
+    pub fn get_by_field_id(&self, field_id: u32) -> Option<Variant<'m, 'v>> {
+        let i = if self.metadata.is_sorted() {
+            // Object fields are ordered lexically by name. For a sorted metadata dictionary,
+            // lexical name order is the same as numeric field id order.
+            let cmp = |i| Some(self.field_id(i)?.cmp(&field_id));
+            try_binary_search_range_by(0..self.len(), cmp)?.ok()?
+        } else {
+            (0..self.len()).find(|i| self.field_id(*i) == Some(field_id))?
+        };
+
         self.field(i)
     }
 }
@@ -505,6 +539,18 @@ mod tests {
         assert!(name_field.is_some());
         assert_eq!(name_field.unwrap().as_string(), Some("hello"));
 
+        // Test field access by id with a sorted metadata dictionary
+        assert_eq!(
+            variant_obj.get_by_field_id(0).unwrap().as_boolean(),
+            Some(true)
+        );
+        assert_eq!(variant_obj.get_by_field_id(1).unwrap().as_int8(), Some(42));
+        assert_eq!(
+            variant_obj.get_by_field_id(2).unwrap().as_string(),
+            Some("hello")
+        );
+        assert!(variant_obj.get_by_field_id(3).is_none());
+
         // Test non-existent field
         let missing_field = variant_obj.get("missing");
         assert!(missing_field.is_none());
@@ -558,6 +604,44 @@ mod tests {
         let variant_obj = variant.as_object().unwrap();
         assert_eq!(variant_obj.len(), 1);
         assert_eq!(variant_obj.get(""), Some(Variant::from(42)));
+    }
+
+    #[test]
+    fn test_variant_object_get_by_field_id_unsorted_metadata() {
+        let mut builder =
+            VariantBuilder::new().with_field_names(["name", "missing", "age", "active"]);
+        let mut object = builder.new_object();
+        object.insert("active", true);
+        object.insert("age", 42_i8);
+        object.insert("name", "hello");
+        object.finish();
+
+        let (metadata, value) = builder.finish();
+        let variant = Variant::new(&metadata, &value);
+        assert!(!variant.metadata().is_sorted());
+
+        let active_id = variant.metadata().get_entry("active").unwrap().0;
+        let age_id = variant.metadata().get_entry("age").unwrap().0;
+        let name_id = variant.metadata().get_entry("name").unwrap().0;
+        let missing_id = variant.metadata().get_entry("missing").unwrap().0;
+
+        assert_eq!(
+            variant
+                .get_object_field_by_id(active_id)
+                .unwrap()
+                .as_boolean(),
+            Some(true)
+        );
+        assert_eq!(
+            variant.get_object_field_by_id(age_id).unwrap().as_int8(),
+            Some(42)
+        );
+        assert_eq!(
+            variant.get_object_field_by_id(name_id).unwrap().as_string(),
+            Some("hello")
+        );
+        assert_eq!(variant.get_object_field_by_id(missing_id), None);
+        assert_eq!(variant.get_object_field_by_id(u32::MAX), None);
     }
 
     #[test]


### PR DESCRIPTION
# Rationale for this change

Based on benchmark https://github.com/apache/arrow-rs/pull/10357

<img width="1512" height="382" alt="Screenshot 2026-07-16 at 5 15 20 PM" src="https://github.com/user-attachments/assets/74425745-85ea-4411-88f7-6845f6dd8ad7" />

This PR speeds up field extraction from unshredded variant objects by avoiding repeated field name decoding for every row

Variant object keys are stored as numeric field ids that map to a metadata dictionary. `variant_get` currently stores a named path by repeatedly mapping those ids back to strings and comparing the strings for each row, _even when a batch shares one metadata dictionary_. This repeated per-row work dominates  when dealing with wide dictionaries

This optimization adds metadata scoped field id lookups, caches parsed metadata, and resolves named path elements to ids once per metadata dictionary before scanning rows. It re-resolves paths when the metadata changes and retains name lookup for unsorted dictionaries