### PR TITLE
chore(arrow-cast): support white space prefixed parse for ints and floats

### DIFF
--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -459,6 +459,14 @@ impl Parser for Float32Type {
 
 impl Parser for Float64Type {
     fn parse(string: &str) -> Option<f64> {
+        let mut string = string;
+        if string
+            .as_bytes()
+            .first()
+            .is_some_and(|first_byte| !first_byte.is_ascii_digit())
+        {
+            string = string.trim_start()
+        }
         lexical_core::parse(string.as_bytes()).ok()
     }
 }
@@ -467,9 +475,17 @@ macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
             fn parse(string: &str) -> Option<Self::Native> {
+                let mut string = string;
                 if !string.as_bytes().last().is_some_and(|x| x.is_ascii_digit()) {
                     return None;
                 }
+                if string
+                    .as_bytes()
+                    .first()
+                    .is_some_and(|first| !first.is_ascii_digit())
+                {
+                    string = string.trim_start();
+                };
                 match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(
                     string.as_bytes(),
                 ) {
@@ -2871,5 +2887,20 @@ mod tests {
         assert_eq!(interval.months, 0);
         assert_eq!(interval.days, 0);
         assert_eq!(interval.nanoseconds, NANOS_PER_SECOND);
+    }
+    #[test]
+    fn test_parse_prefix_white_space() {
+        assert_eq!(Float64Type::parse(" 1.5"), Some(1.5));
+        assert_eq!(Float64Type::parse("\t\n 20.54"), Some(20.54));
+        assert_eq!(Float64Type::parse("\n2.5"), Some(2.5));
+        assert_eq!(Float64Type::parse("\n\t\n\t\n40.5123"), Some(40.5123));
+        assert_eq!(Float64Type::parse(" 1.5"), Some(1.5));
+        assert_eq!(Int32Type::parse(" 3"), Some(3));
+        assert_eq!(Int32Type::parse("          30"), Some(30));
+        assert_eq!(Int32Type::parse("\n \n 100"), Some(100));
+        assert_eq!(Int32Type::parse(" \n25"), Some(25));
+        assert_eq!(Int32Type::parse("\t800"), Some(800));
+        assert_eq!(Int32Type::parse("\t  \n \t 851"), Some(851));
+        assert_eq!(Int32Type::parse("\t\n\t\n\n\n\t1"), Some(1));
     }
 }

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -481,8 +481,7 @@ fn truncate_white_space(string: &str) -> &str {
 macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
-            fn parse(string: &str) -> Option<Self::Native> {
-                let mut string = string;
+            fn parse(mut string: &str) -> Option<Self::Native> {
                 if !string.as_bytes().last().is_some_and(|x| x.is_ascii_digit()) {
                     return None;
                 }
@@ -2900,8 +2899,11 @@ mod tests {
         assert_eq!(Float64Type::parse(" 1.5"), Some(1.5));
         assert_eq!(Float64Type::parse("\t\n 20.54"), Some(20.54));
         assert_eq!(Float64Type::parse("\n2.5"), Some(2.5));
+        assert_eq!(Float64Type::parse("\n-942.5423"), Some(-942.5423));
         assert_eq!(Float64Type::parse("\n\t\n\t\n40.5123"), Some(40.5123));
         assert_eq!(Float64Type::parse(" 1.5"), Some(1.5));
+        assert_eq!(Float64Type::parse("\n\t\n\t\n-40.5123"), Some(-40.5123));
+        assert_eq!(Float64Type::parse(" -1.5"), Some(-1.5));
         assert_eq!(Int32Type::parse(" 3"), Some(3));
         assert_eq!(Int32Type::parse("          30"), Some(30));
         assert_eq!(Int32Type::parse("\n \n 100"), Some(100));
@@ -2909,5 +2911,7 @@ mod tests {
         assert_eq!(Int32Type::parse("\t800"), Some(800));
         assert_eq!(Int32Type::parse("\t  \n \t 851"), Some(851));
         assert_eq!(Int32Type::parse("\t\n\t\n\n\n\t1"), Some(1));
+        assert_eq!(Int32Type::parse(" \n-25"), Some(-25));
+        assert_eq!(Int32Type::parse("\t-800"), Some(-800));
     }
 }

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -465,7 +465,7 @@ impl Parser for Float64Type {
             .first()
             .is_some_and(|first_byte| !first_byte.is_ascii_digit())
         {
-            string = string.trim_start()
+            string = string.trim_ascii_start()
         }
         lexical_core::parse(string.as_bytes()).ok()
     }
@@ -484,7 +484,7 @@ macro_rules! parser_primitive {
                     .first()
                     .is_some_and(|first| !first.is_ascii_digit())
                 {
-                    string = string.trim_start();
+                    string = string.trim_ascii_start();
                 };
                 match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(
                     string.as_bytes(),

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -445,6 +445,7 @@ pub trait Parser: ArrowPrimitiveType {
 
 impl Parser for Float16Type {
     fn parse(string: &str) -> Option<f16> {
+        let string = truncate_white_space(string);
         lexical_core::parse(string.as_bytes())
             .ok()
             .map(f16::from_f32)
@@ -453,21 +454,27 @@ impl Parser for Float16Type {
 
 impl Parser for Float32Type {
     fn parse(string: &str) -> Option<f32> {
+        let string = truncate_white_space(string);
         lexical_core::parse(string.as_bytes()).ok()
     }
 }
 
 impl Parser for Float64Type {
     fn parse(string: &str) -> Option<f64> {
-        let mut string = string;
-        if string
-            .as_bytes()
-            .first()
-            .is_some_and(|first_byte| !first_byte.is_ascii_digit())
-        {
-            string = string.trim_ascii_start()
-        }
+        let string = truncate_white_space(string);
         lexical_core::parse(string.as_bytes()).ok()
+    }
+}
+#[inline]
+fn truncate_white_space(string: &str) -> &str {
+    if string
+        .as_bytes()
+        .first()
+        .is_some_and(|first_byte| !first_byte.is_ascii_digit())
+    {
+        string.trim_ascii_start()
+    } else {
+        string
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes half of #9538.

# Rationale for this change
currently parsing ints and floats with white space prefiing the number caused the cast to fail
```rust
assert_eq!(Float64Type::parse("\n\t\n\t\n40.5123"), Some(40.5123));
assert_eq!(Float64Type::parse(" 1.5"), Some(1.5));
assert_eq!(Int32Type::parse(" 3"), Some(3));
assert_eq!(Int32Type::parse("          30"), Some(30));
```

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
this PR adds a check to the string before parsing. it checks the first byte, if its not an ascii digit it will trim the left side of the string. 

Performance was a consideration to avoid regressions here — see https://github.com/apache/arrow-rs/pull/9537#issuecomment-4085626688. In the worst case where a string doesn't need trimming (no leading whitespace), the cost is just one slice operation to grab the first byte plus a range comparison to check if it's an ASCII digit.

benchmarks show no significant change
<img width="1155" height="493" alt="Image 7-18-26 at 1 02 PM" src="https://github.com/user-attachments/assets/911560a4-bc4f-4dde-83a0-858e4a470bf8" />


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes. I created a test with 12 assertiosn to validate behavoir 
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
yes. arrow-rs/datafusion cast operations will no longer fail when a number is prefixed with white space.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
