### PR TITLE
[58_maintenance] Fix MSRV CI check (pin tonic to 0.14.5, install cargo-msrv --locked)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,7 +118,15 @@ jobs:
         uses: ./.github/actions/setup-builder
       - name: Install cargo-msrv (if needed)
         # cargo-msrv binary may be cached by the cargo cache step in setup-builder, and cargo install will error if it is already installed
-        run: if which cargo-msrv ; then echo "using existing cargo-msrv binary" ; else cargo install cargo-msrv ; fi
+        run: if which cargo-msrv ; then echo "using existing cargo-msrv binary" ; else cargo install cargo-msrv --locked ; fi
+      - name: Downgrade workspace dependencies
+        # Necessary because tonic 0.14.6 requires rust 1.88 or newer. We do not commit a Cargo.lock,
+        # so `cargo msrv verify` resolves fresh and would otherwise pick these newer versions. The
+        # tonic crates must be downgraded in matched pairs so their inter-crate requirements stay
+        # satisfiable. See https://github.com/apache/arrow-rs/issues/10349
+        run: |
+          cargo update -p tonic -p tonic-prost --precise 0.14.5
+          cargo update -p tonic-build -p tonic-prost-build --precise 0.14.5
       - name: Check all packages
         run: |
           # run `cargo msrv verify --manifest-path "path/to/Cargo.toml"` to see problematic dependencies


### PR DESCRIPTION
# Which issue does this PR close?

<!-- No dedicated issue for the CI break; file one if a tracker is wanted. -->

- Part of #10349 (58.4.0 release effort).
- Unblocks #10351, whose CI surfaced this pre-existing failure.
- Prior art: #7290 (Fix MSRV CI Check), same class of fix.

# Rationale for this change

The `Verify MSRV` job on `58_maintenance` is failing on every PR (surfaced by #10351, whose own changes are parquet-only and unrelated). Two independent, pre-existing problems, both from dependency drift:

1. **`cargo install cargo-msrv` fails to build.** Installed unlocked, cargo-msrv's transitive deps resolve to their newest versions; recent `aws-*` releases require rustc 1.94.1, newer than the CI container's rustc, so the install fails before `verify` runs.

2. **`cargo msrv verify` fails on `arrow-flight`.** We commit no `Cargo.lock`, so `verify` resolves fresh each run and picks the newest deps. `tonic 0.14.6` now requires rustc 1.88, above our 1.85 MSRV.

# What changes are included in this PR?

Both changes are in `.github/workflows/rust.yml` (MSRV job only):

- Install cargo-msrv with `--locked`, so its transitive deps resolve to versions that build on the CI container's rustc instead of the newest published ones.
- Add a `Downgrade workspace dependencies` step that pins the tonic crates to 0.14.5 (the latest release supporting rustc 1.85) before `cargo msrv verify`, following the approach in #7290. The tonic crates are downgraded in matched pairs (`tonic`/`tonic-prost`, then `tonic-build`/`tonic-prost-build`) so their inter-crate `^` requirements stay satisfiable.

No source, `Cargo.toml`, or declared-MSRV changes.

# Are these changes tested?

Yes, verified locally against a 1.85.1 toolchain with `cargo-msrv` 0.19.3 (matching CI):

- Without the pins: `cargo msrv verify` on `arrow-flight` reports `is_compatible: false` (`tonic 0.14.6` requires 1.88).
- With the pins: the full CI `find` loop (`cargo msrv verify` over all 29 packages) passes.

# Are there any user-facing changes?

No. CI-only change; no public API, code, or declared-MSRV changes.

---

**Note for reviewers:** `main` has the same latent failure -- I ran `cargo msrv verify` on `main`'s HEAD and it fails identically on `tonic 0.14.6`. Its CI is currently green only because of a cached registry index predating that release. The `--locked` fix is already on `main`; the tonic pin step is not. Suggest a follow-up applying the tonic pin step to `main` as well.
