### PR TITLE
chore(parquet): add link to ticket in object_store deprecation message

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -116,9 +116,8 @@ experimental = ["variant_experimental"]
 # Enable async APIs
 async = ["futures", "tokio"]
 # Enable object_store integration
-# Deprecated: implement `AsyncFileReader` directly instead, see the example on
-# the `AsyncFileReader` trait documentation and `parquet/examples/object_store.rs`.
 # This feature will be removed in a future release.
+# See https://github.com/apache/arrow-rs/issues/10308
 object_store = ["dep:object_store", "async"]
 # Group Zstd dependencies
 zstd = ["dep:zstd"]

--- a/parquet/examples/object_store.rs
+++ b/parquet/examples/object_store.rs
@@ -32,8 +32,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 /// This example demonstrates reading and writing Parquet files on object
-/// storage via the [`object_store`] crate, without the deprecated
-/// `ParquetObjectReader` and `ParquetObjectWriter` types.
+/// storage via the [`object_store`] crate.
 ///
 /// # Example Overview
 ///

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -53,7 +53,7 @@ use tokio::runtime::Handle;
 /// ```
 #[deprecated(
     since = "59.2.0",
-    note = "Implement `AsyncFileReader` directly instead; see the example on the `AsyncFileReader` trait documentation and `parquet/examples/object_store.rs`. Use `SpawnedReader` to perform I/O on a dedicated runtime."
+    note = "Implement `AsyncFileReader` directly instead; see the example on the `AsyncFileReader` trait documentation and `parquet/examples/object_store.rs`. Use `SpawnedReader` to perform I/O on a dedicated runtime. See https://github.com/apache/arrow-rs/issues/10308"
 )]
 #[derive(Clone, Debug)]
 pub struct ParquetObjectReader {
@@ -140,7 +140,7 @@ impl ParquetObjectReader {
     /// [here]: https://www.influxdata.com/blog/using-rustlangs-async-tokio-runtime-for-cpu-bound-tasks/
     #[deprecated(
         since = "59.2.0",
-        note = "Wrap the reader in a `SpawnedReader` instead, e.g. `SpawnedReader::new(reader, handle)`"
+        note = "Wrap the reader in a `SpawnedReader` instead, e.g. `SpawnedReader::new(reader, handle)`. See https://github.com/apache/arrow-rs/issues/10308"
     )]
     pub fn with_runtime(self, handle: Handle) -> Self {
         Self {

--- a/parquet/src/arrow/async_writer/store.rs
+++ b/parquet/src/arrow/async_writer/store.rs
@@ -77,7 +77,7 @@ use tokio::io::AsyncWriteExt;
 /// [`AsyncArrowWriter`]: crate::arrow::async_writer::AsyncArrowWriter
 #[deprecated(
     since = "59.2.0",
-    note = "Pass an `object_store::buffered::BufWriter` to `AsyncArrowWriter` directly instead; see `parquet/examples/object_store.rs`"
+    note = "Pass an `object_store::buffered::BufWriter` to `AsyncArrowWriter` directly instead; see https://github.com/apache/arrow-rs/issues/10308 and `parquet/examples/object_store.rs`."
 )]
 #[derive(Debug)]
 pub struct ParquetObjectWriter {


### PR DESCRIPTION
# Which issue does this PR close?

- Follow on to https://github.com/apache/arrow-rs/pull/10354

# Rationale for this change
I think it will help people who hit the deprecation message to leave links to relevant issue (https://github.com/apache/arrow-rs/issues/10308) so they can find relevant context

# What changes are included in this PR?

Add a bunch of links 

# Are these changes tested?

By CI

# Are there any user-facing changes?

Better messages