### PR TITLE
chore(avro): add link to ticket in object_store deprecation message

### DIFF
--- a/arrow-avro/src/lib.rs
+++ b/arrow-avro/src/lib.rs
@@ -131,10 +131,14 @@
 //! [`AsyncAvroFileReader`] implements `Stream<Item = Result<RecordBatch, ArrowError>>`,
 //! allowing efficient async streaming of record batches. Any [`AsyncFileReader`]
 //! can be used as the source; there is a built-in implementation for types
-//! implementing `AsyncRead + AsyncSeek` (such as `tokio::fs::File`), and object
+//! implementing [`AsyncRead`] + [`AsyncSeek`] (such as [`tokio::fs::File`]), and object
 //! storage services such as S3 can be integrated by implementing
 //! [`AsyncFileReader`] on top of a client such as the [object_store] crate
 //! (see the example on the trait documentation).
+//!
+//! [`AsyncRead`]: tokio::io::AsyncRead
+//! [`AsyncSeek`]: tokio::io::AsyncSeek
+//! [`tokio::fs::File`]: https://docs.rs/tokio/latest/tokio/fs/struct.File.html
 //!
 //! ```ignore
 //! use arrow_avro::reader::AsyncAvroFileReader;

--- a/arrow-avro/src/reader/async_reader/async_file_reader.rs
+++ b/arrow-avro/src/reader/async_reader/async_file_reader.rs
@@ -30,11 +30,13 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
 /// 1. There is a default implementation for types that implement [`AsyncRead`]
 ///    and [`AsyncSeek`], for example [`tokio::fs::File`].
 ///
-/// 2. Implementations for remote storage, such as the `object_store` crate,
+/// 2. Implementations for remote storage, such as the [`object_store`] crate,
 ///    can implement this interface directly, typically by pairing a store
 ///    handle with an object path and delegating [`Self::get_bytes`] and
 ///    [`Self::get_byte_ranges`] to ranged reads. [`super::SpawnedReader`] can
 ///    wrap such a reader to perform its I/O on a dedicated tokio runtime.
+///
+/// [`object_store`]: https://crates.io/crates/object_store
 ///
 /// # Example: implementing `AsyncFileReader` for the `object_store` crate
 ///

--- a/arrow-avro/src/reader/async_reader/store.rs
+++ b/arrow-avro/src/reader/async_reader/store.rs
@@ -31,7 +31,7 @@ use tokio::runtime::Handle;
 /// An implementation of an AsyncFileReader using the [`ObjectStore`] API.
 #[deprecated(
     since = "59.2.0",
-    note = "Implement `AsyncFileReader` directly instead; see the example on the `AsyncFileReader` trait documentation and `arrow-avro/examples/object_store.rs`. Use `SpawnedReader` to perform I/O on a dedicated runtime."
+    note = "Implement `AsyncFileReader` directly instead; see the example on the `AsyncFileReader` trait documentation and `arrow-avro/examples/object_store.rs`. Use `SpawnedReader` to perform I/O on a dedicated runtime. See also https://github.com/apache/arrow-rs/issues/10308"
 )]
 #[derive(Clone, Debug)]
 pub struct AvroObjectReader {
@@ -61,7 +61,7 @@ impl AvroObjectReader {
     /// [here]: https://www.influxdata.com/blog/using-rustlangs-async-tokio-runtime-for-cpu-bound-tasks/
     #[deprecated(
         since = "59.2.0",
-        note = "Wrap the reader in a `SpawnedReader` instead, e.g. `SpawnedReader::new(reader, handle)`"
+        note = "Wrap the reader in a `SpawnedReader` instead, e.g. `SpawnedReader::new(reader, handle)`. See also https://github.com/apache/arrow-rs/issues/10308"
     )]
     pub fn with_runtime(self, handle: Handle) -> Self {
         Self {


### PR DESCRIPTION
# Which issue does this PR close?

- Follow on to https://github.com/apache/arrow-rs/pull/10354

# Rationale for this change
I think it will help people who hit the deprecation message to leave links to relevant issue (https://github.com/apache/arrow-rs/issues/10308) so they can find relevant context

This is similar to https://github.com/apache/arrow-rs/pull/10502

# What changes are included in this PR?

Add some links to the deprecation issue

# Are these changes tested?
By CI
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
Better deprecation message