### PR TITLE
create_array! Drop (Large)Binary special case and support BinaryView

### DIFF
--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -1580,7 +1580,7 @@ mod tests {
         Some("c".as_bytes())
     );
 
-    test_binary!(test_binary_min_max_all_nulls, vec![None, None], None, None);
+    test_binary!(test_binary_min_max_all_nulls, vec![None::<&[u8]>, None], None, None);
 
     test_binary!(
         test_binary_min_max_1,

--- a/arrow-arith/src/aggregate.rs
+++ b/arrow-arith/src/aggregate.rs
@@ -1580,7 +1580,12 @@ mod tests {
         Some("c".as_bytes())
     );
 
-    test_binary!(test_binary_min_max_all_nulls, vec![None::<&[u8]>, None], None, None);
+    test_binary!(
+        test_binary_min_max_all_nulls,
+        vec![None::<&[u8]>, None],
+        None,
+        None
+    );
 
     test_binary!(
         test_binary_min_max_1,

--- a/arrow-array/src/array/binary_array.rs
+++ b/arrow-array/src/array/binary_array.rs
@@ -100,13 +100,17 @@ impl<OffsetSize: OffsetSizeTrait> From<Vec<Option<&[u8]>>> for GenericBinaryArra
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<Option<[u8; C]>>> for GenericBinaryArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<Option<[u8; C]>>>
+    for GenericBinaryArray<OffsetSize>
+{
     fn from(v: Vec<Option<[u8; C]>>) -> Self {
         v.into_iter().collect()
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<Option<&[u8; C]>>> for GenericBinaryArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<Option<&[u8; C]>>>
+    for GenericBinaryArray<OffsetSize>
+{
     fn from(v: Vec<Option<&[u8; C]>>) -> Self {
         v.into_iter().collect()
     }
@@ -118,13 +122,17 @@ impl<OffsetSize: OffsetSizeTrait> From<Vec<&[u8]>> for GenericBinaryArray<Offset
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<[u8; C]>> for GenericBinaryArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<[u8; C]>>
+    for GenericBinaryArray<OffsetSize>
+{
     fn from(v: Vec<[u8; C]>) -> Self {
         Self::from_iter_values(v)
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<&[u8; C]>> for GenericBinaryArray<OffsetSize> {
+impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<&[u8; C]>>
+    for GenericBinaryArray<OffsetSize>
+{
     fn from(v: Vec<&[u8; C]>) -> Self {
         Self::from_iter_values(v)
     }

--- a/arrow-array/src/array/binary_array.rs
+++ b/arrow-array/src/array/binary_array.rs
@@ -96,12 +96,36 @@ impl<OffsetSize: OffsetSizeTrait> GenericBinaryArray<OffsetSize> {
 
 impl<OffsetSize: OffsetSizeTrait> From<Vec<Option<&[u8]>>> for GenericBinaryArray<OffsetSize> {
     fn from(v: Vec<Option<&[u8]>>) -> Self {
-        Self::from_opt_vec(v)
+        v.into_iter().collect()
+    }
+}
+
+impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<Option<[u8; C]>>> for GenericBinaryArray<OffsetSize> {
+    fn from(v: Vec<Option<[u8; C]>>) -> Self {
+        v.into_iter().collect()
+    }
+}
+
+impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<Option<&[u8; C]>>> for GenericBinaryArray<OffsetSize> {
+    fn from(v: Vec<Option<&[u8; C]>>) -> Self {
+        v.into_iter().collect()
     }
 }
 
 impl<OffsetSize: OffsetSizeTrait> From<Vec<&[u8]>> for GenericBinaryArray<OffsetSize> {
     fn from(v: Vec<&[u8]>) -> Self {
+        Self::from_iter_values(v)
+    }
+}
+
+impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<[u8; C]>> for GenericBinaryArray<OffsetSize> {
+    fn from(v: Vec<[u8; C]>) -> Self {
+        Self::from_iter_values(v)
+    }
+}
+
+impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<&[u8; C]>> for GenericBinaryArray<OffsetSize> {
+    fn from(v: Vec<&[u8; C]>) -> Self {
         Self::from_iter_values(v)
     }
 }
@@ -575,7 +599,7 @@ mod tests {
 
     #[test]
     fn test_binary_array_all_null() {
-        let data = vec![None];
+        let data = vec![None::<&[u8]>];
         let array = BinaryArray::from(data);
         array
             .into_data()
@@ -585,7 +609,7 @@ mod tests {
 
     #[test]
     fn test_large_binary_array_all_null() {
-        let data = vec![None];
+        let data = vec![None::<&[u8]>];
         let array = LargeBinaryArray::from(data);
         array
             .into_data()

--- a/arrow-array/src/array/binary_array.rs
+++ b/arrow-array/src/array/binary_array.rs
@@ -116,6 +116,12 @@ impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<Option<&[u8; C]>>>
     }
 }
 
+impl<OffsetSize: OffsetSizeTrait> From<Vec<Option<Vec<u8>>>> for GenericBinaryArray<OffsetSize> {
+    fn from(v: Vec<Option<Vec<u8>>>) -> Self {
+        v.into_iter().collect()
+    }
+}
+
 impl<OffsetSize: OffsetSizeTrait> From<Vec<&[u8]>> for GenericBinaryArray<OffsetSize> {
     fn from(v: Vec<&[u8]>) -> Self {
         Self::from_iter_values(v)
@@ -134,6 +140,12 @@ impl<OffsetSize: OffsetSizeTrait, const C: usize> From<Vec<&[u8; C]>>
     for GenericBinaryArray<OffsetSize>
 {
     fn from(v: Vec<&[u8; C]>) -> Self {
+        Self::from_iter_values(v)
+    }
+}
+
+impl<OffsetSize: OffsetSizeTrait> From<Vec<Vec<u8>>> for GenericBinaryArray<OffsetSize> {
+    fn from(v: Vec<Vec<u8>>) -> Self {
         Self::from_iter_values(v)
     }
 }

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -1140,8 +1140,32 @@ impl From<Vec<&[u8]>> for BinaryViewArray {
     }
 }
 
+impl<const C: usize> From<Vec<[u8; C]>> for BinaryViewArray {
+    fn from(v: Vec<[u8; C]>) -> Self {
+        Self::from_iter_values(v)
+    }
+}
+
+impl<const C: usize> From<Vec<&[u8; C]>> for BinaryViewArray {
+    fn from(v: Vec<&[u8; C]>) -> Self {
+        Self::from_iter_values(v)
+    }
+}
+
 impl From<Vec<Option<&[u8]>>> for BinaryViewArray {
     fn from(v: Vec<Option<&[u8]>>) -> Self {
+        v.into_iter().collect()
+    }
+}
+
+impl<const C: usize> From<Vec<Option<[u8; C]>>> for BinaryViewArray {
+    fn from(v: Vec<Option<[u8; C]>>) -> Self {
+        v.into_iter().collect()
+    }
+}
+
+impl<const C: usize> From<Vec<Option<&[u8; C]>>> for BinaryViewArray {
+    fn from(v: Vec<Option<&[u8; C]>>) -> Self {
         v.into_iter().collect()
     }
 }

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -1152,6 +1152,12 @@ impl<const C: usize> From<Vec<&[u8; C]>> for BinaryViewArray {
     }
 }
 
+impl From<Vec<Vec<u8>>> for BinaryViewArray {
+    fn from(v: Vec<Vec<u8>>) -> Self {
+        Self::from_iter_values(v)
+    }
+}
+
 impl From<Vec<Option<&[u8]>>> for BinaryViewArray {
     fn from(v: Vec<Option<&[u8]>>) -> Self {
         v.into_iter().collect()
@@ -1166,6 +1172,12 @@ impl<const C: usize> From<Vec<Option<[u8; C]>>> for BinaryViewArray {
 
 impl<const C: usize> From<Vec<Option<&[u8; C]>>> for BinaryViewArray {
     fn from(v: Vec<Option<&[u8; C]>>) -> Self {
+        v.into_iter().collect()
+    }
+}
+
+impl From<Vec<Option<Vec<u8>>>> for BinaryViewArray {
+    fn from(v: Vec<Option<Vec<u8>>>) -> Self {
         v.into_iter().collect()
     }
 }

--- a/arrow-array/src/record_batch.rs
+++ b/arrow-array/src/record_batch.rs
@@ -115,7 +115,9 @@ macro_rules! create_array {
     (@from TimestampMillisecond) => { $crate::TimestampMillisecondArray };
     (@from TimestampMicrosecond) => { $crate::TimestampMicrosecondArray };
     (@from TimestampNanosecond) => { $crate::TimestampNanosecondArray };
-
+    (@from Binary) => { $crate::BinaryArray };
+    (@from BinaryView) => { $crate::BinaryViewArray };
+    (@from LargeBinary) => { $crate::LargeBinaryArray };
     (@from $ty: ident) => {
         compile_error!(concat!("Unsupported data type: ", stringify!($ty)))
     };
@@ -124,24 +126,8 @@ macro_rules! create_array {
         std::sync::Arc::new($crate::NullArray::new($size))
     };
 
-    (Binary, [$($values: expr),*]) => {
-        std::sync::Arc::new($crate::BinaryArray::from_vec(vec![$($values),*]))
-    };
-
-    (LargeBinary, [$($values: expr),*]) => {
-        std::sync::Arc::new($crate::LargeBinaryArray::from_vec(vec![$($values),*]))
-    };
-
     ($ty: tt, [$($values: expr),*]) => {
         std::sync::Arc::new(<$crate::create_array!(@from $ty)>::from(vec![$($values),*]))
-    };
-
-    (Binary, $values: expr) => {
-        std::sync::Arc::new($crate::BinaryArray::from_vec($values))
-    };
-
-    (LargeBinary, $values: expr) => {
-        std::sync::Arc::new($crate::LargeBinaryArray::from_vec($values))
     };
 
     ($ty: tt, $values: expr) => {


### PR DESCRIPTION
The three types support `From<Vec<&[u8]>>` and `From<Vec<Option<&[u8]>>>`, making the default macro code paths working

# Rationale for this change

Simplify code and adds `BinaryView` support

# Are these changes tested?

`create_array!(Binary)` is already covered in the tests
