### PR TITLE
chore: remove rust label from infra yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,7 +30,6 @@ github:
   labels:
     - arrow
     - parquet
-    - rust
   enabled_merge_buttons:
     squash: true
     squash_commit_message: PR_TITLE_AND_DESC


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Part of #10455

Interesting point is we have a bunch of labels not listed in this file anyway, which is supposed to manage our repository metadata?

- reference: https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#repository-metadata

only issue/PR with this label is:

- https://github.com/apache/arrow-rs/pull/10138
- honestly don't know how dependabot decided to add the label here