### PR TITLE
chore: fix failing miri test

### DIFF
--- a/arrow-schema/src/datatype_parse.rs
+++ b/arrow-schema/src/datatype_parse.rs
@@ -1489,7 +1489,7 @@ mod test {
             // too large for i32
             (
                 "FixedSizeBinary(4000000000), ",
-                "Error converting 4000000000 into i32 for FixedSizeBinary: out of range integral type conversion attempted",
+                "Error converting 4000000000 into i32 for FixedSizeBinary",
             ),
             // can't have negative width
             (

--- a/arrow-schema/src/datatype_parse.rs
+++ b/arrow-schema/src/datatype_parse.rs
@@ -1503,35 +1503,35 @@ mod test {
             // can't have negative precision
             (
                 "Decimal32(-3, 5)",
-                "Error converting -3 into u8 for Decimal32: out of range integral type conversion attempted",
+                "Error converting -3 into u8 for Decimal32",
             ),
             (
                 "Decimal64(-3, 5)",
-                "Error converting -3 into u8 for Decimal64: out of range integral type conversion attempted",
+                "Error converting -3 into u8 for Decimal64",
             ),
             (
                 "Decimal128(-3, 5)",
-                "Error converting -3 into u8 for Decimal128: out of range integral type conversion attempted",
+                "Error converting -3 into u8 for Decimal128",
             ),
             (
                 "Decimal256(-3, 5)",
-                "Error converting -3 into u8 for Decimal256: out of range integral type conversion attempted",
+                "Error converting -3 into u8 for Decimal256",
             ),
             (
                 "Decimal32(3, 500)",
-                "Error converting 500 into i8 for Decimal32: out of range integral type conversion attempted",
+                "Error converting 500 into i8 for Decimal32",
             ),
             (
                 "Decimal64(3, 500)",
-                "Error converting 500 into i8 for Decimal64: out of range integral type conversion attempted",
+                "Error converting 500 into i8 for Decimal64",
             ),
             (
                 "Decimal128(3, 500)",
-                "Error converting 500 into i8 for Decimal128: out of range integral type conversion attempted",
+                "Error converting 500 into i8 for Decimal128",
             ),
             (
                 "Decimal256(3, 500)",
-                "Error converting 500 into i8 for Decimal256: out of range integral type conversion attempted",
+                "Error converting 500 into i8 for Decimal256",
             ),
             ("Struct(f1 Int64)", "Error unknown token: f1"),
             ("Struct(\"f1\" Int64)", "Expected ':'"),


### PR DESCRIPTION
miri failing on main and on PRs:

```sh
running 1 test
    test datatype_parse::test::parse_data_type_errors ... Parsing '', expecting 'Unsupported type '''
    Parsing '', expecting 'Error finding next token'
    Parsing 'null', expecting 'Unsupported type 'null''
    Parsing 'Nu', expecting 'Unsupported type 'Nu''
    Parsing 'Timestamp(ns, +00:00)', expecting 'Error unknown token: +00'
    Parsing 'Timestamp(ns, "+00:00)', expecting 'Unterminated string at: "+00:00)'
    Parsing 'Timestamp(ns, "")', expecting 'empty strings aren't allowed'
    Parsing 'Timestamp(ns, "+00:00"")', expecting 'Parser error: Unterminated string at: ")'
    Parsing 'Timestamp(ns, ', expecting 'Error finding next token'
    Parsing 'Float32 Float32', expecting 'trailing content after parsing 'Float32''
    Parsing 'Int32, ', expecting 'trailing content after parsing 'Int32''
    Parsing 'Int32(3), ', expecting 'trailing content after parsing 'Int32''
    Parsing 'FixedSizeBinary(Int32), ', expecting 'Error finding i64 for FixedSizeBinary, got 'Int32''
    Parsing 'FixedSizeBinary(3.0), ', expecting 'Error parsing 3.0 as integer: invalid digit found in string'
    Parsing 'FixedSizeBinary(4000000000), ', expecting 'Error converting 4000000000 into i32 for FixedSizeBinary: out of range integral type conversion attempted'
    FAILED

    failures:

    failures:
        datatype_parse::test::parse_data_type_errors

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 99 filtered out; finished in 8.15s

  stderr ───

    thread 'datatype_parse::test::parse_data_type_errors' (12098) panicked at arrow-schema/src/datatype_parse.rs:1618:21:


    did not find expected in actual.

    expected: Error converting 4000000000 into i32 for FixedSizeBinary: out of range integral type conversion attempted
    actual: Parser error: Unsupported type 'FixedSizeBinary(4000000000), '. Must be a supported arrow type name such as 'Int32' or 'Timestamp(ns)'. Error converting 4000000000 into i32 for FixedSizeBinary: number too large to fit in target type

```

- https://github.com/apache/arrow-rs/actions/runs/30007758494/job/89207841004

i dunno why miri gives us a different error message, but oh well