### PR TITLE
Fix REE JSON decoder nullability (#10478)

### DIFF
--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -845,9 +845,9 @@ fn make_decoder(
         DataType::BinaryView => Ok(Box::new(BinaryViewDecoder::default())),
         DataType::Map(_, _) => Ok(Box::new(MapArrayDecoder::new(ctx, data_type, is_nullable)?)),
         DataType::RunEndEncoded(ref r, _) => match r.data_type() {
-            DataType::Int16 => Ok(Box::new(RunEndEncodedArrayDecoder::<Int16Type>::new(ctx, data_type, is_nullable)?)),
-            DataType::Int32 => Ok(Box::new(RunEndEncodedArrayDecoder::<Int32Type>::new(ctx, data_type, is_nullable)?)),
-            DataType::Int64 => Ok(Box::new(RunEndEncodedArrayDecoder::<Int64Type>::new(ctx, data_type, is_nullable)?)),
+            DataType::Int16 => Ok(Box::new(RunEndEncodedArrayDecoder::<Int16Type>::new(ctx, data_type)?)),
+            DataType::Int32 => Ok(Box::new(RunEndEncodedArrayDecoder::<Int32Type>::new(ctx, data_type)?)),
+            DataType::Int64 => Ok(Box::new(RunEndEncodedArrayDecoder::<Int64Type>::new(ctx, data_type)?)),
             d => unreachable!("unsupported run end index type: {d}"),
         },
         _ => Err(ArrowError::NotYetImplemented(format!("Support for {data_type} in JSON reader")))
@@ -3582,6 +3582,23 @@ mod tests {
         assert_eq!(values.len(), 2);
         assert_eq!(values.value(0), "x");
         assert_eq!(values.value(1), "y");
+    }
+
+    #[test]
+    fn test_read_run_end_encoded_nulls_in_non_nullable_values() {
+        let ree_type = DataType::RunEndEncoded(
+            Arc::new(Field::new("run_ends", DataType::Int32, false)),
+            Arc::new(Field::new("values", DataType::Utf8, false)),
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new("a", ree_type, true)]));
+
+        for buf in [r#"{"a": null}"#, r#"{}"#] {
+            let mut decoder = ReaderBuilder::new(schema.clone()).build_decoder().unwrap();
+            decoder.decode(buf.as_bytes()).unwrap();
+            decoder
+                .flush()
+                .expect_err("nullable REE parent must not make values nullable");
+        }
     }
 
     #[test]

--- a/arrow-json/src/reader/run_end_array.rs
+++ b/arrow-json/src/reader/run_end_array.rs
@@ -33,27 +33,22 @@ use crate::reader::{ArrayDecoder, DecoderContext};
 pub struct RunEndEncodedArrayDecoder<R> {
     data_type: DataType,
     decoder: Box<dyn ArrayDecoder>,
+    values_nullable: bool,
     phantom: PhantomData<R>,
 }
 
 impl<R: RunEndIndexType> RunEndEncodedArrayDecoder<R> {
-    pub fn new(
-        ctx: &DecoderContext,
-        data_type: &DataType,
-        is_nullable: bool,
-    ) -> Result<Self, ArrowError> {
+    pub fn new(ctx: &DecoderContext, data_type: &DataType) -> Result<Self, ArrowError> {
         let values_field = match data_type {
             DataType::RunEndEncoded(_, v) => v,
             _ => unreachable!(),
         };
-        let decoder = ctx.make_decoder(
-            values_field.data_type(),
-            values_field.is_nullable() || is_nullable,
-        )?;
+        let decoder = ctx.make_decoder(values_field.data_type(), values_field.is_nullable())?;
 
         Ok(Self {
             data_type: data_type.clone(),
             decoder,
+            values_nullable: values_field.is_nullable(),
             phantom: Default::default(),
         })
     }
@@ -67,6 +62,11 @@ impl<R: RunEndIndexType + Send> ArrayDecoder for RunEndEncodedArrayDecoder<R> {
         }
 
         let flat_array = self.decoder.decode(tape, pos)?;
+        if !self.values_nullable && flat_array.null_count() != 0 {
+            return Err(ArrowError::JsonError(
+                "Encountered nulls in non-nullable RunEndEncoded values field".to_string(),
+            ));
+        }
 
         let partitions = partition(from_ref(&flat_array))?;
         let size = partitions.len();


### PR DESCRIPTION
AI-generated contribution disclosure: I used OpenAI Codex to help prepare the implementation and regression test. I reviewed and understand the changes, verified them against the issue, and ran the project checks below. The generated portions are the decoder nullability guard, constructor wiring, and regression test.

## Summary

- Decode run-end encoded values according to the values field's own nullability instead of inheriting nullability from the parent field.
- Reject explicit nulls and missing object fields when the REE values field is non-nullable, while still allowing a nullable REE parent.
- Add regression coverage for both invalid inputs.

This intentionally tightens schema enforcement as described in the issue.

Closes #10478

## Testing

- `cargo test -p arrow-json test_read_run_end_encoded_nulls_in_non_nullable_values`
- `cargo clippy -p arrow-json --all-targets -- -D warnings`
- `cargo fmt --all`
