### PR TITLE
Revert "chore: formalize the default map field names to match default arrow spec (#10297)"

### DIFF
--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -372,13 +372,9 @@ impl MapArray {
         let entry_offsets_buffer = Buffer::from(entry_offsets.to_byte_slice());
         let keys_data = StringArray::from_iter_values(keys);
 
-        let keys_field = Arc::new(Field::new(
-            Field::MAP_KEY_FIELD_DEFAULT_NAME,
-            DataType::Utf8,
-            false,
-        ));
+        let keys_field = Arc::new(Field::new("keys", DataType::Utf8, false));
         let values_field = Arc::new(Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            "values",
             values.data_type().clone(),
             values.null_count() > 0,
         ));
@@ -390,7 +386,7 @@ impl MapArray {
 
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 entry_struct.data_type().clone(),
                 false,
             )),
@@ -635,16 +631,8 @@ mod tests {
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
         let entry_offsets = Buffer::from([0, 3, 6, 8].to_byte_slice());
 
-        let keys = Arc::new(Field::new(
-            Field::MAP_KEY_FIELD_DEFAULT_NAME,
-            DataType::Int32,
-            false,
-        ));
-        let values = Arc::new(Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::UInt32,
-            false,
-        ));
+        let keys = Arc::new(Field::new("keys", DataType::Int32, false));
+        let values = Arc::new(Field::new("values", DataType::UInt32, false));
         let entry_struct = StructArray::from(vec![
             (keys, make_array(keys_data)),
             (values, make_array(values_data)),
@@ -653,7 +641,7 @@ mod tests {
         // Construct a map array from the above two
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 entry_struct.data_type().clone(),
                 false,
             )),
@@ -689,16 +677,8 @@ mod tests {
         //  [[0, 1, 2], [3, 4, 5], [6, 7]]
         let entry_offsets = Buffer::from([0, 3, 6, 8].to_byte_slice());
 
-        let keys_field = Arc::new(Field::new(
-            Field::MAP_KEY_FIELD_DEFAULT_NAME,
-            DataType::Int32,
-            false,
-        ));
-        let values_field = Arc::new(Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::UInt32,
-            true,
-        ));
+        let keys_field = Arc::new(Field::new("keys", DataType::Int32, false));
+        let values_field = Arc::new(Field::new("values", DataType::UInt32, true));
         let entry_struct = StructArray::from(vec![
             (keys_field.clone(), make_array(key_data)),
             (values_field.clone(), make_array(value_data.clone())),
@@ -707,7 +687,7 @@ mod tests {
         // Construct a map array from the above two
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 entry_struct.data_type().clone(),
                 false,
             )),
@@ -818,16 +798,8 @@ mod tests {
         //  [[3, 4, 5], [6, 7]]
         let entry_offsets = Buffer::from([0, 3, 5].to_byte_slice());
 
-        let keys = Arc::new(Field::new(
-            Field::MAP_KEY_FIELD_DEFAULT_NAME,
-            DataType::Int32,
-            false,
-        ));
-        let values = Arc::new(Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::UInt32,
-            false,
-        ));
+        let keys = Arc::new(Field::new("keys", DataType::Int32, false));
+        let values = Arc::new(Field::new("values", DataType::UInt32, false));
         let entry_struct = StructArray::from(vec![
             (keys, make_array(keys_data)),
             (values, make_array(values_data)),
@@ -836,7 +808,7 @@ mod tests {
         // Construct a map array from the above two
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 entry_struct.data_type().clone(),
                 false,
             )),
@@ -867,8 +839,8 @@ mod tests {
         // A DictionaryArray has similar buffer layout to a MapArray
         // but the meaning of the values differs
         let struct_t = DataType::Struct(Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, true),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, true),
+            Field::new("keys", DataType::Int32, true),
+            Field::new("values", DataType::UInt32, true),
         ]));
         let dict_t = DataType::Dictionary(Box::new(DataType::Int32), Box::new(struct_t));
         let _ = MapArray::from(ArrayData::new_empty(&dict_t));
@@ -899,16 +871,8 @@ mod tests {
 
         let key_array = Arc::new(StringArray::from(vec!["a", "b", "c"])) as ArrayRef;
         let value_array = Arc::new(UInt32Array::from(vec![0u32, 10, 20])) as ArrayRef;
-        let keys_field = Arc::new(Field::new(
-            Field::MAP_KEY_FIELD_DEFAULT_NAME,
-            DataType::Utf8,
-            false,
-        ));
-        let values_field = Arc::new(Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::UInt32,
-            false,
-        ));
+        let keys_field = Arc::new(Field::new("keys", DataType::Utf8, false));
+        let values_field = Arc::new(Field::new("values", DataType::UInt32, false));
         let struct_array =
             StructArray::from(vec![(keys_field, key_array), (values_field, value_array)]);
         assert_eq!(
@@ -932,8 +896,8 @@ mod tests {
     fn test_try_new() {
         let offsets = OffsetBuffer::new(vec![0, 1, 4, 5].into());
         let fields = Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, false),
+            Field::new("key", DataType::Int32, false),
+            Field::new("values", DataType::Int32, false),
         ]);
         let columns = vec![
             Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])) as _,
@@ -941,11 +905,7 @@ mod tests {
         ];
 
         let entries = StructArray::new(fields.clone(), columns, None);
-        let field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            DataType::Struct(fields),
-            false,
-        ));
+        let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
 
         MapArray::new(field.clone(), offsets.clone(), entries.clone(), None, false);
 
@@ -998,11 +958,7 @@ mod tests {
         ];
 
         let s = StructArray::new(fields.clone(), columns, None);
-        let field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            DataType::Struct(fields),
-            false,
-        ));
+        let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
         let err = MapArray::try_new(field, offsets, s, None, false).unwrap_err();
 
         assert_eq!(
@@ -1017,16 +973,12 @@ mod tests {
         let keys = Int32Array::from(vec![Some(1), None]);
         let values = Int32Array::from(vec![None, Some(2)]);
         let fields = Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, true),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+            Field::new("keys", DataType::Int32, true),
+            Field::new("values", DataType::Int32, true),
         ]);
         let entries =
             StructArray::new(fields.clone(), vec![Arc::new(keys), Arc::new(values)], None);
-        let field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            DataType::Struct(fields),
-            false,
-        ));
+        let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
 
         let err = MapArray::try_new(field, OffsetBuffer::from_lengths([2]), entries, None, false)
             .unwrap_err();

--- a/arrow-array/src/array/mod.rs
+++ b/arrow-array/src/array/mod.rs
@@ -1178,10 +1178,10 @@ mod tests {
     fn test_null_map() {
         let data_type = DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entry",
                 DataType::Struct(Fields::from(vec![
-                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+                    Field::new("key", DataType::Utf8, false),
+                    Field::new("value", DataType::Int32, true),
                 ])),
                 false,
             )),

--- a/arrow-array/src/builder/map_builder.rs
+++ b/arrow-array/src/builder/map_builder.rs
@@ -79,9 +79,9 @@ pub struct MapFieldNames {
 impl Default for MapFieldNames {
     fn default() -> Self {
         Self {
-            entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
-            key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
-            value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
+            entry: "entries".to_string(),
+            key: "keys".to_string(),
+            value: "values".to_string(),
         }
     }
 }
@@ -395,14 +395,10 @@ mod tests {
             map.data_type(),
             &DataType::Map(
                 Arc::new(Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    "entries",
                     DataType::Struct(
                         vec![
-                            Arc::new(Field::new(
-                                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                                DataType::Int32,
-                                false
-                            )),
+                            Arc::new(Field::new("keys", DataType::Int32, false)),
                             value_field.clone()
                         ]
                         .into()
@@ -423,14 +419,10 @@ mod tests {
             map.data_type(),
             &DataType::Map(
                 Arc::new(Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    "entries",
                     DataType::Struct(
                         vec![
-                            Arc::new(Field::new(
-                                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                                DataType::Int32,
-                                false
-                            )),
+                            Arc::new(Field::new("keys", DataType::Int32, false)),
                             value_field
                         ]
                         .into()
@@ -447,7 +439,7 @@ mod tests {
         let mut key_metadata = HashMap::new();
         key_metadata.insert("foo".to_string(), "bar".to_string());
         let key_field = Arc::new(
-            Field::new("other_key", DataType::Int32, false).with_metadata(key_metadata.clone()),
+            Field::new("keys", DataType::Int32, false).with_metadata(key_metadata.clone()),
         );
         let mut builder = MapBuilder::new(None, Int32Builder::new(), Int32Builder::new())
             .with_keys_field(key_field.clone());
@@ -461,18 +453,14 @@ mod tests {
             map.data_type(),
             &DataType::Map(
                 Arc::new(Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    "entries",
                     DataType::Struct(
                         vec![
                             Arc::new(
-                                Field::new("other_key", DataType::Int32, false)
+                                Field::new("keys", DataType::Int32, false)
                                     .with_metadata(key_metadata)
                             ),
-                            Arc::new(Field::new(
-                                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                                DataType::Int32,
-                                true
-                            ))
+                            Arc::new(Field::new("values", DataType::Int32, true))
                         ]
                         .into()
                     ),
@@ -523,11 +511,7 @@ mod tests {
     #[should_panic(expected = "Keys field must not be nullable")]
     fn test_with_nullable_keys_field() {
         let mut builder = MapBuilder::new(None, Int32Builder::new(), Int32Builder::new())
-            .with_keys_field(Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Int32,
-                true,
-            )));
+            .with_keys_field(Arc::new(Field::new("keys", DataType::Int32, true)));
 
         builder.keys().append_value(1);
         builder.values().append_value(2);
@@ -540,11 +524,7 @@ mod tests {
     #[should_panic(expected = "Incorrect datatype")]
     fn test_keys_field_type_mismatch() {
         let mut builder = MapBuilder::new(None, Int32Builder::new(), Int32Builder::new())
-            .with_keys_field(Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Utf8,
-                false,
-            )));
+            .with_keys_field(Arc::new(Field::new("keys", DataType::Utf8, false)));
 
         builder.keys().append_value(1);
         builder.values().append_value(2);

--- a/arrow-avro/benches/avro_writer.rs
+++ b/arrow-avro/benches/avro_writer.rs
@@ -623,18 +623,10 @@ static DECIMAL256_DATA: Lazy<Vec<RecordBatch>> = Lazy::new(|| {
 static MAP_DATA: Lazy<Vec<RecordBatch>> = Lazy::new(|| {
     use arrow_array::builder::{MapBuilder, StringBuilder};
 
-    let key_field = Arc::new(Field::new(
-        Field::MAP_KEY_FIELD_DEFAULT_NAME,
-        DataType::Utf8,
-        false,
-    ));
-    let value_field = Arc::new(Field::new(
-        Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-        DataType::Utf8,
-        true,
-    ));
+    let key_field = Arc::new(Field::new("keys", DataType::Utf8, false));
+    let value_field = Arc::new(Field::new("values", DataType::Utf8, true));
     let entry_struct = Field::new(
-        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+        "entries",
         DataType::Struct(vec![key_field.as_ref().clone(), value_field.as_ref().clone()].into()),
         false,
     );

--- a/arrow-avro/src/codec.rs
+++ b/arrow-avro/src/codec.rs
@@ -931,12 +931,12 @@ impl Codec {
             }
             Self::Struct(f) => DataType::Struct(f.iter().map(|x| x.field()).collect()),
             Self::Map(value_type) => {
-                let val_field = value_type.field_with_name(Field::MAP_VALUE_FIELD_DEFAULT_NAME);
+                let val_field = value_type.field_with_name("value");
                 DataType::Map(
                     Arc::new(Field::new(
-                        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                        "entries",
                         DataType::Struct(Fields::from(vec![
-                            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                            Field::new("key", DataType::Utf8, false),
                             val_field,
                         ])),
                         false,

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -3041,16 +3041,12 @@ mod test {
             list_builder.append(true);
         }
         arrays.push(Arc::new(list_builder.finish()));
-        let values_field = Arc::new(Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::Int64,
-            false,
-        ));
+        let values_field = Arc::new(Field::new("value", DataType::Int64, false));
         let mut map_builder = MapBuilder::new(
             Some(builder::MapFieldNames {
-                entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
-                key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
-                value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
+                entry: "entries".to_string(),
+                key: "key".to_string(),
+                value: "value".to_string(),
             }),
             StringBuilder::new(),
             Int64Builder::new(),
@@ -6275,9 +6271,9 @@ mod test {
         iaa_builder.append(true);
         let int_array_array = iaa_builder.finish();
         let field_names = MapFieldNames {
-            entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
-            key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
-            value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
+            entry: "entries".to_string(),
+            key: "key".to_string(),
+            value: "value".to_string(),
         };
         let mut int_map_builder =
             MapBuilder::new(Some(field_names), StringBuilder::new(), Int32Builder::new());
@@ -6289,9 +6285,9 @@ mod test {
         int_map_builder.append(true).unwrap(); // finalize map for row 0
         let int_map = int_map_builder.finish();
         let field_names2 = MapFieldNames {
-            entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
-            key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
-            value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
+            entry: "entries".to_string(),
+            key: "key".to_string(),
+            value: "value".to_string(),
         };
         let mut ima_builder = ListBuilder::new(MapBuilder::new(
             Some(field_names2),
@@ -6377,17 +6373,17 @@ mod test {
             .with_metadata(meta_h.clone());
         // G.value : Struct<{ h: ... }> with metadata (G)
         let g_value_struct_field = Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            "value",
             DataType::Struct(vec![h_field.clone()].into()),
             true,
         )
         .with_metadata(meta_g_value.clone());
         // entries struct for Map G
         let entries_struct_field = Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(
                 vec![
-                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                    Field::new("key", DataType::Utf8, false),
                     g_value_struct_field.clone(),
                 ]
                 .into(),
@@ -6446,9 +6442,9 @@ mod test {
                 },
                 {
                     let map_field_names = MapFieldNames {
-                        entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
-                        key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
-                        value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
+                        entry: "entries".to_string(),
+                        key: "key".to_string(),
+                        value: "value".to_string(),
                     };
                     let i_list_builder = ListBuilder::new(Float64Builder::new());
                     let h_struct_builder = StructBuilder::new(
@@ -6474,7 +6470,7 @@ mod test {
                     )
                     .with_values_field(Arc::new(
                         Field::new(
-                            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                            "value",
                             DataType::Struct(vec![h_field.clone()].into()),
                             true,
                         )
@@ -8708,11 +8704,11 @@ mod test {
         )
         .unwrap();
         let map_entries_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(Fields::from(vec![
-                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                Field::new("key", DataType::Utf8, false),
                 Field::new(
-                    Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                    "value",
                     DataType::Union(uf_map_vals.clone(), UnionMode::Dense),
                     true,
                 ),
@@ -8742,10 +8738,10 @@ mod test {
             Field::new("y", DataType::Binary, false),
         ]);
         let union_map_entries = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(Fields::from(vec![
-                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                Field::new("key", DataType::Utf8, false),
+                Field::new("value", DataType::Utf8, false),
             ])),
             false,
         ));
@@ -8924,10 +8920,10 @@ mod test {
             Field::new(item_name, DataType::Struct(kv_fields.clone()), false).with_metadata(kv_md),
         );
         let map_int_entries = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(Fields::from(vec![
-                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, false),
+                Field::new("key", DataType::Utf8, false),
+                Field::new("value", DataType::Int32, false),
             ])),
             false,
         ));
@@ -9170,8 +9166,8 @@ mod test {
                 let vals = Int32Array::from(vec![1, 2, 10]);
                 let entries = StructArray::new(
                     Fields::from(vec![
-                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                        Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, false),
+                        Field::new("key", DataType::Utf8, false),
+                        Field::new("value", DataType::Int32, false),
                     ]),
                     vec![Arc::new(keys) as ArrayRef, Arc::new(vals) as ArrayRef],
                     None,
@@ -9319,8 +9315,8 @@ mod test {
                     let vals = StringArray::from(vec!["v"]);
                     let entries = StructArray::new(
                         Fields::from(vec![
-                            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                            Field::new("key", DataType::Utf8, false),
+                            Field::new("value", DataType::Utf8, false),
                         ]),
                         vec![Arc::new(keys) as ArrayRef, Arc::new(vals) as ArrayRef],
                         None,
@@ -9398,9 +9394,9 @@ mod test {
             });
             let entries = StructArray::new(
                 Fields::from(vec![
-                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                    Field::new("key", DataType::Utf8, false),
                     Field::new(
-                        Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                        "value",
                         DataType::Union(uf_map_vals.clone(), UnionMode::Dense),
                         true,
                     ),

--- a/arrow-avro/src/reader/record.rs
+++ b/arrow-avro/src/reader/record.rs
@@ -505,15 +505,11 @@ impl Decoder {
                 Self::Record(arrow_fields.into(), encodings, field_defaults, projector)
             }
             (Codec::Map(child), _) => {
-                let val_field = child.field_with_name(ArrowField::MAP_VALUE_FIELD_DEFAULT_NAME);
+                let val_field = child.field_with_name("value");
                 let map_field = Arc::new(ArrowField::new(
-                    ArrowField::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    "entries",
                     DataType::Struct(Fields::from(vec![
-                        ArrowField::new(
-                            ArrowField::MAP_KEY_FIELD_DEFAULT_NAME,
-                            DataType::Utf8,
-                            false,
-                        ),
+                        ArrowField::new("key", DataType::Utf8, false),
                         val_field,
                     ])),
                     false,

--- a/arrow-avro/src/schema.rs
+++ b/arrow-avro/src/schema.rs
@@ -2991,19 +2991,11 @@ mod tests {
         let avro_list = AvroSchema::try_from(&list_schema).unwrap();
         assert_json_contains(&avro_list.json_string, "\"type\":\"array\"");
         assert_json_contains(&avro_list.json_string, "\"items\"");
-        let value_field = ArrowField::new(
-            arrow_schema::Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::Boolean,
-            true,
-        );
+        let value_field = ArrowField::new("value", DataType::Boolean, true);
         let entries_struct = ArrowField::new(
-            arrow_schema::Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(Fields::from(vec![
-                ArrowField::new(
-                    arrow_schema::Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                    DataType::Utf8,
-                    false,
-                ),
+                ArrowField::new("key", DataType::Utf8, false),
                 value_field.clone(),
             ])),
             false,
@@ -3201,19 +3193,11 @@ mod tests {
     #[cfg(feature = "avro_custom_types")]
     #[test]
     fn test_map_duration_value_extra() {
-        let val_field = ArrowField::new(
-            ArrowField::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::Duration(TimeUnit::Second),
-            true,
-        );
+        let val_field = ArrowField::new("value", DataType::Duration(TimeUnit::Second), true);
         let entries_struct = ArrowField::new(
-            ArrowField::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(Fields::from(vec![
-                ArrowField::new(
-                    ArrowField::MAP_KEY_FIELD_DEFAULT_NAME,
-                    DataType::Utf8,
-                    false,
-                ),
+                ArrowField::new("key", DataType::Utf8, false),
                 val_field,
             ])),
             false,
@@ -3260,19 +3244,11 @@ mod tests {
         );
         let expected_b = ArrowField::new("b", DataType::List(Arc::new(expected_list_item)), false);
 
-        let expected_map_value = ArrowField::new(
-            arrow_schema::Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::Float64,
-            false,
-        );
+        let expected_map_value = ArrowField::new("value", DataType::Float64, false);
         let expected_entries = ArrowField::new(
-            arrow_schema::Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(Fields::from(vec![
-                ArrowField::new(
-                    arrow_schema::Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                    DataType::Utf8,
-                    false,
-                ),
+                ArrowField::new("key", DataType::Utf8, false),
                 expected_map_value,
             ])),
             false,

--- a/arrow-avro/src/writer/encoder.rs
+++ b/arrow-avro/src/writer/encoder.rs
@@ -1011,7 +1011,7 @@ fn find_struct_child_index(fields: &arrow_schema::Fields, name: &str) -> Option<
 
 fn find_map_value_field_index(fields: &arrow_schema::Fields) -> Option<usize> {
     // Prefer common Arrow field names; fall back to second child if exactly two
-    find_struct_child_index(fields, Field::MAP_VALUE_FIELD_DEFAULT_NAME)
+    find_struct_child_index(fields, "value")
         .or_else(|| find_struct_child_index(fields, "values"))
         .or_else(|| if fields.len() == 2 { Some(1) } else { None })
 }
@@ -2893,8 +2893,8 @@ mod tests {
         let keys = StringArray::from(vec!["k1", "k2"]);
         let values = Int32Array::from(vec![1, 2]);
         let entries_fields = Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, true),
         ]);
         let entries = StructArray::new(
             entries_fields,
@@ -2903,12 +2903,7 @@ mod tests {
         );
         let offsets = arrow_buffer::OffsetBuffer::new(vec![0i32, 2, 2].into());
         let map = MapArray::new(
-            Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                entries.data_type().clone(),
-                false,
-            )
-            .into(),
+            Field::new("entries", entries.data_type().clone(), false).into(),
             offsets,
             entries,
             None,
@@ -3383,8 +3378,8 @@ mod tests {
         let values = Int32Array::from(vec![Some(7), None]);
 
         let entries_fields = Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, true),
         ]);
         let entries = StructArray::new(
             entries_fields,
@@ -3395,12 +3390,7 @@ mod tests {
         // Single row -> offsets [0, 2]
         let offsets = arrow_buffer::OffsetBuffer::new(vec![0i32, 2].into());
         let map = MapArray::new(
-            Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                entries.data_type().clone(),
-                false,
-            )
-            .into(),
+            Field::new("entries", entries.data_type().clone(), false).into(),
             offsets,
             entries,
             None,

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -9138,10 +9138,10 @@ mod tests {
         // Cast null from and to map
         let data_type = DataType::Map(
             Arc::new(Field::new_struct(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entry",
                 vec![
-                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+                    Field::new("key", DataType::Utf8, false),
+                    Field::new("value", DataType::Int32, true),
                 ],
                 false,
             )),
@@ -10142,7 +10142,15 @@ mod tests {
     fn test_cast_map_dont_allow_change_of_order() {
         let string_builder = StringBuilder::new();
         let value_builder = StringBuilder::new();
-        let mut builder = MapBuilder::new(None, string_builder, value_builder);
+        let mut builder = MapBuilder::new(
+            Some(MapFieldNames {
+                entry: "entries".to_string(),
+                key: "key".to_string(),
+                value: "value".to_string(),
+            }),
+            string_builder,
+            value_builder,
+        );
 
         builder.keys().append_value("0");
         builder.values().append_value("test_val_1");
@@ -10157,11 +10165,11 @@ mod tests {
         let new_ordered = true;
         let new_type = DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 DataType::Struct(
                     vec![
-                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                        Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                        Field::new("key", DataType::Utf8, false),
+                        Field::new("value", DataType::Utf8, false),
                     ]
                     .into(),
                 ),
@@ -10185,7 +10193,15 @@ mod tests {
     fn test_cast_map_dont_allow_when_container_cant_cast() {
         let string_builder = StringBuilder::new();
         let value_builder = IntervalDayTimeArray::builder(2);
-        let mut builder = MapBuilder::new(None, string_builder, value_builder);
+        let mut builder = MapBuilder::new(
+            Some(MapFieldNames {
+                entry: "entries".to_string(),
+                key: "key".to_string(),
+                value: "value".to_string(),
+            }),
+            string_builder,
+            value_builder,
+        );
 
         builder.keys().append_value("0");
         builder.values().append_value(IntervalDayTime::new(1, 1));
@@ -10200,15 +10216,11 @@ mod tests {
         let new_ordered = true;
         let new_type = DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 DataType::Struct(
                     vec![
-                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                        Field::new(
-                            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                            DataType::Duration(TimeUnit::Second),
-                            false,
-                        ),
+                        Field::new("key", DataType::Utf8, false),
+                        Field::new("value", DataType::Duration(TimeUnit::Second), false),
                     ]
                     .into(),
                 ),
@@ -10234,10 +10246,9 @@ mod tests {
         let value_builder = StringBuilder::new();
         let mut builder = MapBuilder::new(
             Some(MapFieldNames {
-                // Explicitly writing the name so it will be apparent from what names to what names are we converting to
-                entry: Field::MAP_ENTRIES_FIELD_DEFAULT_NAME.to_string(),
-                key: Field::MAP_KEY_FIELD_DEFAULT_NAME.to_string(),
-                value: Field::MAP_VALUE_FIELD_DEFAULT_NAME.to_string(),
+                entry: "entries".to_string(),
+                key: "key".to_string(),
+                value: "value".to_string(),
             }),
             string_builder,
             value_builder,
@@ -10307,7 +10318,15 @@ mod tests {
     fn test_cast_map_contained_values() {
         let string_builder = StringBuilder::new();
         let value_builder = Int8Builder::new();
-        let mut builder = MapBuilder::new(None, string_builder, value_builder);
+        let mut builder = MapBuilder::new(
+            Some(MapFieldNames {
+                entry: "entries".to_string(),
+                key: "key".to_string(),
+                value: "value".to_string(),
+            }),
+            string_builder,
+            value_builder,
+        );
 
         builder.keys().append_value("0");
         builder.values().append_value(44);
@@ -10320,11 +10339,11 @@ mod tests {
 
         let new_type = DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 DataType::Struct(
                     vec![
-                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                        Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                        Field::new("key", DataType::Utf8, false),
+                        Field::new("value", DataType::Utf8, false),
                     ]
                     .into(),
                 ),

--- a/arrow-cast/src/pretty.rs
+++ b/arrow-cast/src/pretty.rs
@@ -1486,7 +1486,7 @@ mod tests {
             Int32Builder::new(),
         )
         .with_values_field(
-            Field::new("my_values", DataType::Int32, true).with_metadata(money_metadata.clone()),
+            Field::new("values", DataType::Int32, true).with_metadata(money_metadata.clone()),
         );
         array
             .keys()

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -2884,7 +2884,7 @@ mod tests {
     #[test]
     fn should_fail_validation_when_having_map_entries_only_have_1_field() {
         let struct_data_type = DataType::Struct(Fields::from(vec![Field::new(
-            Field::MAP_KEY_FIELD_DEFAULT_NAME,
+            "key",
             DataType::Int32,
             false,
         )]));
@@ -2901,15 +2901,7 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(
-                Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                    struct_data_type,
-                    false,
-                )
-                .into(),
-                false,
-            ),
+            DataType::Map(Field::new("entries", struct_data_type, false).into(), false),
             1,
             None,
             0,
@@ -2939,8 +2931,8 @@ mod tests {
     #[test]
     fn should_fail_validation_when_having_map_entries_have_3_fields() {
         let struct_data_type = DataType::Struct(Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+            Field::new("key", DataType::Int32, false),
+            Field::new("values", DataType::Utf8, true),
             Field::new("other", DataType::Int32, true),
         ]));
 
@@ -2960,15 +2952,7 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(
-                Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                    struct_data_type,
-                    false,
-                )
-                .into(),
-                false,
-            ),
+            DataType::Map(Field::new("entries", struct_data_type, false).into(), false),
             1,
             None,
             0,
@@ -2998,8 +2982,8 @@ mod tests {
     #[test]
     fn should_fail_validation_when_having_nullable_map_keys() {
         let struct_data_type = DataType::Struct(Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, true),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+            Field::new("key", DataType::Int32, true),
+            Field::new("values", DataType::Utf8, true),
         ]));
 
         let key_array_data = valid_non_nullable_int32_array_data(2);
@@ -3015,15 +2999,7 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(
-                Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                    struct_data_type,
-                    false,
-                )
-                .into(),
-                false,
-            ),
+            DataType::Map(Field::new("entries", struct_data_type, false).into(), false),
             1,
             None,
             0,
@@ -3050,8 +3026,8 @@ mod tests {
     #[test]
     fn should_fail_validation_when_having_entries_is_nullable_for_map() {
         let struct_data_type = DataType::Struct(Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+            Field::new("key", DataType::Int32, false),
+            Field::new("values", DataType::Utf8, true),
         ]));
 
         let key_array_data = valid_non_nullable_int32_array_data(2);
@@ -3068,15 +3044,7 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(
-                Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                    struct_data_type,
-                    true,
-                )
-                .into(),
-                false,
-            ),
+            DataType::Map(Field::new("entries", struct_data_type, true).into(), false),
             1,
             None,
             0,
@@ -3104,8 +3072,8 @@ mod tests {
     #[test]
     fn should_allow_to_create_map_from_data() {
         let struct_data_type = DataType::Struct(Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+            Field::new("key", DataType::Int32, false),
+            Field::new("values", DataType::Utf8, true),
         ]));
 
         let key_array_data = valid_non_nullable_int32_array_data(2);
@@ -3121,15 +3089,7 @@ mod tests {
         };
 
         let results = test_both_builder_and_array_data(
-            DataType::Map(
-                Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                    struct_data_type,
-                    false,
-                )
-                .into(),
-                false,
-            ),
+            DataType::Map(Field::new("entries", struct_data_type, false).into(), false),
             1,
             None,
             0,
@@ -3175,10 +3135,10 @@ mod tests {
     fn empty_and_null_map_array_should_pass_validation() {
         let dt = DataType::Map(
             Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 DataType::Struct(Fields::from(vec![
-                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
-                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+                    Field::new("key", DataType::Int32, false),
+                    Field::new("values", DataType::Utf8, true),
                 ])),
                 false,
             )

--- a/arrow-flight/src/encode.rs
+++ b/arrow-flight/src/encode.rs
@@ -1503,19 +1503,9 @@ mod tests {
 
         let schema = Arc::new(Schema::new(vec![Field::new_map(
             "dict_map",
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            Field::new_dictionary(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::UInt16,
-                DataType::Utf8,
-                false,
-            ),
-            Field::new_dictionary(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                DataType::UInt16,
-                DataType::Utf8,
-                true,
-            ),
+            "entries",
+            Field::new_dictionary("keys", DataType::UInt16, DataType::Utf8, false),
+            Field::new_dictionary("values", DataType::UInt16, DataType::Utf8, true),
             false,
             false,
         )]));
@@ -1530,9 +1520,9 @@ mod tests {
         let mut decoder = FlightDataDecoder::new(encoder);
         let expected_schema = Schema::new(vec![Field::new_map(
             "dict_map",
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+            "entries",
+            Field::new("keys", DataType::Utf8, false),
+            Field::new("values", DataType::Utf8, true),
             false,
             false,
         )]);
@@ -1609,19 +1599,9 @@ mod tests {
 
         let schema = Arc::new(Schema::new(vec![Field::new_map(
             "dict_map",
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            Field::new_dictionary(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::UInt16,
-                DataType::Utf8,
-                false,
-            ),
-            Field::new_dictionary(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                DataType::UInt16,
-                DataType::Utf8,
-                true,
-            ),
+            "entries",
+            Field::new_dictionary("keys", DataType::UInt16, DataType::Utf8, false),
+            Field::new_dictionary("values", DataType::UInt16, DataType::Utf8, true),
             false,
             false,
         )]));

--- a/arrow-flight/src/sql/metadata/sql_info.rs
+++ b/arrow-flight/src/sql/metadata/sql_info.rs
@@ -179,11 +179,11 @@ static UNION_TYPE: Lazy<DataType> = Lazy::new(|| {
             "int32_to_int32_list_map",
             DataType::Map(
                 Arc::new(Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    "entries",
                     DataType::Struct(Fields::from(vec![
-                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
+                        Field::new("keys", DataType::Int32, false),
                         Field::new(
-                            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                            "values",
                             DataType::List(Arc::new(Field::new_list_field(DataType::Int32, true))),
                             true,
                         ),

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -86,22 +86,18 @@ pub fn canonicalize_schema(schema: &Schema) -> Schema {
             DataType::Map(child_field, sorted) => match child_field.data_type() {
                 DataType::Struct(fields) if fields.len() == 2 => {
                     let first_field = &fields[0];
-                    let key_field = Arc::new(Field::new(
-                        Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                        first_field.data_type().clone(),
-                        false,
-                    ));
+                    let key_field =
+                        Arc::new(Field::new("key", first_field.data_type().clone(), false));
                     let second_field = &fields[1];
                     let value_field = Arc::new(Field::new(
-                        Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                        "value",
                         second_field.data_type().clone(),
                         second_field.is_nullable(),
                     ));
 
                     let fields = Fields::from([key_field, value_field]);
                     let struct_type = DataType::Struct(fields);
-                    let child_field =
-                        Field::new(Field::MAP_ENTRIES_FIELD_DEFAULT_NAME, struct_type, false);
+                    let child_field = Field::new("entries", struct_type, false);
 
                     Arc::new(Field::new(
                         field.name().as_str(),

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -2748,7 +2748,7 @@ mod tests {
 
         #[allow(deprecated)]
         let keys_field = Arc::new(Field::new_dict(
-            Field::MAP_KEY_FIELD_DEFAULT_NAME,
+            "keys",
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
             false,
             1,
@@ -2756,7 +2756,7 @@ mod tests {
         ));
         #[allow(deprecated)]
         let values_field = Arc::new(Field::new_dict(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            "values",
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
             true,
             2,
@@ -2768,7 +2768,7 @@ mod tests {
         ]);
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 entry_struct.data_type().clone(),
                 false,
             )),
@@ -2959,7 +2959,7 @@ mod tests {
         let key_dict_array = DictionaryArray::new(key_dict_keys, utf8_view_array.clone());
         #[allow(deprecated)]
         let keys_field = Arc::new(Field::new_dict(
-            Field::MAP_KEY_FIELD_DEFAULT_NAME,
+            "keys",
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8View)),
             false,
             1,
@@ -2970,7 +2970,7 @@ mod tests {
         let value_dict_array = DictionaryArray::new(value_dict_keys, bin_view_array);
         #[allow(deprecated)]
         let values_field = Arc::new(Field::new_dict(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+            "values",
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::BinaryView)),
             true,
             2,
@@ -2983,7 +2983,7 @@ mod tests {
 
         let map_data_type = DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 entry_struct.data_type().clone(),
                 false,
             )),

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -4091,24 +4091,9 @@ mod tests {
 
     #[test]
     fn encode_map_array() {
-        let keys = Arc::new(Field::new(
-            Field::MAP_KEY_FIELD_DEFAULT_NAME,
-            DataType::UInt32,
-            false,
-        ));
-        let values = Arc::new(Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::UInt32,
-            true,
-        ));
-        let map_field = Field::new_map(
-            "map",
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            keys,
-            values,
-            false,
-            true,
-        );
+        let keys = Arc::new(Field::new("keys", DataType::UInt32, false));
+        let values = Arc::new(Field::new("values", DataType::UInt32, true));
+        let map_field = Field::new_map("map", "entries", keys, values, false, true);
         let schema = Arc::new(Schema::new(vec![map_field]));
 
         let values = Arc::new(generate_map_array_data());
@@ -4440,17 +4425,17 @@ mod tests {
 
         #[allow(deprecated)]
         let entries_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(
                 vec![
                     Field::new_dict(
-                        Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                        "key",
                         DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
                         false,
                         1,
                         false,
                     ),
-                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+                    Field::new("value", DataType::Int32, true),
                 ]
                 .into(),
             ),
@@ -4460,18 +4445,14 @@ mod tests {
         let entries = StructArray::from(vec![
             (
                 Arc::new(Field::new(
-                    Field::MAP_KEY_FIELD_DEFAULT_NAME,
+                    "key",
                     DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
                     false,
                 )),
                 Arc::new(dict_keys) as ArrayRef,
             ),
             (
-                Arc::new(Field::new(
-                    Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                    DataType::Int32,
-                    true,
-                )),
+                Arc::new(Field::new("value", DataType::Int32, true)),
                 Arc::new(values) as ArrayRef,
             ),
         ]);
@@ -4512,12 +4493,12 @@ mod tests {
 
         #[allow(deprecated)]
         let entries_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(
                 vec![
-                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+                    Field::new("key", DataType::Utf8, false),
                     Field::new_dict(
-                        Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                        "value",
                         DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
                         true,
                         2,
@@ -4531,16 +4512,12 @@ mod tests {
 
         let entries = StructArray::from(vec![
             (
-                Arc::new(Field::new(
-                    Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                    DataType::Utf8,
-                    false,
-                )),
+                Arc::new(Field::new("key", DataType::Utf8, false)),
                 Arc::new(keys) as ArrayRef,
             ),
             (
                 Arc::new(Field::new(
-                    Field::MAP_VALUE_FIELD_DEFAULT_NAME,
+                    "value",
                     DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
                     true,
                 )),

--- a/arrow-json/benches/json_reader.rs
+++ b/arrow-json/benches/json_reader.rs
@@ -363,11 +363,11 @@ fn build_map_values(rows: usize, entries: usize) -> Vec<Value> {
 
 fn build_map_schema() -> Arc<Schema> {
     let entries_field = Arc::new(Field::new(
-        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+        "entries",
         DataType::Struct(
             vec![
-                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int64, true),
+                Field::new("keys", DataType::Utf8, false),
+                Field::new("values", DataType::Int64, true),
             ]
             .into(),
         ),

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -1287,13 +1287,9 @@ mod tests {
         "#;
         let map = Field::new_map(
             "map",
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new_list(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                Field::new("element", DataType::Utf8, true),
-                true,
-            ),
+            "entries",
+            Field::new("key", DataType::Utf8, false),
+            Field::new_list("value", Field::new("element", DataType::Utf8, true), true),
             false,
             true,
         );
@@ -1329,9 +1325,9 @@ mod tests {
     fn test_map_non_nullable_value() {
         let map = Field::new_map(
             "map",
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, false),
+            "entries",
+            Field::new("keys", DataType::Utf8, false),
+            Field::new("values", DataType::Utf8, false),
             false,
             false,
         );
@@ -1346,7 +1342,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "Invalid argument error: Found unmasked nulls for non-nullable StructArray field \"value\""
+            "Invalid argument error: Found unmasked nulls for non-nullable StructArray field \"values\""
         );
     }
 
@@ -3065,9 +3061,9 @@ mod tests {
             Field::new("b", DataType::new_list(DataType::Int32, true), true),
             Field::new_map(
                 "c",
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+                "entries",
+                Field::new("keys", DataType::Utf8, false),
+                Field::new("values", DataType::Int32, true),
                 false,
                 false,
             ),
@@ -3255,10 +3251,10 @@ mod tests {
                 "map",
                 DataType::Map(
                     Arc::new(Field::new(
-                        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                        "entries",
                         DataType::Struct(Fields::from(vec![
-                            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+                            Field::new("keys", DataType::Utf8, false),
+                            Field::new("values", DataType::Utf8, true),
                         ])),
                         false, // not nullable
                     )),
@@ -3513,10 +3509,10 @@ mod tests {
                 "map",
                 DataType::Map(
                     Arc::new(Field::new(
-                        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                        "entries",
                         DataType::Struct(Fields::from(vec![
-                            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+                            Field::new("keys", DataType::Utf8, false),
+                            Field::new("values", DataType::Utf8, true),
                         ])),
                         false, // not nullable
                     )),
@@ -3574,10 +3570,10 @@ mod tests {
                 "map",
                 DataType::Map(
                     Arc::new(Field::new(
-                        Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                        "entries",
                         DataType::Struct(Fields::from(vec![
-                            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+                            Field::new("keys", DataType::Utf8, false),
+                            Field::new("values", DataType::Utf8, true),
                         ])),
                         false, // not nullable
                     )),

--- a/arrow-json/src/writer/mod.rs
+++ b/arrow-json/src/writer/mod.rs
@@ -1421,23 +1421,15 @@ mod tests {
     fn run_json_writer_map_with_keys(keys_array: ArrayRef) {
         let values_array = super::Int64Array::from(vec![10, 20, 30, 40, 50]);
 
-        let keys_field = Arc::new(Field::new(
-            Field::MAP_KEY_FIELD_DEFAULT_NAME,
-            keys_array.data_type().clone(),
-            false,
-        ));
-        let values_field = Arc::new(Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::Int64,
-            false,
-        ));
+        let keys_field = Arc::new(Field::new("keys", keys_array.data_type().clone(), false));
+        let values_field = Arc::new(Field::new("values", DataType::Int64, false));
         let entry_struct = StructArray::from(vec![
             (keys_field, keys_array.clone()),
             (values_field, Arc::new(values_array) as ArrayRef),
         ]);
 
         let entries_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             entry_struct.data_type().clone(),
             false,
         ));

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -4426,11 +4426,7 @@ mod tests {
     #[test]
     fn test_single_map_with_non_nullable_values() {
         // Use `with_values_field` on `MapBuilder` to set the values are not nullable
-        let value_field = Arc::new(Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::Int32,
-            false,
-        ));
+        let value_field = Arc::new(Field::new("values", DataType::Int32, false));
         let mut builder = MapBuilder::new(None, StringBuilder::new(), Int32Builder::new())
             .with_values_field(value_field);
         // Entry 0: {"a": 1, "b": 2}
@@ -4468,11 +4464,7 @@ mod tests {
     #[test]
     fn test_single_map_with_non_nullable_map_but_with_nullable_values() {
         // Map column is non-nullable, but values are nullable
-        let value_field = Arc::new(Field::new(
-            Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-            DataType::Int32,
-            true,
-        ));
+        let value_field = Arc::new(Field::new("values", DataType::Int32, true));
         let mut builder = MapBuilder::new(None, StringBuilder::new(), Int32Builder::new())
             .with_values_field(value_field);
 
@@ -4853,17 +4845,9 @@ mod tests {
         let nulls = NullBuffer::from_iter((0..len).map(|_| rng.random_bool(valid_percent)));
         let field = Arc::new(Field::new_map(
             "",
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                keys.data_type().clone(),
-                false,
-            ),
-            Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                values.data_type().clone(),
-                true,
-            ),
+            "entries",
+            Field::new("keys", keys.data_type().clone(), false),
+            Field::new("values", values.data_type().clone(), true),
             false,
             true,
         ));
@@ -6371,19 +6355,11 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 1, 1, 3].into());
         let entries_fields = vec![
-            Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Utf8,
-                false,
-            )),
-            Arc::new(Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                DataType::Null,
-                true,
-            )),
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(Field::new("values", DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6410,19 +6386,11 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 1, 1, 3].into());
         let entries_fields = vec![
-            Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Utf8,
-                false,
-            )),
-            Arc::new(Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                DataType::Null,
-                true,
-            )),
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(Field::new("values", DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6448,19 +6416,11 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0i32].into());
         let entries_fields = vec![
-            Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Utf8,
-                false,
-            )),
-            Arc::new(Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                DataType::Null,
-                true,
-            )),
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(Field::new("values", DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6484,19 +6444,11 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 1, 1, 3].into());
         let entries_fields = vec![
-            Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Utf8,
-                false,
-            )),
-            Arc::new(Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                DataType::Null,
-                true,
-            )),
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(Field::new("values", DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6522,19 +6474,11 @@ mod tests {
 
         let offsets = OffsetBuffer::new(vec![0, 0, 0, 0].into());
         let entries_fields = vec![
-            Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Utf8,
-                false,
-            )),
-            Arc::new(Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                DataType::Null,
-                true,
-            )),
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(Field::new("values", DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6563,19 +6507,11 @@ mod tests {
         let inner_null_values = Arc::new(NullArray::new(3)) as ArrayRef;
 
         let inner_entries_fields = vec![
-            Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Utf8,
-                false,
-            )),
-            Arc::new(Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                DataType::Null,
-                true,
-            )),
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(Field::new("values", DataType::Null, true)),
         ];
         let inner_struct_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(inner_entries_fields.clone().into()),
             false,
         ));
@@ -6599,19 +6535,11 @@ mod tests {
 
         let inner_map_type = DataType::Map(inner_struct_field.clone(), false);
         let outer_entries_fields = vec![
-            Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Utf8,
-                false,
-            )),
-            Arc::new(Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                inner_map_type,
-                true,
-            )),
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(Field::new("values", inner_map_type, true)),
         ];
         let outer_struct_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(outer_entries_fields.clone().into()),
             false,
         ));
@@ -6646,19 +6574,11 @@ mod tests {
         let null_values = Arc::new(NullArray::new(3)) as ArrayRef;
 
         let entries_fields = vec![
-            Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Utf8,
-                false,
-            )),
-            Arc::new(Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                DataType::Null,
-                true,
-            )),
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(Field::new("values", DataType::Null, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));
@@ -6705,19 +6625,11 @@ mod tests {
 
         let list_type = list_array.data_type().clone();
         let entries_fields = vec![
-            Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Utf8,
-                false,
-            )),
-            Arc::new(Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                list_type,
-                true,
-            )),
+            Arc::new(Field::new("keys", DataType::Utf8, false)),
+            Arc::new(Field::new("values", list_type, true)),
         ];
         let struct_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(entries_fields.clone().into()),
             false,
         ));

--- a/arrow-schema/src/datatype_display.rs
+++ b/arrow-schema/src/datatype_display.rs
@@ -432,11 +432,11 @@ mod tests {
     #[test]
     fn test_display_map() {
         let entry_field = Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(
                 vec![
-                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+                    Field::new("key", DataType::Utf8, false),
+                    Field::new("value", DataType::Int32, true),
                 ]
                 .into(),
             ),
@@ -450,11 +450,11 @@ mod tests {
 
         // Test with metadata
         let mut entry_field_with_metadata = Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(
                 vec![
-                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+                    Field::new("key", DataType::Utf8, false),
+                    Field::new("value", DataType::Int32, true),
                 ]
                 .into(),
             ),

--- a/arrow-schema/src/datatype_parse.rs
+++ b/arrow-schema/src/datatype_parse.rs
@@ -1209,9 +1209,9 @@ mod test {
             DataType::Map(
                 Arc::new(Field::new_map(
                     "nested_map",
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+                    "entries",
+                    Field::new("key", DataType::Utf8, false),
+                    Field::new("value", DataType::Int32, true),
                     false,
                     true,
                 )),

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -957,19 +957,13 @@ mod tests {
 
     #[test]
     fn test_map_keys_sorted() {
-        let keys = Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false);
-        let values = Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::UInt32, false);
+        let keys = Field::new("keys", DataType::Int32, false);
+        let values = Field::new("values", DataType::UInt32, false);
         let entry_struct = DataType::Struct(vec![keys, values].into());
 
         // Construct a map array from the above two
-        let map_data_type = DataType::Map(
-            Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                entry_struct,
-                false,
-            )),
-            true,
-        );
+        let map_data_type =
+            DataType::Map(Arc::new(Field::new("entries", entry_struct, false)), true);
 
         let arrow_schema = FFI_ArrowSchema::try_from(map_data_type).unwrap();
         assert!(arrow_schema.map_keys_sorted());

--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -181,18 +181,6 @@ impl AsRef<Field> for Field {
 impl Field {
     /// Default list member field name
     pub const LIST_FIELD_DEFAULT_NAME: &'static str = "item";
-    /// Default field name for the entries field for Map
-    ///
-    /// See [Arrow Spec](https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138))
-    pub const MAP_ENTRIES_FIELD_DEFAULT_NAME: &'static str = "entries";
-    /// Default field name for the key field for Map
-    ///
-    /// See [Arrow Spec](https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138))
-    pub const MAP_KEY_FIELD_DEFAULT_NAME: &'static str = "key";
-    /// Default field name for the value field for Map
-    ///
-    /// See [Arrow Spec](https://github.com/apache/arrow/blob/b19c4761b558ade94ae05743062d92aacedef10e/format/Schema.fbs#L127-L138))
-    pub const MAP_VALUE_FIELD_DEFAULT_NAME: &'static str = "value";
 
     /// Creates a new field with the given name, data type, and nullability
     ///

--- a/arrow-schema/src/fields.rs
+++ b/arrow-schema/src/fields.rs
@@ -675,13 +675,9 @@ mod tests {
             ),
             Field::new_map(
                 "g",
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                Field::new(
-                    Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                    DataType::LargeUtf8,
-                    false,
-                ),
-                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+                "entries",
+                Field::new("keys", DataType::LargeUtf8, false),
+                Field::new("values", DataType::Int32, true),
                 false,
                 false,
             ),

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -849,9 +849,9 @@ mod tests {
     fn test_create_map_array() {
         let map_field = Field::new_map(
             "map",
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+            "entries",
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Utf8, true),
             false,
             false,
         );

--- a/arrow/tests/array_transform.rs
+++ b/arrow/tests/array_transform.rs
@@ -798,19 +798,11 @@ fn test_map_nulls_append() {
 
     let expected_entry_array = StructArray::from(vec![
         (
-            Arc::new(Field::new(
-                Field::MAP_KEY_FIELD_DEFAULT_NAME,
-                DataType::Int64,
-                false,
-            )),
+            Arc::new(Field::new("keys", DataType::Int64, false)),
             Arc::new(expected_key_array) as ArrayRef,
         ),
         (
-            Arc::new(Field::new(
-                Field::MAP_VALUE_FIELD_DEFAULT_NAME,
-                DataType::Int64,
-                true,
-            )),
+            Arc::new(Field::new("values", DataType::Int64, true)),
             Arc::new(expected_value_array) as ArrayRef,
         ),
     ]);
@@ -820,10 +812,10 @@ fn test_map_nulls_append() {
     let expected_list_data = ArrayData::try_new(
         DataType::Map(
             Arc::new(Field::new(
-                Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                "entries",
                 DataType::Struct(Fields::from(vec![
-                    Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int64, false),
-                    Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int64, true),
+                    Field::new("keys", DataType::Int64, false),
+                    Field::new("values", DataType::Int64, true),
                 ])),
                 false,
             )),

--- a/parquet-variant-compute/src/arrow_to_variant.rs
+++ b/parquet-variant-compute/src/arrow_to_variant.rs
@@ -1378,8 +1378,8 @@ mod tests {
         let keys = StringArray::from(vec!["key1", "key2", "key3"]);
         let values = Int32Array::from(vec![1, 2, 3]);
         let entries_fields = Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, true),
         ]);
         let entries = StructArray::new(
             entries_fields.clone(),
@@ -1399,7 +1399,7 @@ mod tests {
 
         // Create the map field
         let map_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(entries_fields),
             false, // Keys are non-nullable
         ));

--- a/parquet-variant-compute/src/cast_to_variant.rs
+++ b/parquet-variant-compute/src/cast_to_variant.rs
@@ -1983,8 +1983,8 @@ mod tests {
         let keys = StringArray::from(vec!["key1", "key2", "key3"]);
         let values = Int32Array::from(vec![1, 2, 3]);
         let entries_fields = Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, true),
         ]);
         let entries = StructArray::new(
             entries_fields.clone(),
@@ -1999,7 +1999,7 @@ mod tests {
         let null_buffer = Some(NullBuffer::from(vec![true, true, false, true]));
 
         let map_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(entries_fields),
             false,
         ));
@@ -2039,8 +2039,8 @@ mod tests {
     fn test_cast_to_variant_map_with_non_string_keys() {
         let offsets = OffsetBuffer::new(vec![0, 1, 3].into());
         let fields = Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Int32, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, false),
+            Field::new("key", DataType::Int32, false),
+            Field::new("values", DataType::Int32, false),
         ]);
         let columns = vec![
             Arc::new(Int32Array::from(vec![1, 2, 3])) as _,
@@ -2048,11 +2048,7 @@ mod tests {
         ];
 
         let entries = StructArray::new(fields.clone(), columns, None);
-        let field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-            DataType::Struct(fields),
-            false,
-        ));
+        let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
 
         let map_array = MapArray::new(field.clone(), offsets.clone(), entries.clone(), None, false);
 

--- a/parquet-variant-compute/src/shred_variant.rs
+++ b/parquet-variant-compute/src/shred_variant.rs
@@ -1471,10 +1471,10 @@ mod tests {
             ),
             DataType::Map(
                 Arc::new(Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    "entries",
                     DataType::Struct(Fields::from(vec![
-                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                        Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Int32, true),
+                        Field::new("key", DataType::Utf8, false),
+                        Field::new("value", DataType::Int32, true),
                     ])),
                     false,
                 )),

--- a/parquet-variant-compute/src/variant_to_arrow.rs
+++ b/parquet-variant-compute/src/variant_to_arrow.rs
@@ -1460,10 +1460,10 @@ mod tests {
         let item_field = Arc::new(Field::new("item", DataType::Int32, true));
         let struct_fields = Fields::from(vec![Field::new("child", DataType::Int32, true)]);
         let map_entries_field = Arc::new(Field::new(
-            Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+            "entries",
             DataType::Struct(Fields::from(vec![
-                Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-                Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Float64, true),
+                Field::new("key", DataType::Utf8, false),
+                Field::new("value", DataType::Float64, true),
             ])),
             true,
         ));

--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -158,10 +158,10 @@ mod tests {
             "map",
             ArrowType::Map(
                 Arc::new(Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
+                    "entries",
                     ArrowType::Struct(Fields::from(vec![
-                        Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, ArrowType::Utf8, false),
-                        Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, ArrowType::Int32, true),
+                        Field::new("keys", ArrowType::Utf8, false),
+                        Field::new("values", ArrowType::Int32, true),
                     ])),
                     false,
                 )),

--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -1908,17 +1908,13 @@ mod tests {
         {"stocks":{"hedged": "$YYY", "long": null, "short": "$D"}}
         "#;
         let entries_struct_type = DataType::Struct(Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Utf8, true),
         ]));
         let stocks_field = Field::new(
             "stocks",
             DataType::Map(
-                Arc::new(Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                    entries_struct_type,
-                    false,
-                )),
+                Arc::new(Field::new("entries", entries_struct_type, false)),
                 false,
             ),
             // not nullable, so the keys have max level = 1

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2752,17 +2752,13 @@ mod tests {
         {"stocks":{"hedged": "$YYY", "long": null, "short": "$D"}}
         "#;
         let entries_struct_type = DataType::Struct(Fields::from(vec![
-            Field::new(Field::MAP_KEY_FIELD_DEFAULT_NAME, DataType::Utf8, false),
-            Field::new(Field::MAP_VALUE_FIELD_DEFAULT_NAME, DataType::Utf8, true),
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Utf8, true),
         ]));
         let stocks_field = Field::new(
             "stocks",
             DataType::Map(
-                Arc::new(Field::new(
-                    Field::MAP_ENTRIES_FIELD_DEFAULT_NAME,
-                    entries_struct_type,
-                    false,
-                )),
+                Arc::new(Field::new("entries", entries_struct_type, false)),
                 false,
             ),
             true,
@@ -3901,9 +3897,9 @@ mod tests {
             Field::new_list("my_list", Field::new("item", DataType::Int32, false), false);
         let map_field = Field::new_map(
             "my_map",
-            "my_entries",
-            Field::new("my_keys", DataType::Int32, false),
-            Field::new("my_values", DataType::Int32, true),
+            "entries",
+            Field::new("keys", DataType::Int32, false),
+            Field::new("values", DataType::Int32, true),
             false,
             true,
         );
@@ -3931,9 +3927,9 @@ mod tests {
         let map_field = &schema.get_fields()[1].get_fields()[0];
         // Coerced name of "entries" should be "key_value"
         assert_eq!(map_field.name(), "key_value");
-        // Coerced name of "my_keys" should be "key"
+        // Coerced name of "keys" should be "key"
         assert_eq!(map_field.get_fields()[0].name(), "key");
-        // Coerced name of "my_values" should be "value"
+        // Coerced name of "values" should be "value"
         assert_eq!(map_field.get_fields()[1].name(), "value");
 
         // Double check schema after reading from the file

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -1731,9 +1731,9 @@ mod tests {
             ),
             Field::new_map(
                 "my_map",
-                "my_entries",
-                Field::new("my_keys", DataType::Utf8, false),
-                Field::new("my_values", DataType::Int32, true),
+                "entries",
+                Field::new("keys", DataType::Utf8, false),
+                Field::new("values", DataType::Int32, true),
                 false,
                 true,
             ),
@@ -1776,9 +1776,9 @@ mod tests {
                 }
             }
             OPTIONAL GROUP my_map (MAP) {
-                REPEATED GROUP my_entries {
-                    REQUIRED BINARY my_keys (STRING);
-                    OPTIONAL INT32 my_values;
+                REPEATED GROUP entries {
+                    REQUIRED BINARY keys (STRING);
+                    OPTIONAL INT32 values;
                 }
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

cc @Jefffrey and @rluvaton 

# Rationale for this change

#10297 changed the default map field names from `keys`/`values` to `key`/`value` to match the Arrow spec. This is a good change to align with the spec, but it is a breaking change: it broke the DataFusion upgrade (https://github.com/apache/datafusion/pull/24030) because data produced elsewhere (e.g. by other Arrow implementations) uses the old `keys`/`values` field names, causing schema mismatches such as:

```
InvalidArgumentError("Incorrect datatype for StructArray field \"metadata\", expected Map(\"entries\": non-null Struct(\"keys\": non-null Utf8, \"values\": Utf8), unsorted) got Map(\"entries\": non-null Struct(\"key\": non-null Utf8, \"value\": Utf8), unsorted)")
```

See discussion on #10297: https://github.com/apache/arrow-rs/pull/10297#issuecomment-5147036600

We should hold the field name change for the next breaking release to minimize downstream churn on a minor release, rather than ship it in a minor release.

# What changes are included in this PR?

- Reverts b963ecf64745367274a4903f73a49b52958e412d (#10297), restoring the default map field names to `keys`/`values` (plural).
- Updates a test added by #10475 after #10297 merged 

# Are these changes tested?

Existing tests.

# Are there any user-facing changes?

Yes: this reverts the default `MapFieldNames` back to `keys`/`values` (as it was prior to #10297), rather than `key`/`value`. The intent is to reapply #10297 as part of the next breaking release.