### PR TITLE
perf(parquet): Optimize DeltaByteArrayEncoder and friends

### DIFF
--- a/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
+++ b/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
@@ -73,7 +73,7 @@ impl<T: DataType> Decoder<T> for ByteStreamSplitDecoder<T> {
     }
 
     fn get(&mut self, buffer: &mut [<T as DataType>::T]) -> Result<usize> {
-        // We assume self.encoded_bytes contains the full data 
+        // We assume self.encoded_bytes contains the full data
         // (which it must, since we can only know where to split the streams once all data is collected),
         // but buffer can just be sliced starting from the given index.
 

--- a/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
+++ b/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
@@ -44,9 +44,6 @@ impl<T: DataType> ByteStreamSplitDecoder<T> {
     }
 }
 
-// Here we assume src contains the full data (which it must, since we're
-// can only know where to split the streams once all data is collected),
-// but dst can be just a slice starting from the given index.
 // We iterate over the output bytes and fill them in from their strided
 // input byte locations.
 fn join_streams_const<const TYPE_SIZE: usize>(src: &[u8], dst: &mut [u8], stride: usize) {
@@ -76,6 +73,10 @@ impl<T: DataType> Decoder<T> for ByteStreamSplitDecoder<T> {
     }
 
     fn get(&mut self, buffer: &mut [<T as DataType>::T]) -> Result<usize> {
+        // We assume self.encoded_bytes contains the full data 
+        // (which it must, since we can only know where to split the streams once all data is collected),
+        // but buffer can just be sliced starting from the given index.
+
         let total_remaining_values = self.values_left();
         let num_values = buffer.len().min(total_remaining_values);
         let buffer = &mut buffer[..num_values];
@@ -83,6 +84,7 @@ impl<T: DataType> Decoder<T> for ByteStreamSplitDecoder<T> {
         // SAFETY: i/f32 and i/f64 has no constraints on their internal representation, so we can modify it as we want
         let dst = unsafe { <T as DataType>::T::slice_as_bytes_mut(buffer) };
         let type_size = T::get_type_size();
+
         let stride = self.encoded_bytes.len() / type_size;
         let src = &self.encoded_bytes[self.values_decoded..];
         match type_size {

--- a/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
+++ b/parquet/src/encodings/decoding/byte_stream_split_decoder.rs
@@ -49,32 +49,19 @@ impl<T: DataType> ByteStreamSplitDecoder<T> {
 // but dst can be just a slice starting from the given index.
 // We iterate over the output bytes and fill them in from their strided
 // input byte locations.
-fn join_streams_const<const TYPE_SIZE: usize>(
-    src: &[u8],
-    dst: &mut [u8],
-    stride: usize,
-    values_decoded: usize,
-) {
-    let sub_src = &src[values_decoded..];
+fn join_streams_const<const TYPE_SIZE: usize>(src: &[u8], dst: &mut [u8], stride: usize) {
     for i in 0..dst.len() / TYPE_SIZE {
         for j in 0..TYPE_SIZE {
-            dst[i * TYPE_SIZE + j] = sub_src[i + j * stride];
+            dst[i * TYPE_SIZE + j] = src[i + j * stride];
         }
     }
 }
 
 // Like the above, but type_size is not known at compile time.
-fn join_streams_variable(
-    src: &[u8],
-    dst: &mut [u8],
-    stride: usize,
-    type_size: usize,
-    values_decoded: usize,
-) {
-    let sub_src = &src[values_decoded..];
+fn join_streams_variable(src: &[u8], dst: &mut [u8], stride: usize, type_size: usize) {
     for i in 0..dst.len() / type_size {
         for j in 0..type_size {
-            dst[i * type_size + j] = sub_src[i + j * stride];
+            dst[i * type_size + j] = src[i + j * stride];
         }
     }
 }
@@ -94,22 +81,13 @@ impl<T: DataType> Decoder<T> for ByteStreamSplitDecoder<T> {
         let buffer = &mut buffer[..num_values];
 
         // SAFETY: i/f32 and i/f64 has no constraints on their internal representation, so we can modify it as we want
-        let raw_out_bytes = unsafe { <T as DataType>::T::slice_as_bytes_mut(buffer) };
+        let dst = unsafe { <T as DataType>::T::slice_as_bytes_mut(buffer) };
         let type_size = T::get_type_size();
         let stride = self.encoded_bytes.len() / type_size;
+        let src = &self.encoded_bytes[self.values_decoded..];
         match type_size {
-            4 => join_streams_const::<4>(
-                &self.encoded_bytes,
-                raw_out_bytes,
-                stride,
-                self.values_decoded,
-            ),
-            8 => join_streams_const::<8>(
-                &self.encoded_bytes,
-                raw_out_bytes,
-                stride,
-                self.values_decoded,
-            ),
+            4 => join_streams_const::<4>(src, dst, stride),
+            8 => join_streams_const::<8>(src, dst, stride),
             _ => {
                 return Err(general_err!(
                     "byte stream split unsupported for data types of size {} bytes",
@@ -189,48 +167,21 @@ impl<T: DataType> Decoder<T> for VariableWidthByteStreamSplitDecoder<T> {
         // Since this is FIXED_LEN_BYTE_ARRAY data, we can't use slice_as_bytes_mut. Instead we'll
         // have to do some data copies.
         let mut tmp_vec = vec![0_u8; num_values * type_size];
-        let raw_out_bytes = tmp_vec.as_mut_slice();
+        let dst = tmp_vec.as_mut_slice();
 
+        let src = &self.encoded_bytes[self.values_decoded..];
         let stride = self.encoded_bytes.len() / type_size;
         match type_size {
-            2 => join_streams_const::<2>(
-                &self.encoded_bytes,
-                raw_out_bytes,
-                stride,
-                self.values_decoded,
-            ),
-            4 => join_streams_const::<4>(
-                &self.encoded_bytes,
-                raw_out_bytes,
-                stride,
-                self.values_decoded,
-            ),
-            8 => join_streams_const::<8>(
-                &self.encoded_bytes,
-                raw_out_bytes,
-                stride,
-                self.values_decoded,
-            ),
-            16 => join_streams_const::<16>(
-                &self.encoded_bytes,
-                raw_out_bytes,
-                stride,
-                self.values_decoded,
-            ),
-            _ => join_streams_variable(
-                &self.encoded_bytes,
-                raw_out_bytes,
-                stride,
-                type_size,
-                self.values_decoded,
-            ),
+            2 => join_streams_const::<2>(src, dst, stride),
+            4 => join_streams_const::<4>(src, dst, stride),
+            8 => join_streams_const::<8>(src, dst, stride),
+            16 => join_streams_const::<16>(src, dst, stride),
+            _ => join_streams_variable(src, dst, stride, type_size),
         }
         self.values_decoded += num_values;
 
-        // create a buffer from the vec so far (and leave a new Vec in its place)
-        let vec_with_data = std::mem::take(&mut tmp_vec);
         // convert Vec to Bytes (which is a ref counted wrapper)
-        let bytes_with_data = Bytes::from(vec_with_data);
+        let bytes_with_data = Bytes::from(tmp_vec);
         for (i, bi) in buffer.iter_mut().enumerate().take(num_values) {
             // Get a view into the data, without also copying the bytes
             let data = bytes_with_data.slice(i * type_size..(i + 1) * type_size);

--- a/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
+++ b/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
@@ -22,7 +22,7 @@ use crate::errors::{ParquetError, Result};
 
 use super::Encoder;
 
-use bytes::{BufMut, Bytes};
+use bytes::BufMut;
 use std::cmp;
 use std::marker::PhantomData;
 
@@ -88,12 +88,15 @@ impl<T: DataType> Encoder<T> for ByteStreamSplitEncoder<T> {
         self.buffer.len()
     }
 
-    fn flush_buffer(&mut self) -> Result<Bytes> {
-        let mut encoded = vec![0; self.buffer.len()];
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
+        let start = out.len();
+        out.resize(start + self.buffer.len(), 0);
+        let encoded = &mut out[start..];
+
         let type_size = T::get_type_size();
         match type_size {
-            4 => split_streams_const::<4>(&self.buffer, &mut encoded),
-            8 => split_streams_const::<8>(&self.buffer, &mut encoded),
+            4 => split_streams_const::<4>(&self.buffer, encoded),
+            8 => split_streams_const::<8>(&self.buffer, encoded),
             _ => {
                 return Err(general_err!(
                     "byte stream split unsupported for data types of size {} bytes",
@@ -103,7 +106,7 @@ impl<T: DataType> Encoder<T> for ByteStreamSplitEncoder<T> {
         }
 
         self.buffer.clear();
-        Ok(encoded.into())
+        Ok(())
     }
 
     /// return the estimated memory size of this encoder.
@@ -202,26 +205,29 @@ impl<T: DataType> Encoder<T> for VariableWidthByteStreamSplitEncoder<T> {
         self.buffer.len()
     }
 
-    fn flush_buffer(&mut self) -> Result<Bytes> {
-        let mut encoded = vec![0; self.buffer.len()];
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
+        let start = out.len();
+        out.resize(start + self.buffer.len(), 0);
+        let encoded = &mut out[start..];
+
         let type_size = match T::get_physical_type() {
             Type::FIXED_LEN_BYTE_ARRAY => self.type_width,
             _ => T::get_type_size(),
         };
         // split_streams_const() is faster up to type_width == 8
         match type_size {
-            2 => split_streams_const::<2>(&self.buffer, &mut encoded),
-            3 => split_streams_const::<3>(&self.buffer, &mut encoded),
-            4 => split_streams_const::<4>(&self.buffer, &mut encoded),
-            5 => split_streams_const::<5>(&self.buffer, &mut encoded),
-            6 => split_streams_const::<6>(&self.buffer, &mut encoded),
-            7 => split_streams_const::<7>(&self.buffer, &mut encoded),
-            8 => split_streams_const::<8>(&self.buffer, &mut encoded),
-            _ => split_streams_variable(&self.buffer, &mut encoded, type_size),
+            2 => split_streams_const::<2>(&self.buffer, encoded),
+            3 => split_streams_const::<3>(&self.buffer, encoded),
+            4 => split_streams_const::<4>(&self.buffer, encoded),
+            5 => split_streams_const::<5>(&self.buffer, encoded),
+            6 => split_streams_const::<6>(&self.buffer, encoded),
+            7 => split_streams_const::<7>(&self.buffer, encoded),
+            8 => split_streams_const::<8>(&self.buffer, encoded),
+            _ => split_streams_variable(&self.buffer, out, type_size),
         }
 
         self.buffer.clear();
-        Ok(encoded.into())
+        Ok(())
     }
 
     /// return the estimated memory size of this encoder.

--- a/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
+++ b/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
@@ -223,7 +223,7 @@ impl<T: DataType> Encoder<T> for VariableWidthByteStreamSplitEncoder<T> {
             6 => split_streams_const::<6>(&self.buffer, encoded),
             7 => split_streams_const::<7>(&self.buffer, encoded),
             8 => split_streams_const::<8>(&self.buffer, encoded),
-            _ => split_streams_variable(&self.buffer, out, type_size),
+            _ => split_streams_variable(&self.buffer, encoded, type_size),
         }
 
         self.buffer.clear();

--- a/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
+++ b/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
@@ -209,7 +209,8 @@ impl<T: DataType> Encoder<T> for VariableWidthByteStreamSplitEncoder<T> {
             Type::FIXED_LEN_BYTE_ARRAY => self.type_width,
             _ => T::get_type_size(),
         };
-        // split_streams_const() is faster up to type_width == 8
+        // split_streams_const() is faster up to type_width == 8.
+        // 12 and 16 are included since they auto-vectorize nicely.
         match type_size {
             2 => split_streams_const::<2>(src, dst),
             3 => split_streams_const::<3>(src, dst),

--- a/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
+++ b/parquet/src/encodings/encoding/byte_stream_split_encoder.rs
@@ -131,36 +131,30 @@ impl<T: DataType> VariableWidthByteStreamSplitEncoder<T> {
     }
 }
 
+#[cold]
+#[inline(never)]
+fn mismatched_byte_array_size(bytes: usize, type_size: usize) {
+    panic!("Mismatched FixedLenByteArray sizes: {bytes} != {type_size}");
+}
+
 fn put_fixed<T: DataType, const TYPE_SIZE: usize>(dst: &mut [u8], values: &[T::T]) {
-    let mut idx = 0;
-    values.iter().for_each(|x| {
+    for (out, x) in dst.chunks_exact_mut(TYPE_SIZE).zip(values.iter()) {
         let bytes = x.as_bytes();
         if bytes.len() != TYPE_SIZE {
-            panic!(
-                "Mismatched FixedLenByteArray sizes: {} != {}",
-                bytes.len(),
-                TYPE_SIZE
-            );
+            mismatched_byte_array_size(bytes.len(), TYPE_SIZE);
         }
-        dst[idx..(TYPE_SIZE + idx)].copy_from_slice(&bytes[..TYPE_SIZE]);
-        idx += TYPE_SIZE;
-    });
+        out.copy_from_slice(bytes);
+    }
 }
 
 fn put_variable<T: DataType>(dst: &mut [u8], values: &[T::T], type_width: usize) {
-    let mut idx = 0;
-    values.iter().for_each(|x| {
+    for (out, x) in dst.chunks_exact_mut(type_width).zip(values.iter()) {
         let bytes = x.as_bytes();
         if bytes.len() != type_width {
-            panic!(
-                "Mismatched FixedLenByteArray sizes: {} != {}",
-                bytes.len(),
-                type_width
-            );
+            mismatched_byte_array_size(bytes.len(), type_width);
         }
-        dst[idx..idx + type_width].copy_from_slice(bytes);
-        idx += type_width;
-    });
+        out.copy_from_slice(bytes);
+    }
 }
 
 impl<T: DataType> Encoder<T> for VariableWidthByteStreamSplitEncoder<T> {
@@ -174,9 +168,7 @@ impl<T: DataType> Encoder<T> for VariableWidthByteStreamSplitEncoder<T> {
         // slice_as_bytes untenable
         let idx = self.buffer.len();
         let data_len = values.len() * self.type_width;
-        // Ensure enough capacity for the new data
-        self.buffer.reserve(values.len() * self.type_width);
-        // ...and extend the size of buffer to allow direct access
+        // Extend the size of buffer to allow direct access
         self.buffer.put_bytes(0_u8, data_len);
         // Get a slice of the buffer corresponding to the location of the new data
         let out_buf = &mut self.buffer[idx..idx + data_len];
@@ -191,6 +183,8 @@ impl<T: DataType> Encoder<T> for VariableWidthByteStreamSplitEncoder<T> {
             6 => put_fixed::<T, 6>(out_buf, values),
             7 => put_fixed::<T, 7>(out_buf, values),
             8 => put_fixed::<T, 8>(out_buf, values),
+            12 => put_fixed::<T, 12>(out_buf, values),
+            16 => put_fixed::<T, 16>(out_buf, values),
             _ => put_variable::<T>(out_buf, values, self.type_width),
         }
 
@@ -206,9 +200,10 @@ impl<T: DataType> Encoder<T> for VariableWidthByteStreamSplitEncoder<T> {
     }
 
     fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
+        let src = &self.buffer[..];
         let start = out.len();
-        out.resize(start + self.buffer.len(), 0);
-        let encoded = &mut out[start..];
+        out.resize(start + src.len(), 0);
+        let dst = &mut out[start..];
 
         let type_size = match T::get_physical_type() {
             Type::FIXED_LEN_BYTE_ARRAY => self.type_width,
@@ -216,14 +211,16 @@ impl<T: DataType> Encoder<T> for VariableWidthByteStreamSplitEncoder<T> {
         };
         // split_streams_const() is faster up to type_width == 8
         match type_size {
-            2 => split_streams_const::<2>(&self.buffer, encoded),
-            3 => split_streams_const::<3>(&self.buffer, encoded),
-            4 => split_streams_const::<4>(&self.buffer, encoded),
-            5 => split_streams_const::<5>(&self.buffer, encoded),
-            6 => split_streams_const::<6>(&self.buffer, encoded),
-            7 => split_streams_const::<7>(&self.buffer, encoded),
-            8 => split_streams_const::<8>(&self.buffer, encoded),
-            _ => split_streams_variable(&self.buffer, encoded, type_size),
+            2 => split_streams_const::<2>(src, dst),
+            3 => split_streams_const::<3>(src, dst),
+            4 => split_streams_const::<4>(src, dst),
+            5 => split_streams_const::<5>(src, dst),
+            6 => split_streams_const::<6>(src, dst),
+            7 => split_streams_const::<7>(src, dst),
+            8 => split_streams_const::<8>(src, dst),
+            12 => split_streams_const::<12>(src, dst),
+            16 => split_streams_const::<16>(src, dst),
+            _ => split_streams_variable(src, dst, type_size),
         }
 
         self.buffer.clear();

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -184,6 +184,12 @@ impl<T: DataType> Encoder<T> for DictEncoder<T> {
         self.write_indices()
     }
 
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
+        // TODO: RleEncoder could be reused instead of consumed
+        out.extend_from_slice(&self.flush_buffer()?);
+        Ok(())
+    }
+
     /// Returns the estimated total memory usage
     ///
     /// For this encoder, the indices are unencoded bytes (refer to [`Self::write_indices`]).

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -132,6 +132,8 @@ impl<T: DataType> DictEncoder<T> {
     /// Writes out the dictionary values with RLE encoding in a byte buffer, and return
     /// the result.
     pub fn write_indices(&mut self) -> Result<Bytes> {
+        // TODO: Move this into flush_buffer/flush_to?
+        //       That could allow reusing buffer with flush_to.
         let buffer_len = self.estimated_data_encoded_size();
         let mut buffer = Vec::with_capacity(buffer_len);
         buffer.push(self.bit_width());

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -164,9 +164,6 @@ impl<T: DataType> Encoder<T> for DictEncoder<T> {
         Ok(())
     }
 
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
     fn encoding(&self) -> Encoding {
         Encoding::PLAIN_DICTIONARY
     }

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -82,7 +82,7 @@ pub trait Encoder<T: DataType>: Send {
         Ok(buffer.into())
     }
 
-    /// Flushes the underlying byte buffer that's being processed by this encoder. 
+    /// Flushes the underlying byte buffer that's being processed by this encoder.
     /// This will also reset the internal state.
     fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()>;
 }
@@ -670,6 +670,8 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
 pub struct DeltaByteArrayEncoder<T: DataType> {
     prefix_len_encoder: DeltaBitPackEncoder<Int32Type>,
     suffix_writer: DeltaLengthByteArrayEncoder<ByteArrayType>,
+    prefix_lengths: Vec<i32>,
+    suffixes: Vec<ByteArray>,
     previous: ByteArray,
     _phantom: PhantomData<T>,
 }
@@ -686,6 +688,8 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
         Self {
             prefix_len_encoder: DeltaBitPackEncoder::new(),
             suffix_writer: DeltaLengthByteArrayEncoder::new(),
+            prefix_lengths: Vec::new(),
+            suffixes: Vec::new(),
             previous: ByteArray::new(),
             _phantom: PhantomData,
         }
@@ -694,8 +698,8 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
 
 impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
     fn put(&mut self, values: &[T::T]) -> Result<()> {
-        let mut prefix_lengths: Vec<i32> = Vec::with_capacity(values.len());
-        let mut suffixes: Vec<ByteArray> = Vec::with_capacity(values.len());
+        self.prefix_lengths.reserve(values.len());
+        self.suffixes.reserve(values.len());
 
         let values = values.iter().map(|x| match T::get_physical_type() {
             Type::BYTE_ARRAY => x.as_any().downcast_ref::<ByteArray>().unwrap(),
@@ -711,15 +715,19 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
             let previous = previous_array.data();
             // Number of leading bytes shared with the previous value
             let match_len = common_prefix_length(previous, current);
-            prefix_lengths.push(match_len as i32);
-            suffixes.push(current_array.slice(match_len, current_array.len() - match_len));
+            self.prefix_lengths.push(match_len as i32);
+            self.suffixes
+                .push(current_array.slice(match_len, current.len() - match_len));
             // Update previous for the next prefix
             previous_array = current_array;
         }
         self.previous = previous_array.clone();
-        
-        self.prefix_len_encoder.put(&prefix_lengths)?;
-        self.suffix_writer.put(&suffixes)?;
+
+        self.prefix_len_encoder.put(&self.prefix_lengths)?;
+        self.suffix_writer.put(&self.suffixes)?;
+
+        self.prefix_lengths.clear();
+        self.suffixes.clear();
 
         Ok(())
     }

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -722,6 +722,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
             previous = current;
             previous_array = current_array;
         }
+        // Avoid keeping big values alive by copying previous slice into buffer
         self.previous.clear();
         self.previous.extend_from_slice(previous_array.data());
 
@@ -764,6 +765,8 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
     fn estimated_memory_size(&self) -> usize {
         self.prefix_len_encoder.estimated_memory_size()
             + self.suffix_writer.estimated_memory_size()
+            + self.prefix_lengths.capacity() * std::mem::size_of::<i32>()
+            + self.suffixes.capacity() * std::mem::size_of::<ByteArray>()
             + (self.previous.capacity() * std::mem::size_of::<u8>())
     }
 }

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -76,7 +76,15 @@ pub trait Encoder<T: DataType>: Send {
 
     /// Flushes the underlying byte buffer that's being processed by this encoder, and
     /// return the immutable copy of it. This will also reset the internal state.
-    fn flush_buffer(&mut self) -> Result<Bytes>;
+    fn flush_buffer(&mut self) -> Result<Bytes> {
+        let mut buffer = Vec::new();
+        self.flush_to(&mut buffer)?;
+        Ok(buffer.into())
+    }
+
+    /// Flushes the underlying byte buffer that's being processed by this encoder. 
+    /// This will also reset the internal state.
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()>;
 }
 
 /// Gets a encoder for the particular data type `T` and encoding `encoding`. Memory usage
@@ -163,6 +171,15 @@ impl<T: DataType> Encoder<T> for PlainEncoder<T> {
             .extend_from_slice(self.bit_writer.flush_buffer());
         self.bit_writer.clear();
         Ok(std::mem::take(&mut self.buffer).into())
+    }
+
+    #[inline]
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
+        out.extend_from_slice(&self.buffer);
+        out.extend_from_slice(self.bit_writer.flush_buffer());
+        self.buffer.clear();
+        self.bit_writer.clear();
+        Ok(())
     }
 
     #[inline]
@@ -259,6 +276,12 @@ impl<T: DataType> Encoder<T> for RleValueEncoder<T> {
         buf[..4].copy_from_slice(&len.to_le_bytes());
 
         Ok(buf.into())
+    }
+
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
+        // TODO: RleEncoder could be reused instead of consumed
+        out.extend_from_slice(&self.flush_buffer()?);
+        Ok(())
     }
 
     /// return the estimated memory size of this encoder.
@@ -478,18 +501,17 @@ impl<T: DataType> Encoder<T> for DeltaBitPackEncoder<T> {
     }
 
     fn estimated_data_encoded_size(&self) -> usize {
-        self.bit_writer.bytes_written()
+        self.page_header_writer.bytes_written() + self.bit_writer.bytes_written()
     }
 
-    fn flush_buffer(&mut self) -> Result<Bytes> {
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
         // Write remaining values
         self.flush_block_values()?;
         // Write page header with total values
         self.write_page_header();
 
-        let mut buffer = Vec::new();
-        buffer.extend_from_slice(self.page_header_writer.flush_buffer());
-        buffer.extend_from_slice(self.bit_writer.flush_buffer());
+        out.extend_from_slice(self.page_header_writer.flush_buffer());
+        out.extend_from_slice(self.bit_writer.flush_buffer());
 
         // Reset state
         self.page_header_writer.clear();
@@ -499,7 +521,7 @@ impl<T: DataType> Encoder<T> for DeltaBitPackEncoder<T> {
         self.current_value = 0;
         self.values_in_block = 0;
 
-        Ok(buffer.into())
+        Ok(())
     }
 
     /// return the estimated memory size of this encoder.
@@ -627,22 +649,22 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
         self.len_encoder.estimated_data_encoded_size() + self.encoded_size
     }
 
-    fn flush_buffer(&mut self) -> Result<Bytes> {
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
         ensure_phys_ty!(
             Type::BYTE_ARRAY,
             "DeltaLengthByteArrayEncoder only supports ByteArrayType"
         );
 
-        let mut total_bytes = vec![];
-        let lengths = self.len_encoder.flush_buffer()?;
-        total_bytes.extend_from_slice(&lengths);
+        out.reserve(self.estimated_data_encoded_size());
+        self.len_encoder.flush_to(out)?;
+
         self.data.iter().for_each(|byte_array| {
-            total_bytes.extend_from_slice(byte_array.data());
+            out.extend_from_slice(byte_array.data());
         });
         self.data.clear();
         self.encoded_size = 0;
 
-        Ok(total_bytes.into())
+        Ok(())
     }
 
     /// return the estimated memory size of this encoder.
@@ -723,21 +745,16 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
             + self.suffix_writer.estimated_data_encoded_size()
     }
 
-    fn flush_buffer(&mut self) -> Result<Bytes> {
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
         match T::get_physical_type() {
             Type::BYTE_ARRAY | Type::FIXED_LEN_BYTE_ARRAY => {
-                // TODO: investigate if we can merge lengths and suffixes
-                // without copying data into new vector.
-                let mut total_bytes = vec![];
                 // Insert lengths ...
-                let lengths = self.prefix_len_encoder.flush_buffer()?;
-                total_bytes.extend_from_slice(&lengths);
+                self.prefix_len_encoder.flush_to(out)?;
                 // ... followed by suffixes
-                let suffixes = self.suffix_writer.flush_buffer()?;
-                total_bytes.extend_from_slice(&suffixes);
+                self.suffix_writer.flush_to(out)?;
 
                 self.previous.clear();
-                Ok(total_bytes.into())
+                Ok(())
             }
             _ => panic!(
                 "DeltaByteArrayEncoder only supports ByteArrayType and FixedLenByteArrayType"

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -670,7 +670,7 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
 pub struct DeltaByteArrayEncoder<T: DataType> {
     prefix_len_encoder: DeltaBitPackEncoder<Int32Type>,
     suffix_writer: DeltaLengthByteArrayEncoder<ByteArrayType>,
-    previous: Vec<u8>,
+    previous: ByteArray,
     _phantom: PhantomData<T>,
 }
 
@@ -686,7 +686,7 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
         Self {
             prefix_len_encoder: DeltaBitPackEncoder::new(),
             suffix_writer: DeltaLengthByteArrayEncoder::new(),
-            previous: vec![],
+            previous: ByteArray::new(),
             _phantom: PhantomData,
         }
     }
@@ -705,16 +705,19 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
             ),
         });
 
-        for byte_array in values {
-            let current = byte_array.data();
+        let mut previous_array = &self.previous;
+        for current_array in values {
+            let current = current_array.data();
+            let previous = previous_array.data();
             // Number of leading bytes shared with the previous value
-            let match_len = common_prefix_length(&self.previous, current);
+            let match_len = common_prefix_length(previous, current);
             prefix_lengths.push(match_len as i32);
-            suffixes.push(byte_array.slice(match_len, byte_array.len() - match_len));
+            suffixes.push(current_array.slice(match_len, current_array.len() - match_len));
             // Update previous for the next prefix
-            self.previous.clear();
-            self.previous.extend_from_slice(current);
+            previous_array = current_array;
         }
+        self.previous = previous_array.clone();
+        
         self.prefix_len_encoder.put(&prefix_lengths)?;
         self.suffix_writer.put(&suffixes)?;
 
@@ -738,7 +741,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
                 // ... followed by suffixes
                 self.suffix_writer.flush_to(out)?;
 
-                self.previous.clear();
+                self.previous = ByteArray::new();
                 Ok(())
             }
             _ => panic!(
@@ -751,7 +754,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
     fn estimated_memory_size(&self) -> usize {
         self.prefix_len_encoder.estimated_memory_size()
             + self.suffix_writer.estimated_memory_size()
-            + (self.previous.capacity() * std::mem::size_of::<u8>())
+            + (self.previous.len() * std::mem::size_of::<u8>())
     }
 }
 

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -764,7 +764,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
     fn estimated_memory_size(&self) -> usize {
         self.prefix_len_encoder.estimated_memory_size()
             + self.suffix_writer.estimated_memory_size()
-            + (self.previous.len() * std::mem::size_of::<u8>())
+            + (self.previous.capacity() * std::mem::size_of::<u8>())
     }
 }
 

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -577,6 +577,8 @@ impl<T: DataType> DeltaBitPackEncoderConversion<T> for DeltaBitPackEncoder<T> {
 pub struct DeltaLengthByteArrayEncoder<T: DataType> {
     // length encoder
     len_encoder: DeltaBitPackEncoder<Int32Type>,
+    // length buffer
+    lengths: Vec<i32>,
     // byte array data
     data: Vec<ByteArray>,
     // data size in bytes of encoded values
@@ -595,6 +597,7 @@ impl<T: DataType> DeltaLengthByteArrayEncoder<T> {
     pub fn new() -> Self {
         Self {
             len_encoder: DeltaBitPackEncoder::new(),
+            lengths: vec![],
             data: vec![],
             encoded_size: 0,
             _phantom: PhantomData,
@@ -613,14 +616,15 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
             .iter()
             .map(|x| x.as_any().downcast_ref::<ByteArray>().unwrap());
 
-        let mut lengths: Vec<i32> = Vec::with_capacity(values.len());
+        self.lengths.reserve(values.len());
         for byte_array in values {
             let len = byte_array.len();
-            lengths.push(len as i32);
+            self.lengths.push(len as i32);
             self.encoded_size += len;
             self.data.push(byte_array.clone());
         }
-        self.len_encoder.put(&lengths)?;
+        self.len_encoder.put(&self.lengths)?;
+        self.lengths.clear();
 
         Ok(())
     }

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -672,7 +672,7 @@ pub struct DeltaByteArrayEncoder<T: DataType> {
     suffix_writer: DeltaLengthByteArrayEncoder<ByteArrayType>,
     prefix_lengths: Vec<i32>,
     suffixes: Vec<ByteArray>,
-    previous: ByteArray,
+    previous: Vec<u8>,
     _phantom: PhantomData<T>,
 }
 
@@ -690,7 +690,7 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
             suffix_writer: DeltaLengthByteArrayEncoder::new(),
             prefix_lengths: Vec::new(),
             suffixes: Vec::new(),
-            previous: Bytes::new().into(),
+            previous: Vec::new(),
             _phantom: PhantomData,
         }
     }
@@ -709,19 +709,21 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
             ),
         });
 
-        let mut previous_array = &self.previous;
+        let mut previous = self.previous.as_slice();
+        let mut previous_array = &ByteArray::from(Bytes::new());
         for current_array in values {
             let current = current_array.data();
-            let previous = previous_array.data();
             // Number of leading bytes shared with the previous value
             let match_len = common_prefix_length(previous, current);
             self.prefix_lengths.push(match_len as i32);
             self.suffixes
                 .push(current_array.slice(match_len, current.len() - match_len));
             // Update previous for the next prefix
+            previous = current;
             previous_array = current_array;
         }
-        self.previous = previous_array.clone();
+        self.previous.clear();
+        self.previous.extend_from_slice(previous_array.data());
 
         self.prefix_len_encoder.put(&self.prefix_lengths)?;
         self.suffix_writer.put(&self.suffixes)?;
@@ -749,7 +751,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
                 // ... followed by suffixes
                 self.suffix_writer.flush_to(out)?;
 
-                self.previous = Bytes::new().into();
+                self.previous.clear();
                 Ok(())
             }
             _ => panic!(

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -671,7 +671,7 @@ pub struct DeltaByteArrayEncoder<T: DataType> {
     suffix_writer: DeltaLengthByteArrayEncoder<ByteArrayType>,
     prefix_lengths: Vec<i32>,
     suffixes: Vec<ByteArray>,
-    previous: ByteArray,
+    previous: Vec<u8>,
     _phantom: PhantomData<T>,
 }
 
@@ -689,7 +689,7 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
             suffix_writer: DeltaLengthByteArrayEncoder::new(),
             prefix_lengths: Vec::new(),
             suffixes: Vec::new(),
-            previous: Bytes::new().into(),
+            previous: Vec::new(),
             _phantom: PhantomData,
         }
     }
@@ -708,19 +708,21 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
             ),
         });
 
-        let mut previous_array = &self.previous;
+        let mut previous = self.previous.as_slice();
+        let mut previous_array = &ByteArray::from(Bytes::new());
         for current_array in values {
             let current = current_array.data();
-            let previous = previous_array.data();
             // Number of leading bytes shared with the previous value
             let match_len = common_prefix_length(previous, current);
             self.prefix_lengths.push(match_len as i32);
             self.suffixes
                 .push(current_array.slice(match_len, current.len() - match_len));
             // Update previous for the next prefix
+            previous = current;
             previous_array = current_array;
         }
-        self.previous = previous_array.clone();
+        self.previous.clear();
+        self.previous.extend_from_slice(previous_array.data());
 
         self.prefix_len_encoder.put(&self.prefix_lengths)?;
         self.suffix_writer.put(&self.suffixes)?;
@@ -748,7 +750,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
                 // ... followed by suffixes
                 self.suffix_writer.flush_to(out)?;
 
-                self.previous = Bytes::new().into();
+                self.previous.clear();
                 Ok(())
             }
             _ => panic!(

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -596,7 +596,7 @@ impl<T: DataType> DeltaLengthByteArrayEncoder<T> {
 impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
     fn put(&mut self, values: &[T::T]) -> Result<()> {
         ensure_phys_ty!(
-            Type::BYTE_ARRAY | Type::FIXED_LEN_BYTE_ARRAY,
+            Type::BYTE_ARRAY,
             "DeltaLengthByteArrayEncoder only supports ByteArrayType"
         );
 
@@ -630,7 +630,7 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
 
     fn flush_buffer(&mut self) -> Result<Bytes> {
         ensure_phys_ty!(
-            Type::BYTE_ARRAY | Type::FIXED_LEN_BYTE_ARRAY,
+            Type::BYTE_ARRAY,
             "DeltaLengthByteArrayEncoder only supports ByteArrayType"
         );
 

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -595,7 +595,7 @@ impl<T: DataType> DeltaLengthByteArrayEncoder<T> {
 impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
     fn put(&mut self, values: &[T::T]) -> Result<()> {
         ensure_phys_ty!(
-            Type::BYTE_ARRAY | Type::FIXED_LEN_BYTE_ARRAY,
+            Type::BYTE_ARRAY,
             "DeltaLengthByteArrayEncoder only supports ByteArrayType"
         );
 
@@ -629,7 +629,7 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
 
     fn flush_buffer(&mut self) -> Result<Bytes> {
         ensure_phys_ty!(
-            Type::BYTE_ARRAY | Type::FIXED_LEN_BYTE_ARRAY,
+            Type::BYTE_ARRAY,
             "DeltaLengthByteArrayEncoder only supports ByteArrayType"
         );
 

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -578,6 +578,8 @@ impl<T: DataType> DeltaBitPackEncoderConversion<T> for DeltaBitPackEncoder<T> {
 pub struct DeltaLengthByteArrayEncoder<T: DataType> {
     // length encoder
     len_encoder: DeltaBitPackEncoder<Int32Type>,
+    // length buffer
+    lengths: Vec<i32>,
     // byte array data
     data: Vec<ByteArray>,
     // data size in bytes of encoded values
@@ -596,6 +598,7 @@ impl<T: DataType> DeltaLengthByteArrayEncoder<T> {
     pub fn new() -> Self {
         Self {
             len_encoder: DeltaBitPackEncoder::new(),
+            lengths: vec![],
             data: vec![],
             encoded_size: 0,
             _phantom: PhantomData,
@@ -614,14 +617,15 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
             .iter()
             .map(|x| x.as_any().downcast_ref::<ByteArray>().unwrap());
 
-        let mut lengths: Vec<i32> = Vec::with_capacity(values.len());
+        self.lengths.reserve(values.len());
         for byte_array in values {
             let len = byte_array.len();
-            lengths.push(len as i32);
+            self.lengths.push(len as i32);
             self.encoded_size += len;
             self.data.push(byte_array.clone());
         }
-        self.len_encoder.put(&lengths)?;
+        self.len_encoder.put(&self.lengths)?;
+        self.lengths.clear();
 
         Ok(())
     }

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -763,7 +763,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
     fn estimated_memory_size(&self) -> usize {
         self.prefix_len_encoder.estimated_memory_size()
             + self.suffix_writer.estimated_memory_size()
-            + (self.previous.len() * std::mem::size_of::<u8>())
+            + (self.previous.capacity() * std::mem::size_of::<u8>())
     }
 }
 

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -600,18 +600,18 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
             "DeltaLengthByteArrayEncoder only supports ByteArrayType"
         );
 
-        let val_it = || {
-            values
-                .iter()
-                .map(|x| x.as_any().downcast_ref::<ByteArray>().unwrap())
-        };
+        let values = values
+            .iter()
+            .map(|x| x.as_any().downcast_ref::<ByteArray>().unwrap());
 
-        let lengths: Vec<i32> = val_it().map(|byte_array| byte_array.len() as i32).collect();
-        self.len_encoder.put(&lengths)?;
-        for byte_array in val_it() {
-            self.encoded_size += byte_array.len();
+        let mut lengths: Vec<i32> = Vec::with_capacity(values.len());
+        for byte_array in values {
+            let len = byte_array.len();
+            lengths.push(len as i32);
+            self.encoded_size += len;
             self.data.push(byte_array.clone());
         }
+        self.len_encoder.put(&lengths)?;
 
         Ok(())
     }
@@ -684,19 +684,16 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
 
 impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
     fn put(&mut self, values: &[T::T]) -> Result<()> {
-        let mut prefix_lengths: Vec<i32> = vec![];
-        let mut suffixes: Vec<ByteArray> = vec![];
+        let mut prefix_lengths: Vec<i32> = Vec::with_capacity(values.len());
+        let mut suffixes: Vec<ByteArray> = Vec::with_capacity(values.len());
 
-        let values = values
-            .iter()
-            .map(|x| x.as_any())
-            .map(|x| match T::get_physical_type() {
-                Type::BYTE_ARRAY => x.downcast_ref::<ByteArray>().unwrap(),
-                Type::FIXED_LEN_BYTE_ARRAY => x.downcast_ref::<FixedLenByteArray>().unwrap(),
-                _ => panic!(
-                    "DeltaByteArrayEncoder only supports ByteArrayType and FixedLenByteArrayType"
-                ),
-            });
+        let values = values.iter().map(|x| match T::get_physical_type() {
+            Type::BYTE_ARRAY => x.as_any().downcast_ref::<ByteArray>().unwrap(),
+            Type::FIXED_LEN_BYTE_ARRAY => x.as_any().downcast_ref::<FixedLenByteArray>().unwrap(),
+            _ => panic!(
+                "DeltaByteArrayEncoder only supports ByteArrayType and FixedLenByteArrayType"
+            ),
+        });
 
         for byte_array in values {
             let current = byte_array.data();

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -153,10 +153,6 @@ impl<T: DataType> PlainEncoder<T> {
 }
 
 impl<T: DataType> Encoder<T> for PlainEncoder<T> {
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
-    #[cold]
     fn encoding(&self) -> Encoding {
         Encoding::PLAIN
     }
@@ -243,10 +239,6 @@ impl<T: DataType> Encoder<T> for RleValueEncoder<T> {
         Ok(())
     }
 
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
-    #[cold]
     fn encoding(&self) -> Encoding {
         Encoding::RLE
     }
@@ -492,10 +484,6 @@ impl<T: DataType> Encoder<T> for DeltaBitPackEncoder<T> {
         Ok(())
     }
 
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
-    #[cold]
     fn encoding(&self) -> Encoding {
         Encoding::DELTA_BINARY_PACKED
     }
@@ -637,10 +625,6 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
         Ok(())
     }
 
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
-    #[cold]
     fn encoding(&self) -> Encoding {
         Encoding::DELTA_LENGTH_BYTE_ARRAY
     }
@@ -732,10 +716,6 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
         Ok(())
     }
 
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
-    #[cold]
     fn encoding(&self) -> Encoding {
         Encoding::DELTA_BYTE_ARRAY
     }

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -599,18 +599,18 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
             "DeltaLengthByteArrayEncoder only supports ByteArrayType"
         );
 
-        let val_it = || {
-            values
-                .iter()
-                .map(|x| x.as_any().downcast_ref::<ByteArray>().unwrap())
-        };
+        let values = values
+            .iter()
+            .map(|x| x.as_any().downcast_ref::<ByteArray>().unwrap());
 
-        let lengths: Vec<i32> = val_it().map(|byte_array| byte_array.len() as i32).collect();
-        self.len_encoder.put(&lengths)?;
-        for byte_array in val_it() {
-            self.encoded_size += byte_array.len();
+        let mut lengths: Vec<i32> = Vec::with_capacity(values.len());
+        for byte_array in values {
+            let len = byte_array.len();
+            lengths.push(len as i32);
+            self.encoded_size += len;
             self.data.push(byte_array.clone());
         }
+        self.len_encoder.put(&lengths)?;
 
         Ok(())
     }
@@ -683,19 +683,16 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
 
 impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
     fn put(&mut self, values: &[T::T]) -> Result<()> {
-        let mut prefix_lengths: Vec<i32> = vec![];
-        let mut suffixes: Vec<ByteArray> = vec![];
+        let mut prefix_lengths: Vec<i32> = Vec::with_capacity(values.len());
+        let mut suffixes: Vec<ByteArray> = Vec::with_capacity(values.len());
 
-        let values = values
-            .iter()
-            .map(|x| x.as_any())
-            .map(|x| match T::get_physical_type() {
-                Type::BYTE_ARRAY => x.downcast_ref::<ByteArray>().unwrap(),
-                Type::FIXED_LEN_BYTE_ARRAY => x.downcast_ref::<FixedLenByteArray>().unwrap(),
-                _ => panic!(
-                    "DeltaByteArrayEncoder only supports ByteArrayType and FixedLenByteArrayType"
-                ),
-            });
+        let values = values.iter().map(|x| match T::get_physical_type() {
+            Type::BYTE_ARRAY => x.as_any().downcast_ref::<ByteArray>().unwrap(),
+            Type::FIXED_LEN_BYTE_ARRAY => x.as_any().downcast_ref::<FixedLenByteArray>().unwrap(),
+            _ => panic!(
+                "DeltaByteArrayEncoder only supports ByteArrayType and FixedLenByteArrayType"
+            ),
+        });
 
         for byte_array in values {
             let current = byte_array.data();

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -669,7 +669,7 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
 pub struct DeltaByteArrayEncoder<T: DataType> {
     prefix_len_encoder: DeltaBitPackEncoder<Int32Type>,
     suffix_writer: DeltaLengthByteArrayEncoder<ByteArrayType>,
-    previous: Vec<u8>,
+    previous: ByteArray,
     _phantom: PhantomData<T>,
 }
 
@@ -685,7 +685,7 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
         Self {
             prefix_len_encoder: DeltaBitPackEncoder::new(),
             suffix_writer: DeltaLengthByteArrayEncoder::new(),
-            previous: vec![],
+            previous: ByteArray::new(),
             _phantom: PhantomData,
         }
     }
@@ -704,16 +704,19 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
             ),
         });
 
-        for byte_array in values {
-            let current = byte_array.data();
+        let mut previous_array = &self.previous;
+        for current_array in values {
+            let current = current_array.data();
+            let previous = previous_array.data();
             // Number of leading bytes shared with the previous value
-            let match_len = common_prefix_length(&self.previous, current);
+            let match_len = common_prefix_length(previous, current);
             prefix_lengths.push(match_len as i32);
-            suffixes.push(byte_array.slice(match_len, byte_array.len() - match_len));
+            suffixes.push(current_array.slice(match_len, current_array.len() - match_len));
             // Update previous for the next prefix
-            self.previous.clear();
-            self.previous.extend_from_slice(current);
+            previous_array = current_array;
         }
+        self.previous = previous_array.clone();
+        
         self.prefix_len_encoder.put(&prefix_lengths)?;
         self.suffix_writer.put(&suffixes)?;
 
@@ -737,7 +740,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
                 // ... followed by suffixes
                 self.suffix_writer.flush_to(out)?;
 
-                self.previous.clear();
+                self.previous = ByteArray::new();
                 Ok(())
             }
             _ => panic!(
@@ -750,7 +753,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
     fn estimated_memory_size(&self) -> usize {
         self.prefix_len_encoder.estimated_memory_size()
             + self.suffix_writer.estimated_memory_size()
-            + (self.previous.capacity() * std::mem::size_of::<u8>())
+            + (self.previous.len() * std::mem::size_of::<u8>())
     }
 }
 

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -76,7 +76,15 @@ pub trait Encoder<T: DataType>: Send {
 
     /// Flushes the underlying byte buffer that's being processed by this encoder, and
     /// return the immutable copy of it. This will also reset the internal state.
-    fn flush_buffer(&mut self) -> Result<Bytes>;
+    fn flush_buffer(&mut self) -> Result<Bytes> {
+        let mut buffer = Vec::new();
+        self.flush_to(&mut buffer)?;
+        Ok(buffer.into())
+    }
+
+    /// Flushes the underlying byte buffer that's being processed by this encoder. 
+    /// This will also reset the internal state.
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()>;
 }
 
 /// Gets a encoder for the particular data type `T` and encoding `encoding`. Memory usage
@@ -164,6 +172,15 @@ impl<T: DataType> Encoder<T> for PlainEncoder<T> {
             .extend_from_slice(self.bit_writer.flush_buffer());
         self.bit_writer.clear();
         Ok(std::mem::take(&mut self.buffer).into())
+    }
+
+    #[inline]
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
+        out.extend_from_slice(&self.buffer);
+        out.extend_from_slice(self.bit_writer.flush_buffer());
+        self.buffer.clear();
+        self.bit_writer.clear();
+        Ok(())
     }
 
     #[inline]
@@ -260,6 +277,12 @@ impl<T: DataType> Encoder<T> for RleValueEncoder<T> {
         buf[..4].copy_from_slice(&len.to_le_bytes());
 
         Ok(buf.into())
+    }
+
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
+        // TODO: RleEncoder could be reused instead of consumed
+        out.extend_from_slice(&self.flush_buffer()?);
+        Ok(())
     }
 
     /// return the estimated memory size of this encoder.
@@ -479,18 +502,17 @@ impl<T: DataType> Encoder<T> for DeltaBitPackEncoder<T> {
     }
 
     fn estimated_data_encoded_size(&self) -> usize {
-        self.bit_writer.bytes_written()
+        self.page_header_writer.bytes_written() + self.bit_writer.bytes_written()
     }
 
-    fn flush_buffer(&mut self) -> Result<Bytes> {
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
         // Write remaining values
         self.flush_block_values()?;
         // Write page header with total values
         self.write_page_header();
 
-        let mut buffer = Vec::new();
-        buffer.extend_from_slice(self.page_header_writer.flush_buffer());
-        buffer.extend_from_slice(self.bit_writer.flush_buffer());
+        out.extend_from_slice(self.page_header_writer.flush_buffer());
+        out.extend_from_slice(self.bit_writer.flush_buffer());
 
         // Reset state
         self.page_header_writer.clear();
@@ -500,7 +522,7 @@ impl<T: DataType> Encoder<T> for DeltaBitPackEncoder<T> {
         self.current_value = 0;
         self.values_in_block = 0;
 
-        Ok(buffer.into())
+        Ok(())
     }
 
     /// return the estimated memory size of this encoder.
@@ -628,22 +650,22 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
         self.len_encoder.estimated_data_encoded_size() + self.encoded_size
     }
 
-    fn flush_buffer(&mut self) -> Result<Bytes> {
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
         ensure_phys_ty!(
             Type::BYTE_ARRAY,
             "DeltaLengthByteArrayEncoder only supports ByteArrayType"
         );
 
-        let mut total_bytes = vec![];
-        let lengths = self.len_encoder.flush_buffer()?;
-        total_bytes.extend_from_slice(&lengths);
+        out.reserve(self.estimated_data_encoded_size());
+        self.len_encoder.flush_to(out)?;
+
         self.data.iter().for_each(|byte_array| {
-            total_bytes.extend_from_slice(byte_array.data());
+            out.extend_from_slice(byte_array.data());
         });
         self.data.clear();
         self.encoded_size = 0;
 
-        Ok(total_bytes.into())
+        Ok(())
     }
 
     /// return the estimated memory size of this encoder.
@@ -724,21 +746,16 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
             + self.suffix_writer.estimated_data_encoded_size()
     }
 
-    fn flush_buffer(&mut self) -> Result<Bytes> {
+    fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()> {
         match T::get_physical_type() {
             Type::BYTE_ARRAY | Type::FIXED_LEN_BYTE_ARRAY => {
-                // TODO: investigate if we can merge lengths and suffixes
-                // without copying data into new vector.
-                let mut total_bytes = vec![];
                 // Insert lengths ...
-                let lengths = self.prefix_len_encoder.flush_buffer()?;
-                total_bytes.extend_from_slice(&lengths);
+                self.prefix_len_encoder.flush_to(out)?;
                 // ... followed by suffixes
-                let suffixes = self.suffix_writer.flush_buffer()?;
-                total_bytes.extend_from_slice(&suffixes);
+                self.suffix_writer.flush_to(out)?;
 
                 self.previous.clear();
-                Ok(total_bytes.into())
+                Ok(())
             }
             _ => panic!(
                 "DeltaByteArrayEncoder only supports ByteArrayType and FixedLenByteArrayType"

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -689,7 +689,7 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
             suffix_writer: DeltaLengthByteArrayEncoder::new(),
             prefix_lengths: Vec::new(),
             suffixes: Vec::new(),
-            previous: ByteArray::new(),
+            previous: Bytes::new().into(),
             _phantom: PhantomData,
         }
     }
@@ -748,7 +748,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
                 // ... followed by suffixes
                 self.suffix_writer.flush_to(out)?;
 
-                self.previous = ByteArray::new();
+                self.previous = Bytes::new().into();
                 Ok(())
             }
             _ => panic!(

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -690,7 +690,7 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
             suffix_writer: DeltaLengthByteArrayEncoder::new(),
             prefix_lengths: Vec::new(),
             suffixes: Vec::new(),
-            previous: ByteArray::new(),
+            previous: Bytes::new().into(),
             _phantom: PhantomData,
         }
     }
@@ -749,7 +749,7 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
                 // ... followed by suffixes
                 self.suffix_writer.flush_to(out)?;
 
-                self.previous = ByteArray::new();
+                self.previous = Bytes::new().into();
                 Ok(())
             }
             _ => panic!(

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -154,10 +154,6 @@ impl<T: DataType> PlainEncoder<T> {
 }
 
 impl<T: DataType> Encoder<T> for PlainEncoder<T> {
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
-    #[cold]
     fn encoding(&self) -> Encoding {
         Encoding::PLAIN
     }
@@ -244,10 +240,6 @@ impl<T: DataType> Encoder<T> for RleValueEncoder<T> {
         Ok(())
     }
 
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
-    #[cold]
     fn encoding(&self) -> Encoding {
         Encoding::RLE
     }
@@ -493,10 +485,6 @@ impl<T: DataType> Encoder<T> for DeltaBitPackEncoder<T> {
         Ok(())
     }
 
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
-    #[cold]
     fn encoding(&self) -> Encoding {
         Encoding::DELTA_BINARY_PACKED
     }
@@ -638,10 +626,6 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
         Ok(())
     }
 
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
-    #[cold]
     fn encoding(&self) -> Encoding {
         Encoding::DELTA_LENGTH_BYTE_ARRAY
     }
@@ -733,10 +717,6 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
         Ok(())
     }
 
-    // Performance Note:
-    // As far as can be seen these functions are rarely called and as such we can hint to the
-    // compiler that they dont need to be folded into hot locations in the final output.
-    #[cold]
     fn encoding(&self) -> Encoding {
         Encoding::DELTA_BYTE_ARRAY
     }

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -82,7 +82,7 @@ pub trait Encoder<T: DataType>: Send {
         Ok(buffer.into())
     }
 
-    /// Flushes the underlying byte buffer that's being processed by this encoder. 
+    /// Flushes the underlying byte buffer that's being processed by this encoder.
     /// This will also reset the internal state.
     fn flush_to(&mut self, out: &mut Vec<u8>) -> Result<()>;
 }
@@ -669,6 +669,8 @@ impl<T: DataType> Encoder<T> for DeltaLengthByteArrayEncoder<T> {
 pub struct DeltaByteArrayEncoder<T: DataType> {
     prefix_len_encoder: DeltaBitPackEncoder<Int32Type>,
     suffix_writer: DeltaLengthByteArrayEncoder<ByteArrayType>,
+    prefix_lengths: Vec<i32>,
+    suffixes: Vec<ByteArray>,
     previous: ByteArray,
     _phantom: PhantomData<T>,
 }
@@ -685,6 +687,8 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
         Self {
             prefix_len_encoder: DeltaBitPackEncoder::new(),
             suffix_writer: DeltaLengthByteArrayEncoder::new(),
+            prefix_lengths: Vec::new(),
+            suffixes: Vec::new(),
             previous: ByteArray::new(),
             _phantom: PhantomData,
         }
@@ -693,8 +697,8 @@ impl<T: DataType> DeltaByteArrayEncoder<T> {
 
 impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
     fn put(&mut self, values: &[T::T]) -> Result<()> {
-        let mut prefix_lengths: Vec<i32> = Vec::with_capacity(values.len());
-        let mut suffixes: Vec<ByteArray> = Vec::with_capacity(values.len());
+        self.prefix_lengths.reserve(values.len());
+        self.suffixes.reserve(values.len());
 
         let values = values.iter().map(|x| match T::get_physical_type() {
             Type::BYTE_ARRAY => x.as_any().downcast_ref::<ByteArray>().unwrap(),
@@ -710,15 +714,19 @@ impl<T: DataType> Encoder<T> for DeltaByteArrayEncoder<T> {
             let previous = previous_array.data();
             // Number of leading bytes shared with the previous value
             let match_len = common_prefix_length(previous, current);
-            prefix_lengths.push(match_len as i32);
-            suffixes.push(current_array.slice(match_len, current_array.len() - match_len));
+            self.prefix_lengths.push(match_len as i32);
+            self.suffixes
+                .push(current_array.slice(match_len, current.len() - match_len));
             // Update previous for the next prefix
             previous_array = current_array;
         }
         self.previous = previous_array.clone();
-        
-        self.prefix_len_encoder.put(&prefix_lengths)?;
-        self.suffix_writer.put(&suffixes)?;
+
+        self.prefix_len_encoder.put(&self.prefix_lengths)?;
+        self.suffix_writer.put(&self.suffixes)?;
+
+        self.prefix_lengths.clear();
+        self.suffixes.clear();
 
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

N/A

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
In our case, improve performance for delta-encoded decimals.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Reduce allocs and copies when delta-encoding byte-arrays.

Also removed some suspicious `#[cold]` attributes on `Encoder::encoding`.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->
Encoder correctness should be covered by existing tests.
I can add benchmarks if desired, since the removal of byte array copies is a nice win (especially combined with https://github.com/apache/arrow-rs/pull/10364).

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
`parquet::encodings::encoding::Encoder` has a new `flush_to` function, but the module is gated behind the experimental feature. I can rewrite it to make `flush_to` a default method if needed.
