### PR TITLE
fix off by one error for slice accounting

### DIFF
--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -2651,7 +2651,7 @@ mod tests {
     fn test_slice_memory_size_binary_offset_buffer_len_plus_one() {
         // 2-element array: array len = 2, not 3
         // values: 5 bytes
-        let data_buffer = Buffer::from_slice_ref(&[0u8, 1, 2, 3, 4]);
+        let data_buffer = Buffer::from_slice_ref([0u8, 1, 2, 3, 4]);
         // offsets need array_len+1 entries to mark the end of every element:
         let offsets_buffer = Buffer::from_slice_ref([0_i32, 2_i32, 5_i32]);
         let array = ArrayData::try_new(

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -530,7 +530,19 @@ impl ArrayData {
         for spec in layout.buffers.iter() {
             match spec {
                 BufferSpec::FixedWidth { byte_width, .. } => {
-                    let buffer_size = self.len.checked_mul(*byte_width).ok_or_else(|| {
+                    // Offset buffers contain len+1 elements: one boundary per element
+                    // plus a final boundary marking the end of the last element.
+                    let len = match self.data_type {
+                        DataType::Utf8
+                        | DataType::LargeUtf8
+                        | DataType::Binary
+                        | DataType::LargeBinary
+                        | DataType::List(_)
+                        | DataType::LargeList(_)
+                        | DataType::Map(_, _) => self.len + 1,
+                        _ => self.len,
+                    };
+                    let buffer_size = len.checked_mul(*byte_width).ok_or_else(|| {
                         ArrowError::ComputeError(
                             "Integer overflow computing buffer size".to_string(),
                         )
@@ -2614,6 +2626,44 @@ mod tests {
         let string_data_slice = string_data.slice(1, 2);
         assert!(string_data_slice.ptr_eq(&string_data_slice));
         assert!(!string_data_slice.ptr_eq(&string_data))
+    }
+
+    #[test]
+    fn test_slice_memory_size_utf8_offset_buffer_len_plus_one() {
+        // 2-element array ["hello", "world"]: array len = 2, 10 bytes
+        let data_buffer = Buffer::from_slice_ref("helloworld".as_bytes());
+        // offsets need array_len+1 entries to mark the end of every string:
+        //   [0, 5, 10] -> 3 i32s = 12 bytes
+        let offsets_buffer = Buffer::from_slice_ref([0_i32, 5_i32, 10_i32]);
+        let array = ArrayData::try_new(
+            DataType::Utf8,
+            2,
+            None,
+            0,
+            vec![offsets_buffer, data_buffer],
+            vec![],
+        )
+        .unwrap();
+        assert_eq!(array.get_slice_memory_size().unwrap(), 22); // 12 + 10
+    }
+
+    #[test]
+    fn test_slice_memory_size_binary_offset_buffer_len_plus_one() {
+        // 2-element array: array len = 2, not 3
+        // values: 5 bytes
+        let data_buffer = Buffer::from_slice_ref(&[0u8, 1, 2, 3, 4]);
+        // offsets need array_len+1 entries to mark the end of every element:
+        let offsets_buffer = Buffer::from_slice_ref([0_i32, 2_i32, 5_i32]);
+        let array = ArrayData::try_new(
+            DataType::Binary,
+            2,
+            None,
+            0,
+            vec![offsets_buffer, data_buffer],
+            vec![],
+        )
+        .unwrap();
+        assert_eq!(array.get_slice_memory_size().unwrap(), 17); // 12 + 5
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10385.
- works towards closing #10383

# Rationale for this change
`get_slice_memory_size` is used to estimate how much memory a slice of an ArrayData actually occupies. For variable-width types (Utf8, Binary, List, etc.), the offset buffer stores len+1 boundaries, one per element plus a final entry marking the end of the last element. The old code calculated `len * byte_width`, missing that final boundary and consistently under-reporting the size of any array using an offset buffer.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
the FixedWidth buffer size is now calculated as (len + 1) * byte_width instead of len * byte_width.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
Yes I added two test for string arrays and binary arrays. existing test still pass
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
users will have more accurate memory accounting
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
