### PR TITLE
[58_maintenance]  chore: Ignore py03 vulnerabilities until upgrade

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,6 +30,7 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+      - '.github/workflows/dev_pr/audit.yml'
 
 jobs:
   cargo-audit:
@@ -43,4 +44,7 @@ jobs:
         # Waiting on an object_store release with quick-xml >=0.41.0.
         # https://rustsec.org/advisories/RUSTSEC-2026-0194
         # https://rustsec.org/advisories/RUSTSEC-2026-0195
-        run: cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195
+        # Need to update to py03 >=0.29.0
+        # https://rustsec.org/advisories/RUSTSEC-2026-0176
+        # https://rustsec.org/advisories/RUSTSEC-2026-0177
+        run: cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195 --ignore RUSTSEC-2026-0176 --ignore RUSTSEC-2026-0177


### PR DESCRIPTION
# Which issue does this PR close?
- part of https://github.com/apache/arrow-rs/issues/10349

# Rationale for this change

trying to get a clean CI run, and new rustsec vulnerabilities affect older verisons of py03
- https://rustsec.org/advisories/RUSTSEC-2026-0176
- https://rustsec.org/advisories/RUSTSEC-2026-0177

Neither seems specific to arrow-rs so I think it is best to ignore them until we have updated py03 versions (which we will do in our next major release

# What changes are included in this PR?
1. Add them to the ignore
2. trigger audit workflow on changes to the workflow itself (so I can test more easily)

# Are these changes tested?

yes by ci

# Are there any user-facing changes?

No