### PR TITLE
Enable allow_attributes lint for arrow-string

### DIFF
--- a/arrow-string/src/binary_predicate.rs
+++ b/arrow-string/src/binary_predicate.rs
@@ -22,7 +22,7 @@ use std::iter::zip;
 
 /// A binary based predicate
 #[cfg_attr(
-    all(target_os = "linux", target_arch = "x86_64"),
+    target_arch = "x86_64",
     expect(clippy::large_enum_variant)
 )]
 pub enum BinaryPredicate<'a> {

--- a/arrow-string/src/binary_predicate.rs
+++ b/arrow-string/src/binary_predicate.rs
@@ -21,7 +21,6 @@ use memchr::memmem::Finder;
 use std::iter::zip;
 
 /// A binary based predicate
-#[allow(clippy::large_enum_variant)]
 pub enum BinaryPredicate<'a> {
     Contains(Finder<'a>),
     StartsWith(&'a [u8]),

--- a/arrow-string/src/binary_predicate.rs
+++ b/arrow-string/src/binary_predicate.rs
@@ -21,6 +21,10 @@ use memchr::memmem::Finder;
 use std::iter::zip;
 
 /// A binary based predicate
+#[cfg_attr(
+    all(target_os = "linux", target_arch = "x86_64"),
+    expect(clippy::large_enum_variant)
+)]
 pub enum BinaryPredicate<'a> {
     Contains(Finder<'a>),
     StartsWith(&'a [u8]),

--- a/arrow-string/src/binary_predicate.rs
+++ b/arrow-string/src/binary_predicate.rs
@@ -21,10 +21,7 @@ use memchr::memmem::Finder;
 use std::iter::zip;
 
 /// A binary based predicate
-#[cfg_attr(
-    target_arch = "x86_64",
-    expect(clippy::large_enum_variant)
-)]
+#[cfg_attr(target_arch = "x86_64", expect(clippy::large_enum_variant))]
 pub enum BinaryPredicate<'a> {
     Contains(Finder<'a>),
     StartsWith(&'a [u8]),

--- a/arrow-string/src/lib.rs
+++ b/arrow-string/src/lib.rs
@@ -22,6 +22,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 mod binary_like;

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -24,10 +24,7 @@ use regex::{Regex, RegexBuilder};
 use std::iter::zip;
 
 /// A string based predicate
-#[cfg_attr(
-    target_arch = "x86_64",
-    expect(clippy::large_enum_variant)
-)]
+#[cfg_attr(target_arch = "x86_64", expect(clippy::large_enum_variant))]
 pub(crate) enum Predicate<'a> {
     Eq(&'a str),
     Contains(Finder<'a>),

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -24,7 +24,6 @@ use regex::{Regex, RegexBuilder};
 use std::iter::zip;
 
 /// A string based predicate
-#[allow(clippy::large_enum_variant)]
 pub(crate) enum Predicate<'a> {
     Eq(&'a str),
     Contains(Finder<'a>),

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -25,7 +25,7 @@ use std::iter::zip;
 
 /// A string based predicate
 #[cfg_attr(
-    all(target_os = "linux", target_arch = "x86_64"),
+    target_arch = "x86_64",
     expect(clippy::large_enum_variant)
 )]
 pub(crate) enum Predicate<'a> {

--- a/arrow-string/src/predicate.rs
+++ b/arrow-string/src/predicate.rs
@@ -24,6 +24,10 @@ use regex::{Regex, RegexBuilder};
 use std::iter::zip;
 
 /// A string based predicate
+#[cfg_attr(
+    all(target_os = "linux", target_arch = "x86_64"),
+    expect(clippy::large_enum_variant)
+)]
 pub(crate) enum Predicate<'a> {
     Eq(&'a str),
     Contains(Finder<'a>),


### PR DESCRIPTION
## Which issue does this PR close?

Part of #10458.

## Rationale for this change

Enable `clippy::allow_attributes` for `arrow-string` so future lint suppressions use expectations and stale suppressions are detectable. The existing `large_enum_variant` suppressions are still required on x86_64 Linux, so they are converted to target-specific `expect` attributes instead of unconditional `allow` attributes.

## What changes are included in this PR?

- Deny `clippy::allow_attributes` in the `arrow-string` crate.
- Convert the two x86_64 Linux `large_enum_variant` suppressions to lint expectations.

## Are there any user-facing changes?

No.

## How was this change tested?

- `cargo +1.96.1 fmt --all -- --check`
- `cargo +1.96.1 clippy -p arrow-string --all-targets --all-features -- -D warnings`
- `cargo +1.96.1 clippy -p arrow-string --target x86_64-unknown-linux-gnu --all-targets --all-features -- -D warnings`
- `cargo +1.96.1 test -p arrow-string --all-features` (182 unit tests and 10 doc tests passed)

## AI assistance

AI assistance was used to identify the lint occurrences and draft the minimal edits. I reviewed the full diff and validated it with formatting, Clippy, and the crate's tests.