### PR TITLE
fix(arrow-schema): stop asserting on unstable TryFromIntError message in tests

### DIFF
--- a/arrow-schema/src/datatype_parse.rs
+++ b/arrow-schema/src/datatype_parse.rs
@@ -1489,7 +1489,7 @@ mod test {
             // too large for i32
             (
                 "FixedSizeBinary(4000000000), ",
-                "Error converting 4000000000 into i32 for FixedSizeBinary: out of range integral type conversion attempted",
+                "Error converting 4000000000 into i32 for FixedSizeBinary:",
             ),
             // can't have negative width
             (
@@ -1503,35 +1503,35 @@ mod test {
             // can't have negative precision
             (
                 "Decimal32(-3, 5)",
-                "Error converting -3 into u8 for Decimal32: out of range integral type conversion attempted",
+                "Error converting -3 into u8 for Decimal32:",
             ),
             (
                 "Decimal64(-3, 5)",
-                "Error converting -3 into u8 for Decimal64: out of range integral type conversion attempted",
+                "Error converting -3 into u8 for Decimal64:",
             ),
             (
                 "Decimal128(-3, 5)",
-                "Error converting -3 into u8 for Decimal128: out of range integral type conversion attempted",
+                "Error converting -3 into u8 for Decimal128:",
             ),
             (
                 "Decimal256(-3, 5)",
-                "Error converting -3 into u8 for Decimal256: out of range integral type conversion attempted",
+                "Error converting -3 into u8 for Decimal256:",
             ),
             (
                 "Decimal32(3, 500)",
-                "Error converting 500 into i8 for Decimal32: out of range integral type conversion attempted",
+                "Error converting 500 into i8 for Decimal32:",
             ),
             (
                 "Decimal64(3, 500)",
-                "Error converting 500 into i8 for Decimal64: out of range integral type conversion attempted",
+                "Error converting 500 into i8 for Decimal64:",
             ),
             (
                 "Decimal128(3, 500)",
-                "Error converting 500 into i8 for Decimal128: out of range integral type conversion attempted",
+                "Error converting 500 into i8 for Decimal128:",
             ),
             (
                 "Decimal256(3, 500)",
-                "Error converting 500 into i8 for Decimal256: out of range integral type conversion attempted",
+                "Error converting 500 into i8 for Decimal256:",
             ),
             ("Struct(f1 Int64)", "Error unknown token: f1"),
             ("Struct(\"f1\" Int64)", "Expected ':'"),


### PR DESCRIPTION
# Which issue does this PR close?

No separate issue. The fix is one line per test case and the failing CI runs are evidence enough.

# Rationale for this change

MIRI CI uses nightly Rust. A recent nightly changed the `Display` output of `TryFromIntError` from `"out of range integral type conversion attempted"` to `"number too large to fit in target type"` (and similar variants). Tests in `datatype_parse.rs` were asserting on that stdlib-owned suffix, so they broke on MIRI without any change to our code.

# What changes are included in this PR?

Trimmed 9 expected substrings in `parse_data_type_errors` to stop at the `:` that separates our message from the stdlib one. The tests now only assert on the part of the error string we control.

# Are these changes tested?

`parse_data_type_errors` passes on stable. MIRI CI should go green once this merges.

# Are there any user-facing changes?

No. Test-only change, no behavior or API impact.