### PR TITLE
chore: bump resolver to v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,15 +47,11 @@ members = [
     "parquet_derive_test",
 ]
 
-# Enable the version 2 feature resolver, which avoids unifying features for targets that are not being built
-#
-# Critically this prevents dev-dependencies from enabling features even when not building a target that
-# uses dev-dependencies, e.g. the library crate. This in turn ensures that we can catch invalid feature
-# flag combinations that would otherwise only surface in dependent crates
-#
-# Reference - https://doc.rust-lang.org/nightly/cargo/reference/features.html#feature-resolver-version-2
-#
-resolver = "2"
+# This is the default for edition 2024 but we must manually specify it for virtual
+# workspaces.
+# - https://github.com/rust-lang/cargo/issues/10112
+# - https://github.com/rust-lang/cargo/issues/10587
+resolver = "3"
 
 exclude = [
     # arrow-pyarrow-testing is excluded because it requires a Python interpreter with the pyarrow package installed,


### PR DESCRIPTION
v3 should supersede v2 (and adds extra feature)

- https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

Unfortunately even though v3 is the default in edition 2024, we still need to specify it manually since the setting doesn't play well with virtual workspaces 😔