### PR TITLE
fix(json): reject null REE values in non-nullable fields

### DIFF
--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -3638,6 +3638,32 @@ mod tests {
     }
 
     #[test]
+    fn test_read_run_end_encoded_rejects_null_non_nullable_values() {
+        let ree_type = DataType::RunEndEncoded(
+            Arc::new(Field::new("run_ends", DataType::Int32, false)),
+            Arc::new(Field::new("values", DataType::Utf8, false)),
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new("a", ree_type, true)]));
+
+        for buf in [
+            r#"
+            {"a": "x"}
+            {"a": null}
+            {"a": "y"}
+            "#,
+            r#"
+            {"a": "x"}
+            {}
+            {"a": "y"}
+            "#,
+        ] {
+            let mut decoder = ReaderBuilder::new(schema.clone()).build_decoder().unwrap();
+            let res = decoder.decode(buf.as_bytes()).and_then(|_| decoder.flush());
+            assert!(res.is_err());
+        }
+    }
+
+    #[test]
     fn test_read_run_end_encoded_consecutive_nulls() {
         let buf = r#"
         {"a": "x"}

--- a/arrow-json/src/reader/run_end_array.rs
+++ b/arrow-json/src/reader/run_end_array.rs
@@ -32,6 +32,7 @@ use crate::reader::{ArrayDecoder, DecoderContext};
 
 pub struct RunEndEncodedArrayDecoder<R> {
     data_type: DataType,
+    values_nullable: bool,
     decoder: Box<dyn ArrayDecoder>,
     phantom: PhantomData<R>,
 }
@@ -40,19 +41,17 @@ impl<R: RunEndIndexType> RunEndEncodedArrayDecoder<R> {
     pub fn new(
         ctx: &DecoderContext,
         data_type: &DataType,
-        is_nullable: bool,
+        _is_nullable: bool,
     ) -> Result<Self, ArrowError> {
         let values_field = match data_type {
             DataType::RunEndEncoded(_, v) => v,
             _ => unreachable!(),
         };
-        let decoder = ctx.make_decoder(
-            values_field.data_type(),
-            values_field.is_nullable() || is_nullable,
-        )?;
+        let decoder = ctx.make_decoder(values_field.data_type(), values_field.is_nullable())?;
 
         Ok(Self {
             data_type: data_type.clone(),
+            values_nullable: values_field.is_nullable(),
             decoder,
             phantom: Default::default(),
         })
@@ -86,6 +85,12 @@ impl<R: RunEndIndexType + Send> ArrayDecoder for RunEndEncodedArrayDecoder<R> {
 
         let indices = UInt32Array::from_iter_values(indices.into_iter().map(|i| i as u32));
         let values = take(flat_array.as_ref(), &indices, None)?;
+
+        if !self.values_nullable && values.nulls().is_some() {
+            return Err(ArrowError::JsonError(
+                "Non-nullable RunEndEncoded values cannot contain nulls".to_string(),
+            ));
+        }
 
         // SAFETY: run_ends are strictly increasing with the last value equal to len
         let run_ends = unsafe { RunEndBuffer::new_unchecked(ScalarBuffer::from(run_ends), 0, len) };


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10478

## Rationale

A RunEndEncoded array has no container-level validity mask. When its `values` field is non-nullable, null JSON values or missing fields must therefore be rejected even when the enclosing REE field is nullable.

## What changed

- keep the child decoder aligned with the `values` field nullability
- validate the decoded run values before constructing the RunArray
- add regression coverage for explicit null and missing-field inputs

## Testing

- `cargo test -p arrow-json`
- `cargo fmt --all -- --check`
- `git diff --check`