### PR TITLE
chore(arrow): add unchecked array builder methods

### DIFF
--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -93,6 +93,17 @@ impl BooleanArray {
         Self { values, nulls }
     }
 
+    /// Create a new [`BooleanArray`] from the provided values and nulls without validation.
+    ///
+    /// # Safety
+    /// - `values.len() == nulls.len()` if `nulls` is `Some`
+    pub unsafe fn new_unchecked(values: BooleanBuffer, nulls: Option<NullBuffer>) -> Self {
+        if cfg!(feature = "force_validate") {
+            return Self::new(values, nulls);
+        }
+        Self { values, nulls }
+    }
+
     /// Create a new [`BooleanArray`] with length `len` consisting only of nulls
     pub fn new_null(len: usize) -> Self {
         Self {

--- a/arrow-array/src/array/fixed_size_binary_array.rs
+++ b/arrow-array/src/array/fixed_size_binary_array.rs
@@ -118,6 +118,30 @@ impl FixedSizeBinaryArray {
         Self::try_new(value_length, values, nulls).unwrap()
     }
 
+    /// Create a new [`FixedSizeBinaryArray`] from the provided parts without validation.
+    ///
+    /// # Safety
+    /// - `value_length >= 0`
+    /// - `values.len() == len * value_length as usize`
+    /// - `nulls.len() == len` if `nulls` is `Some`
+    pub unsafe fn new_unchecked(
+        value_length: i32,
+        values: Buffer,
+        nulls: Option<NullBuffer>,
+        len: usize,
+    ) -> Self {
+        if cfg!(feature = "force_validate") {
+            return Self::try_new_with_len(value_length, values, nulls, len).unwrap();
+        }
+        Self {
+            data_type: DataType::FixedSizeBinary(value_length),
+            value_data: values,
+            value_size: value_length as usize,
+            nulls,
+            len,
+        }
+    }
+
     /// Create a new [`Scalar`] from `value`
     pub fn new_scalar(value: impl AsRef<[u8]>) -> Scalar<Self> {
         let v = value.as_ref();

--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -142,6 +142,32 @@ impl FixedSizeListArray {
         Self::try_new(field, size, values, nulls).unwrap()
     }
 
+    /// Create a new [`FixedSizeListArray`] from the provided parts without validation.
+    ///
+    /// # Safety
+    /// - `size >= 0`
+    /// - `values.len() == len * size as usize`
+    /// - `nulls.len() == len` if `nulls` is `Some`
+    /// - `field.data_type() == values.data_type()`
+    pub unsafe fn new_unchecked(
+        field: FieldRef,
+        size: i32,
+        values: ArrayRef,
+        nulls: Option<NullBuffer>,
+        len: usize,
+    ) -> Self {
+        if cfg!(feature = "force_validate") {
+            return Self::try_new_with_length(field, size, values, nulls, len).unwrap();
+        }
+        Self {
+            data_type: DataType::FixedSizeList(field, size),
+            values,
+            value_length: size,
+            nulls,
+            len,
+        }
+    }
+
     /// Create a new [`FixedSizeListArray`] from the provided parts, returning an error on failure.
     ///
     /// Note that if `size == 0` and `nulls` is `None` (a degenerate, non-nullable

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -272,6 +272,29 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
         Self::try_new(field, offsets, values, nulls).unwrap()
     }
 
+    /// Create a new [`GenericListArray`] from the provided parts without validation.
+    ///
+    /// # Safety
+    /// - `offsets.len() - 1 == nulls.len()` if `nulls` is `Some`
+    /// - `offsets.last() <= values.len()`
+    /// - `field.data_type() == values.data_type()`
+    pub unsafe fn new_unchecked(
+        field: FieldRef,
+        offsets: OffsetBuffer<OffsetSize>,
+        values: ArrayRef,
+        nulls: Option<NullBuffer>,
+    ) -> Self {
+        if cfg!(feature = "force_validate") {
+            return Self::new(field, offsets, values, nulls);
+        }
+        Self {
+            data_type: Self::DATA_TYPE_CONSTRUCTOR(field),
+            nulls,
+            values,
+            value_offsets: offsets,
+        }
+    }
+
     /// Create a new [`GenericListArray`] of length `len` where all values are null
     pub fn new_null(field: FieldRef, len: usize) -> Self {
         let values = new_empty_array(field.data_type());

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -146,6 +146,31 @@ impl MapArray {
         Self::try_new(field, offsets, entries, nulls, ordered).unwrap()
     }
 
+    /// Create a new [`MapArray`] from the provided parts without validation.
+    ///
+    /// # Safety
+    /// - `offsets.len() - 1 == nulls.len()` if `nulls` is `Some`
+    /// - `offsets.last() <= entries.len()`
+    /// - `entries` has exactly 2 columns and its keys column is non-nullable
+    /// - `field.data_type() == entries.data_type()`
+    pub unsafe fn new_unchecked(
+        field: FieldRef,
+        offsets: OffsetBuffer<i32>,
+        entries: StructArray,
+        nulls: Option<NullBuffer>,
+        ordered: bool,
+    ) -> Self {
+        if cfg!(feature = "force_validate") {
+            return Self::new(field, offsets, entries, nulls, ordered);
+        }
+        Self {
+            data_type: DataType::Map(field, ordered),
+            nulls,
+            entries,
+            value_offsets: offsets,
+        }
+    }
+
     /// Deconstruct this array into its constituent parts
     pub fn into_parts(
         self,

--- a/arrow-array/src/array/primitive_array.rs
+++ b/arrow-array/src/array/primitive_array.rs
@@ -636,6 +636,24 @@ impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
         Self::try_new(values, nulls).unwrap()
     }
 
+    /// Create a new [`PrimitiveArray`] from the provided values and nulls without validation.
+    ///
+    /// # Safety
+    /// - `values.len() == nulls.len()` if `nulls` is `Some`
+    pub unsafe fn new_unchecked(
+        values: ScalarBuffer<T::Native>,
+        nulls: Option<NullBuffer>,
+    ) -> Self {
+        if cfg!(feature = "force_validate") {
+            return Self::new(values, nulls);
+        }
+        Self {
+            data_type: T::DATA_TYPE,
+            values,
+            nulls,
+        }
+    }
+
     /// Create a new [`PrimitiveArray`] of the given length where all values are null
     pub fn new_null(length: usize) -> Self {
         Self {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10244.

# Rationale for this change
we can avoid un-needed validation at callsites by using `new_unchecked()` instead of `new()`.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
 added missing `new_unchecked` methods for PrimitiveArray, BooleanArray, GenericListArray, FixedSizeListArray, FixedSizeBinaryArray and MapArray.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
n/a no call sites have been changes yet.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
users now have the option to construct these arrays without validation but it must be done within an unsafe block.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
