### PR TITLE
chore(arrow-cast): support suffix white space in arrow-cast parse

### DIFF
--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -467,6 +467,9 @@ impl Parser for Float32Type {
 
 impl Parser for Float64Type {
     fn parse(string: &str) -> Option<f64> {
+        if let Ok(raw_float) = lexical_core::parse(string.as_bytes()) {
+            return Some(raw_float);
+        }
         let string = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes()).ok()
     }

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -2906,7 +2906,6 @@ mod tests {
     }
     #[test]
     fn test_parse_prefix_white_space() {
-        /*
         assert_eq!(Float64Type::parse(" 1.5"), Some(1.5));
         assert_eq!(Float64Type::parse("\t\n 20.54"), Some(20.54));
         assert_eq!(Float64Type::parse("\n2.5"), Some(2.5));
@@ -2948,7 +2947,6 @@ mod tests {
         assert_eq!(Int32Type::parse("30x"), None);
         assert_eq!(Int32Type::parse("100px"), None);
         assert_eq!(Int32Type::parse("-25!"), None);
-        */
         assert_eq!(Int32Type::parse("3j"), None);
         assert_eq!(Int32Type::parse("3"), Some(3));
     }

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -445,7 +445,7 @@ pub trait Parser: ArrowPrimitiveType {
 
 impl Parser for Float16Type {
     fn parse(string: &str) -> Option<f16> {
-        let (string, _) = trim_pre_and_post_whitespace(string);
+        let string = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes())
             .ok()
             .map(f16::from_f32)
@@ -454,30 +454,29 @@ impl Parser for Float16Type {
 
 impl Parser for Float32Type {
     fn parse(string: &str) -> Option<f32> {
-        let (string, _) = trim_pre_and_post_whitespace(string);
+        let string = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes()).ok()
     }
 }
 
 impl Parser for Float64Type {
     fn parse(string: &str) -> Option<f64> {
-        let (string, _) = trim_pre_and_post_whitespace(string);
+        let string = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes()).ok()
     }
 }
 
 /// this is a no-op if the string starts and ends with a digit, otherwise it will trim whitespace from the start and end of the string.
 #[inline]
-fn trim_pre_and_post_whitespace(string: &str) -> (&str, bool) {
+fn trim_pre_and_post_whitespace(string: &str) -> &str {
     let bytes = string.as_bytes();
     let prefix = bytes.first().is_some_and(|b| !b.is_ascii_digit());
     let suffix = bytes.last().is_some_and(|b| !b.is_ascii_digit());
-    println!("bytes : {:?}, len: {}", bytes, bytes.len());
     match (prefix, suffix) {
-        (false, false) => (string, bytes.len() >= 1),
-        (true, false) => (string.trim_ascii_start(), false),
-        (false, true) => (string.trim_ascii_end(), false),
-        (true, true) => (string.trim_ascii(), false),
+        (false, false) => string,
+        (true, false) => string.trim_ascii_start(),
+        (false, true) => string.trim_ascii_end(),
+        (true, true) => string.trim_ascii(),
     }
 }
 
@@ -485,10 +484,10 @@ macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
             fn parse(string: &str) -> Option<Self::Native> {
-                let (string, not_empty) = trim_pre_and_post_whitespace(string);
-                if !not_empty {
+                if string.is_empty() {
                     return None;
                 }
+                let string = trim_pre_and_post_whitespace(string);
                 match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(
                     string.as_bytes(),
                 ) {

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -445,7 +445,7 @@ pub trait Parser: ArrowPrimitiveType {
 
 impl Parser for Float16Type {
     fn parse(string: &str) -> Option<f16> {
-        let string = truncate_white_space(string);
+        let string = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes())
             .ok()
             .map(f16::from_f32)
@@ -454,44 +454,40 @@ impl Parser for Float16Type {
 
 impl Parser for Float32Type {
     fn parse(string: &str) -> Option<f32> {
-        let string = truncate_white_space(string);
+        let string = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes()).ok()
     }
 }
 
 impl Parser for Float64Type {
     fn parse(string: &str) -> Option<f64> {
-        let string = truncate_white_space(string);
+        let string = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes()).ok()
     }
 }
+
+/// this is a no-op if the string starts and ends with a digit, otherwise it will trim whitespace from the start and end of the string.
 #[inline]
-fn truncate_white_space(string: &str) -> &str {
-    if string
-        .as_bytes()
-        .first()
-        .is_some_and(|first_byte| !first_byte.is_ascii_digit())
-    {
-        string.trim_ascii_start()
-    } else {
-        string
+fn trim_pre_and_post_whitespace(string: &str) -> &str {
+    let bytes = string.as_bytes();
+    let prefix = bytes.first().is_some_and(|b| !b.is_ascii_digit());
+    let suffix = bytes.last().is_some_and(|b| !b.is_ascii_digit());
+    match (prefix, suffix) {
+        (false, false) => string,
+        (true, false) => string.trim_ascii_start(),
+        (false, true) => string.trim_ascii_end(),
+        (true, true) => string.trim_ascii(),
     }
 }
 
 macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
-            fn parse(mut string: &str) -> Option<Self::Native> {
+            fn parse(string: &str) -> Option<Self::Native> {
+                let string = trim_pre_and_post_whitespace(string);
                 if !string.as_bytes().last().is_some_and(|x| x.is_ascii_digit()) {
                     return None;
                 }
-                if string
-                    .as_bytes()
-                    .first()
-                    .is_some_and(|first| !first.is_ascii_digit())
-                {
-                    string = string.trim_ascii_start();
-                };
                 match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(
                     string.as_bytes(),
                 ) {
@@ -2913,5 +2909,29 @@ mod tests {
         assert_eq!(Int32Type::parse("\t\n\t\n\n\n\t1"), Some(1));
         assert_eq!(Int32Type::parse(" \n-25"), Some(-25));
         assert_eq!(Int32Type::parse("\t-800"), Some(-800));
+
+        // suffix whitespace
+        assert_eq!(Float64Type::parse("1.5 "), Some(1.5));
+        assert_eq!(Float64Type::parse("40.5123\n"), Some(40.5123));
+        assert_eq!(Float64Type::parse("40.5123\n\t\n\t\n"), Some(40.5123));
+        assert_eq!(Float64Type::parse("-942.5423\t"), Some(-942.5423));
+        assert_eq!(Int32Type::parse("3 "), Some(3));
+        assert_eq!(Int32Type::parse("30          "), Some(30));
+        assert_eq!(Int32Type::parse("-25 \n"), Some(-25));
+        assert_eq!(Int32Type::parse("800\t"), Some(800));
+        // whitespace on both sides
+        assert_eq!(Float64Type::parse(" 1.5 "), Some(1.5));
+        assert_eq!(Float64Type::parse("\t\n 20.54 \t"), Some(20.54));
+        assert_eq!(Float64Type::parse("\n-942.5423\n"), Some(-942.5423));
+        assert_eq!(Int32Type::parse(" 3 "), Some(3));
+        assert_eq!(Int32Type::parse("\n \n 100 \n"), Some(100));
+        assert_eq!(Int32Type::parse("\t-800\t\n"), Some(-800));
+
+        // trailing non-whitespace chars should not parse
+        assert_eq!(Float64Type::parse("1.5abc"), None);
+        assert_eq!(Float64Type::parse("40.5123x"), None);
+        assert_eq!(Int32Type::parse("30x"), None);
+        assert_eq!(Int32Type::parse("100px"), None);
+        assert_eq!(Int32Type::parse("-25!"), None);
     }
 }

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -445,7 +445,7 @@ pub trait Parser: ArrowPrimitiveType {
 
 impl Parser for Float16Type {
     fn parse(string: &str) -> Option<f16> {
-        if let Some(raw_float) = lexical_core::parse(string.as_bytes()).ok() {
+        if let Ok(raw_float) = lexical_core::parse(string.as_bytes()) {
             return Some(f16::from_f32(raw_float));
         }
         let string = trim_pre_and_post_whitespace(string);
@@ -457,7 +457,7 @@ impl Parser for Float16Type {
 
 impl Parser for Float32Type {
     fn parse(string: &str) -> Option<f32> {
-        if let Some(raw_float) = lexical_core::parse(string.as_bytes()).ok() {
+        if let Ok(raw_float) = lexical_core::parse(string.as_bytes()) {
             return Some(raw_float);
         }
         let string = trim_pre_and_post_whitespace(string);

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -484,13 +484,11 @@ macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
             fn parse(string: &str) -> Option<Self::Native> {
-                if string.is_empty() {
+                let string_bytes = trim_pre_and_post_whitespace(string).as_bytes();
+                if !string_bytes.last().is_some_and(|x| x.is_ascii_digit()) {
                     return None;
                 }
-                let string = trim_pre_and_post_whitespace(string);
-                match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(
-                    string.as_bytes(),
-                ) {
+                match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(string_bytes) {
                     (Some(n), x) if x == string.len() => Some(n),
                     _ => None,
                 }

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -445,6 +445,9 @@ pub trait Parser: ArrowPrimitiveType {
 
 impl Parser for Float16Type {
     fn parse(string: &str) -> Option<f16> {
+        if let Some(raw_float) = lexical_core::parse(string.as_bytes()).ok() {
+            return Some(f16::from_f32(raw_float));
+        }
         let string = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes())
             .ok()
@@ -454,6 +457,9 @@ impl Parser for Float16Type {
 
 impl Parser for Float32Type {
     fn parse(string: &str) -> Option<f32> {
+        if let Some(raw_float) = lexical_core::parse(string.as_bytes()).ok() {
+            return Some(raw_float);
+        }
         let string = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes()).ok()
     }
@@ -484,13 +490,24 @@ macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
             fn parse(string: &str) -> Option<Self::Native> {
-                let string_bytes = trim_pre_and_post_whitespace(string).as_bytes();
-                if !string_bytes.last().is_some_and(|x| x.is_ascii_digit()) {
-                    return None;
+                // let string_bytes = trim_pre_and_post_whitespace(string).as_bytes();
+                let mut raw_bytes = string.as_bytes();
+                if !raw_bytes.last().is_some_and(|x| x.is_ascii_digit()) {
+                    raw_bytes = raw_bytes.trim_ascii_end();
+                    if !raw_bytes.last().is_some_and(|x| x.is_ascii_digit()) {
+                        return None;
+                    }
                 }
-                match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(string_bytes) {
-                    (Some(n), x) if x == string.len() => Some(n),
-                    _ => None,
+                match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(raw_bytes) {
+                    (Some(n), x) if x == raw_bytes.len() => Some(n),
+                    _ => {
+                        let trimmed = raw_bytes.trim_ascii_start();
+                        match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(trimmed)
+                        {
+                            (Some(n), x) if x == trimmed.len() => Some(n),
+                            _ => None,
+                        }
+                    }
                 }
             }
         }

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -490,7 +490,6 @@ macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
             fn parse(string: &str) -> Option<Self::Native> {
-                // let string_bytes = trim_pre_and_post_whitespace(string).as_bytes();
                 let mut raw_bytes = string.as_bytes();
                 if !raw_bytes.last().is_some_and(|x| x.is_ascii_digit()) {
                     raw_bytes = raw_bytes.trim_ascii_end();

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -445,7 +445,7 @@ pub trait Parser: ArrowPrimitiveType {
 
 impl Parser for Float16Type {
     fn parse(string: &str) -> Option<f16> {
-        let string = trim_pre_and_post_whitespace(string);
+        let (string, _) = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes())
             .ok()
             .map(f16::from_f32)
@@ -454,29 +454,30 @@ impl Parser for Float16Type {
 
 impl Parser for Float32Type {
     fn parse(string: &str) -> Option<f32> {
-        let string = trim_pre_and_post_whitespace(string);
+        let (string, _) = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes()).ok()
     }
 }
 
 impl Parser for Float64Type {
     fn parse(string: &str) -> Option<f64> {
-        let string = trim_pre_and_post_whitespace(string);
+        let (string, _) = trim_pre_and_post_whitespace(string);
         lexical_core::parse(string.as_bytes()).ok()
     }
 }
 
 /// this is a no-op if the string starts and ends with a digit, otherwise it will trim whitespace from the start and end of the string.
 #[inline]
-fn trim_pre_and_post_whitespace(string: &str) -> &str {
+fn trim_pre_and_post_whitespace(string: &str) -> (&str, bool) {
     let bytes = string.as_bytes();
     let prefix = bytes.first().is_some_and(|b| !b.is_ascii_digit());
     let suffix = bytes.last().is_some_and(|b| !b.is_ascii_digit());
+    println!("bytes : {:?}, len: {}", bytes, bytes.len());
     match (prefix, suffix) {
-        (false, false) => string,
-        (true, false) => string.trim_ascii_start(),
-        (false, true) => string.trim_ascii_end(),
-        (true, true) => string.trim_ascii(),
+        (false, false) => (string, bytes.len() >= 1),
+        (true, false) => (string.trim_ascii_start(), false),
+        (false, true) => (string.trim_ascii_end(), false),
+        (true, true) => (string.trim_ascii(), false),
     }
 }
 
@@ -484,8 +485,8 @@ macro_rules! parser_primitive {
     ($t:ty) => {
         impl Parser for $t {
             fn parse(string: &str) -> Option<Self::Native> {
-                let string = trim_pre_and_post_whitespace(string);
-                if !string.as_bytes().last().is_some_and(|x| x.is_ascii_digit()) {
+                let (string, not_empty) = trim_pre_and_post_whitespace(string);
+                if !not_empty {
                     return None;
                 }
                 match atoi::FromRadix10SignedChecked::from_radix_10_signed_checked(
@@ -2892,6 +2893,7 @@ mod tests {
     }
     #[test]
     fn test_parse_prefix_white_space() {
+        /*
         assert_eq!(Float64Type::parse(" 1.5"), Some(1.5));
         assert_eq!(Float64Type::parse("\t\n 20.54"), Some(20.54));
         assert_eq!(Float64Type::parse("\n2.5"), Some(2.5));
@@ -2933,5 +2935,8 @@ mod tests {
         assert_eq!(Int32Type::parse("30x"), None);
         assert_eq!(Int32Type::parse("100px"), None);
         assert_eq!(Int32Type::parse("-25!"), None);
+        */
+        assert_eq!(Int32Type::parse("3j"), None);
+        assert_eq!(Int32Type::parse("3"), Some(3));
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #9538.

# Rationale for this change

- see #9538
- see #10374

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
this PR adds support for suffix white space when calling parse
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
yes, users will be able to parse strings that have white space prefixed/suffixed onto numbers/floats.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
