### PR TITLE
fix(parquet): preserve delta encoding for oversized values

### DIFF
--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -484,6 +484,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     }
 
     fn count_values_within_byte_budget_gather(
+        &self,
         values: &Self::Values,
         indices: &[usize],
         byte_budget: usize,
@@ -558,7 +559,23 @@ impl ColumnValueEncoder for ByteArrayEncoder {
             // type can reach here.
             data_type => unreachable!("ByteArrayEncoder cannot be constructed for {data_type:?}"),
         };
-        Some(count)
+        if count == indices.len() || self.dict_encoder.is_some() {
+            return Some(count);
+        }
+
+        let last_value = match &self.fallback.encoder {
+            FallbackEncoderImpl::Delta { last_value, .. } => last_value.as_slice(),
+            _ => return Some(count),
+        };
+        let delta_count = downcast_op!(
+            values.data_type(),
+            values,
+            count_delta_byte_array_within_budget,
+            indices,
+            byte_budget,
+            last_value
+        );
+        Some(count.max(delta_count))
     }
 
     fn num_values(&self) -> usize {
@@ -770,6 +787,56 @@ fn count_within_budget_offsets<T: ByteArrayType>(
         }
     }
     n
+}
+
+/// Returns a larger mini-batch when an oversized first value can prefix-compress
+/// subsequent values without consuming more than one additional page budget.
+fn count_delta_byte_array_within_budget<T>(
+    values: T,
+    indices: &[usize],
+    byte_budget: usize,
+    last_value: &[u8],
+) -> usize
+where
+    T: ArrayAccessor + Copy,
+    T::Item: AsRef<[u8]>,
+{
+    let Some(&first_idx) = indices.first() else {
+        return 0;
+    };
+    if values.value(first_idx).as_ref().len() <= byte_budget {
+        return 0;
+    }
+
+    let mut additional_size = 0usize;
+    for (position, &idx) in indices.iter().enumerate() {
+        let value = values.value(idx);
+        let value = value.as_ref();
+        let previous_value;
+        let previous = if position == 0 {
+            last_value
+        } else {
+            previous_value = values.value(indices[position - 1]);
+            previous_value.as_ref()
+        };
+        let prefix_length = previous
+            .iter()
+            .zip(value)
+            .take_while(|(left, right)| left == right)
+            .count();
+
+        if position != 0 {
+            // Account conservatively for the two delta-encoded i32 lengths in
+            // addition to the suffix bytes written to the page.
+            let encoded_size =
+                (value.len() - prefix_length).saturating_add(2 * std::mem::size_of::<i32>());
+            additional_size = additional_size.saturating_add(encoded_size);
+            if additional_size > byte_budget {
+                return position;
+            }
+        }
+    }
+    indices.len()
 }
 
 /// Computes the min and max for the provided array and indices

--- a/parquet/src/column/writer/byte_budget_chunker.rs
+++ b/parquet/src/column/writer/byte_budget_chunker.rs
@@ -137,6 +137,7 @@ impl ByteBudgetChunker {
             self.page_byte_limit
         };
         self.byte_budget_sub_batch_size::<E>(
+            encoder,
             values,
             value_indices,
             chunk_def,
@@ -152,8 +153,10 @@ impl ByteBudgetChunker {
     /// `#[inline(never)]` keeps this slow path out of the hot
     /// `write_batch_internal` loop; numeric and bool columns never reach it.
     #[inline(never)]
+    #[allow(clippy::too_many_arguments)]
     fn byte_budget_sub_batch_size<E: ColumnValueEncoder>(
         &self,
+        encoder: &E,
         values: &E::Values,
         value_indices: Option<&[usize]>,
         chunk_def: LevelDataRef<'_>,
@@ -177,11 +180,14 @@ impl ByteBudgetChunker {
             Some(idx) => {
                 let end = (values_offset + vals_in_chunk).min(idx.len());
                 let start = values_offset.min(end);
-                E::count_values_within_byte_budget_gather(values, &idx[start..end], budget)
+                encoder.count_values_within_byte_budget_gather(values, &idx[start..end], budget)
             }
-            None => {
-                E::count_values_within_byte_budget(values, values_offset, vals_in_chunk, budget)
-            }
+            None => encoder.count_values_within_byte_budget(
+                values,
+                values_offset,
+                vals_in_chunk,
+                budget,
+            ),
         };
         match fit {
             None => chunk_size,

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -107,6 +107,7 @@ pub trait ColumnValueEncoder {
     /// case is "one wide value, return 1." The variable-width walk only
     /// needs to be precise when the chunk is genuinely near the budget.
     fn count_values_within_byte_budget(
+        &self,
         _values: &Self::Values,
         _offset: usize,
         _len: usize,
@@ -119,6 +120,7 @@ pub trait ColumnValueEncoder {
     /// `indices` rather than a contiguous range. Returns the number of
     /// `indices` that fit, not the maximum index value.
     fn count_values_within_byte_budget_gather(
+        &self,
         _values: &Self::Values,
         _indices: &[usize],
         _byte_budget: usize,
@@ -284,6 +286,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn count_values_within_byte_budget(
+        &self,
         values: &[T::T],
         offset: usize,
         len: usize,
@@ -302,6 +305,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn count_values_within_byte_budget_gather(
+        &self,
         values: &[T::T],
         indices: &[usize],
         byte_budget: usize,

--- a/parquet/tests/arrow_writer_layout.rs
+++ b/parquet/tests/arrow_writer_layout.rs
@@ -28,7 +28,9 @@ use parquet::arrow::arrow_reader::{ArrowReaderOptions, ParquetRecordBatchReaderB
 use parquet::basic::{Encoding, PageType};
 use parquet::file::metadata::PageIndexPolicy;
 use parquet::file::metadata::ParquetMetaData;
-use parquet::file::properties::{EnabledStatistics, ReaderProperties, WriterProperties};
+use parquet::file::properties::{
+    EnabledStatistics, ReaderProperties, WriterProperties, WriterVersion,
+};
 use parquet::file::reader::SerializedPageReader;
 use parquet::schema::types::ColumnPath;
 use std::sync::Arc;
@@ -746,6 +748,47 @@ fn test_large_string() {
             }],
         },
     });
+}
+
+fn delta_byte_array_page_count(strings: Vec<String>) -> usize {
+    let array = Arc::new(StringArray::from(strings)) as _;
+    let batch = RecordBatch::try_from_iter([("col", array)]).unwrap();
+    let props = WriterProperties::builder()
+        .set_writer_version(WriterVersion::PARQUET_2_0)
+        .set_dictionary_enabled(false)
+        .set_encoding(Encoding::DELTA_BYTE_ARRAY)
+        .set_data_page_size_limit(16 * 1024)
+        .set_statistics_enabled(EnabledStatistics::None)
+        .build();
+
+    let mut buf = Vec::new();
+    let mut writer = ArrowWriter::try_new(&mut buf, batch.schema(), Some(props)).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+
+    let data = Bytes::from(buf);
+    let read_options =
+        ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::from(true));
+    let reader = ParquetRecordBatchReaderBuilder::try_new_with_options(data, read_options).unwrap();
+    let pages = &reader.metadata().offset_index().unwrap()[0][0].page_locations;
+
+    pages.len()
+}
+
+#[test]
+fn test_large_repeated_string_delta_encoding() {
+    let value_size = 64 * 1024;
+    let strings = (0..32).map(|_| "x".repeat(value_size)).collect();
+    assert_eq!(delta_byte_array_page_count(strings), 1);
+}
+
+#[test]
+fn test_large_distinct_string_delta_encoding() {
+    let value_size = 64 * 1024;
+    let strings = (0..32)
+        .map(|i| ((b'A' + i) as char).to_string().repeat(value_size))
+        .collect();
+    assert_eq!(delta_byte_array_page_count(strings), 32);
 }
 
 #[test]


### PR DESCRIPTION
# Which issue does this PR close?

  - Closes #10489.

  # Rationale for this change

  The byte-budget chunker estimates byte-array batches using their plain encoded size. For `DELTA_BYTE_ARRAY`, this splits repeated oversized values across pages and resets the prefix state, increasing the
  output from one large value plus small deltas to one full value per page

  # What changes are included in this PR?

  Use the active byte-array encoder state when sizing a mini-batch. After an oversized first delta value, subsequent prefix-compressed values can remain in the page while their suffixes fit within one
  additional page budget. Incompressible oversized values remain split across pages

  # Are these changes tested?

  Yea New Arrow writer layout tests cover both repeated and distinct 64 KiB values with a 16 KiB page limit. The focused layout suite, full `parquet` suite, package/workspace clippy, rustdoc, rustfmt, and
  diff checks pass

  # Are there any user-facing changes?

  Parquet files using `DELTA_BYTE_ARRAY` no longer lose prefix compression solely because individual values exceed the configured page size limit There are no public API changes.