### PR TITLE
[58_maintenance] Add test for `parquet-testing/bad_data/ARROW-GH-47662.parquet` (#10077)

### DIFF
--- a/parquet/tests/arrow_reader/bad_data.rs
+++ b/parquet/tests/arrow_reader/bad_data.rs
@@ -32,6 +32,7 @@ static KNOWN_FILES: &[&str] = &[
     "ARROW-RS-GH-6229-DICTHEADER.parquet",
     "ARROW-RS-GH-6229-LEVELS.parquet",
     "ARROW-GH-45185.parquet",
+    "ARROW-GH-47662.parquet",
     "README.md",
 ];
 
@@ -128,6 +129,15 @@ fn test_arrow_rs_gh_45185_dict_levels() {
     assert_eq!(
         err.to_string(),
         "External: Parquet argument error: Parquet error: first repetition level of batch must be 0"
+    );
+}
+
+#[test]
+fn test_arrow_gh_47662() {
+    let err = read_file("ARROW-GH-47662.parquet").unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "External: Parquet argument error: Parquet error: insufficient values read from column - expected: 100, got: 91"
     );
 }
 


### PR DESCRIPTION
- related to  #9110
- backport of https://github.com/apache/arrow-rs/pull/10077 from @etseidl to 58 branch
