### PR TITLE
Remove always-panicking benchmarks

### DIFF
--- a/arrow/benches/concatenate_elements.rs
+++ b/arrow/benches/concatenate_elements.rs
@@ -22,7 +22,6 @@ extern crate criterion;
 use criterion::Criterion;
 
 use arrow::array::*;
-use arrow::datatypes::*;
 use arrow::util::bench_util::*;
 use arrow_string::concat_elements::concat_elements_dyn;
 use std::hint;

--- a/arrow/benches/concatenate_elements.rs
+++ b/arrow/benches/concatenate_elements.rs
@@ -70,22 +70,6 @@ fn add_benchmark(c: &mut Criterion) {
             c.bench_function(&id, |b| b.iter(|| bench_concat(&array, &array)));
         }
     }
-
-    let v1 = create_string_array_with_len::<i32>(10, 0.0, 20);
-    let v1 = create_dict_from_values::<Int32Type>(1024, 0.0, &v1);
-    let v2 = create_string_array_with_len::<i32>(10, 0.0, 20);
-    let v2 = create_dict_from_values::<Int32Type>(1024, 0.0, &v2);
-    c.bench_function("concat str_dict 1024", |b| {
-        b.iter(|| bench_concat(&v1, &v2))
-    });
-
-    let v1 = create_string_array_with_len::<i32>(1024, 0.0, 20);
-    let v1 = create_sparse_dict_from_values::<Int32Type>(1024, 0.0, &v1, 10..20);
-    let v2 = create_string_array_with_len::<i32>(1024, 0.0, 20);
-    let v2 = create_sparse_dict_from_values::<Int32Type>(1024, 0.0, &v2, 30..40);
-    c.bench_function("concat str_dict_sparse 1024", |b| {
-        b.iter(|| bench_concat(&v1, &v2))
-    });
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION
# Which issue does this PR close?

No attached issue

# Rationale for this change

These benchmarks always panic, since calling `arrow_string::concat_elements::concat_elements_dyn` with `DictionaryArray`s always panics.

# Are these changes tested?

Yes, all tests pass and now a higher percentage of benchmarks run correctly

# Are there any user-facing changes?

No, this is all dev-related