### PR TITLE
fix(arrow-array): make ArrowArrayStreamReader::try_new unsafe

### DIFF
--- a/arrow-array/src/ffi_stream.rs
+++ b/arrow-array/src/ffi_stream.rs
@@ -318,8 +318,27 @@ fn get_stream_schema(stream_ptr: *mut FFI_ArrowArrayStream) -> Result<SchemaRef>
 impl ArrowArrayStreamReader {
     /// Creates a new `ArrowArrayStreamReader` from a `FFI_ArrowArrayStream`.
     /// This is used to import from the C Stream Interface.
-    #[allow(dead_code)]
-    pub fn try_new(mut stream: FFI_ArrowArrayStream) -> Result<Self> {
+    ///
+    /// # Safety
+    ///
+    /// The provided `stream` must be a valid [`FFI_ArrowArrayStream`] per the
+    /// [C Stream Interface]: its callbacks (`get_schema`, `get_next`, `get_last_error`,
+    /// `release`) and `private_data` must be either null/`None` or valid to call for
+    /// the lifetime of the returned reader. Passing a stream with garbage callbacks
+    /// is undefined behavior.
+    ///
+    /// [C Stream Interface]: https://arrow.apache.org/docs/format/CStreamInterface.html
+    ///
+    /// # Example
+    ///
+    /// ```compile_fail
+    /// # use arrow_array::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
+    /// # use arrow_array::RecordBatchReader;
+    /// // try_new is unsafe — this must not compile:
+    /// let stream = FFI_ArrowArrayStream::empty();
+    /// let _reader = ArrowArrayStreamReader::try_new(stream);
+    /// ```
+    pub unsafe fn try_new(mut stream: FFI_ArrowArrayStream) -> Result<Self> {
         if stream.release.is_none() {
             return Err(ArrowError::CDataInterface(
                 "input stream is already released".to_string(),
@@ -342,7 +361,8 @@ impl ArrowArrayStreamReader {
     ///
     /// See [`FFI_ArrowArrayStream::from_raw`]
     pub unsafe fn from_raw(raw_stream: *mut FFI_ArrowArrayStream) -> Result<Self> {
-        Self::try_new(unsafe { FFI_ArrowArrayStream::from_raw(raw_stream) })
+        // SAFETY: caller upholds the same contract as try_new requires
+        unsafe { Self::try_new(FFI_ArrowArrayStream::from_raw(raw_stream)) }
     }
 
     /// Get the last error from `ArrowArrayStreamReader`
@@ -488,7 +508,8 @@ mod tests {
 
         // Import through `FFI_ArrowArrayStream` as `ArrowArrayStreamReader`
         let stream = FFI_ArrowArrayStream::new(reader);
-        let stream_reader = ArrowArrayStreamReader::try_new(stream).unwrap();
+        // SAFETY: stream was constructed via FFI_ArrowArrayStream::new, so callbacks are valid
+        let stream_reader = unsafe { ArrowArrayStreamReader::try_new(stream) }.unwrap();
 
         let imported_schema = stream_reader.schema();
         assert_eq!(imported_schema, schema);
@@ -550,7 +571,8 @@ mod tests {
 
         // Import through `FFI_ArrowArrayStream` as `ArrowArrayStreamReader`
         let stream = FFI_ArrowArrayStream::new(reader);
-        let stream_reader = ArrowArrayStreamReader::try_new(stream).unwrap();
+        // SAFETY: stream was constructed via FFI_ArrowArrayStream::new, so callbacks are valid
+        let stream_reader = unsafe { ArrowArrayStreamReader::try_new(stream) }.unwrap();
 
         let imported_schema = stream_reader.schema();
         assert_eq!(imported_schema, schema);

--- a/arrow-pyarrow/src/lib.rs
+++ b/arrow-pyarrow/src/lib.rs
@@ -384,7 +384,8 @@ impl FromPyArrow for ArrowArrayStreamReader {
                 extract_capsule(&capsule, c"arrow_array_stream", "__arrow_c_stream__")?;
             let stream = unsafe { FFI_ArrowArrayStream::from_raw(stream_ptr.as_ptr()) };
 
-            let stream_reader = ArrowArrayStreamReader::try_new(stream)
+            // SAFETY: stream came from a valid capsule pointer provided by the C stream interface
+            let stream_reader = unsafe { ArrowArrayStreamReader::try_new(stream) }
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
             return Ok(stream_reader);
@@ -403,7 +404,8 @@ impl FromPyArrow for ArrowArrayStreamReader {
             (&raw mut stream as Py_uintptr_t,),
         )?;
 
-        ArrowArrayStreamReader::try_new(stream)
+        // SAFETY: stream was populated by PyArrow's _export_to_c, which fills a valid C stream
+        unsafe { ArrowArrayStreamReader::try_new(stream) }
             .map_err(|err| PyValueError::new_err(err.to_string()))
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #10253

# Rationale for this change

`ArrowArrayStreamReader::try_new` is a safe fn, but it calls `get_stream_schema`, which derefs and calls the caller-supplied `get_schema` fn pointer. every field of `FFI_ArrowArrayStream` is public, so safe code can construct a stream with garbage callbacks and hit UB without writing a single `unsafe` block. the `release.is_none()` check only catches an already-released stream, not a garbage-populated one

both `from_raw` constructors in the same file are already `unsafe` for this exact reason. `try_new` was the one missing it.

# What changes are included in this PR?

- `ArrowArrayStreamReader::try_new` is now `unsafe fn` with a `# Safety` section documenting that the stream's callbacks and `private_data` must be valid per the C stream interface
- `from_raw` body and the two in-module tests wrap their `try_new` calls in `unsafe {}`.
- both `try_new` call sites in `arrow-pyarrow` wrap in `unsafe {}` with a `// SAFETY:` note
- dropped the stale `#[allow(dead_code)]` on `try_new`

the other option from #10253 (private fields on `FFI_ArrowArrayStream`) would break the `#[repr(C)]` ABI that external FFI producers fill field by field, without gaining anything; the callbacks still have to be trusted at call time regardless of visibility.

# Are these changes tested?

yes. a `compile_fail` doctest on `try_new` verifies that calling it without an `unsafe` block is a compile error. the existing round-trip and error-import tests cover the happy path and still pass

# Are there any user-facing changes?

yes, this is a breaking change. `ArrowArrayStreamReader::try_new` is now `unsafe`. callers that obtain a stream from a legitimate FFI source (e.g. `from_raw`, `_export_to_c`) just need to wrap the call in `unsafe {}`