### PR TITLE
Add Miri to more crates

### DIFF
--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -8,17 +8,26 @@
 set -e
 
 CRATES="
+    -p arrow
     -p arrow-arith
     -p arrow-array
+    -p arrow-avro
     -p arrow-buffer
+    -p arrow-cast
+    -p arrow-csv
     -p arrow-data
+    -p arrow-ipc
+    -p arrow-json
     -p arrow-ord
+    -p arrow-row
     -p arrow-schema
     -p arrow-select
+    -p arrow-string
 "
 
 setup_miri() {
     export MIRIFLAGS="-Zmiri-disable-isolation"
+    export INSTA_WORKSPACE_ROOT="$PWD"
     cargo miri setup
     cargo clean
 }

--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -7,6 +7,16 @@
 
 set -e
 
+CRATES="
+    -p arrow-arith
+    -p arrow-array
+    -p arrow-buffer
+    -p arrow-data
+    -p arrow-ord
+    -p arrow-schema
+    -p arrow-select
+"
+
 setup_miri() {
     export MIRIFLAGS="-Zmiri-disable-isolation"
     cargo miri setup
@@ -20,9 +30,7 @@ case $# in
 
         echo "Starting Arrow MIRI run..."
         cargo miri nextest run \
-        -p arrow-buffer -p arrow-data \
-        -p arrow-schema -p arrow-ord \
-        -p arrow-array -p arrow-arith \
+        $CRATES \
         --features ffi --no-fail-fast
     ;;
     2)
@@ -34,9 +42,7 @@ case $# in
         echo "Starting Arrow MIRI run partition ${partition} out of ${total}..."
         cargo miri nextest run \
         --partition slice:"${partition}"/"${total}" \
-        -p arrow-buffer -p arrow-data \
-        -p arrow-schema -p arrow-ord \
-        -p arrow-array -p arrow-arith \
+        $CRATES \
         --features ffi --no-fail-fast
     ;;
     *)

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -30,18 +30,21 @@ on:
     paths:
       - .github/**
       - rust-toolchain.toml
+      - arrow/**
+      - arrow-arith/**
       - arrow-array/**
+      - arrow-avro/**
       - arrow-buffer/**
       - arrow-cast/**
       - arrow-csv/**
       - arrow-data/**
       - arrow-ipc/**
       - arrow-json/**
-      - arrow-avro/**
+      - arrow-ord/**
+      - arrow-row/**
       - arrow-schema/**
       - arrow-select/**
       - arrow-string/**
-      - arrow/**
 
 permissions:
   contents: read

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -28,6 +28,8 @@ on:
       - main
   pull_request:
     paths:
+      - Cargo.toml
+      - Cargo.lock
       - .github/**
       - rust-toolchain.toml
       - arrow/**

--- a/arrow-array/src/arithmetic.rs
+++ b/arrow-array/src/arithmetic.rs
@@ -466,6 +466,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_native_type_comparison() {
         // is_eq
         assert!(8_i8.is_eq(8_i8));
@@ -529,6 +530,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_native_type_add() {
         // add_wrapping
         assert_eq!(8_i8.add_wrapping(2_i8), 10_i8);
@@ -576,6 +578,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_native_type_sub() {
         // sub_wrapping
         assert_eq!(8_i8.sub_wrapping(2_i8), 6_i8);
@@ -623,6 +626,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_native_type_mul() {
         // mul_wrapping
         assert_eq!(8_i8.mul_wrapping(2_i8), 16_i8);
@@ -670,6 +674,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_native_type_div() {
         // div_wrapping
         assert_eq!(8_i8.div_wrapping(2_i8), 4_i8);
@@ -717,6 +722,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_native_type_mod() {
         // mod_wrapping
         assert_eq!(9_i8.mod_wrapping(2_i8), 1_i8);
@@ -764,6 +770,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_native_type_neg() {
         // neg_wrapping
         assert_eq!(8_i8.neg_wrapping(), -8_i8);
@@ -803,6 +810,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_native_type_pow() {
         // pow_wrapping
         assert_eq!(8_i8.pow_wrapping(2_u32), 64_i8);

--- a/arrow-array/src/arithmetic.rs
+++ b/arrow-array/src/arithmetic.rs
@@ -466,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_native_type_comparison() {
         // is_eq
         assert!(8_i8.is_eq(8_i8));
@@ -530,7 +530,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_native_type_add() {
         // add_wrapping
         assert_eq!(8_i8.add_wrapping(2_i8), 10_i8);
@@ -578,7 +578,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_native_type_sub() {
         // sub_wrapping
         assert_eq!(8_i8.sub_wrapping(2_i8), 6_i8);
@@ -626,7 +626,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_native_type_mul() {
         // mul_wrapping
         assert_eq!(8_i8.mul_wrapping(2_i8), 16_i8);
@@ -674,7 +674,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_native_type_div() {
         // div_wrapping
         assert_eq!(8_i8.div_wrapping(2_i8), 4_i8);
@@ -722,7 +722,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_native_type_mod() {
         // mod_wrapping
         assert_eq!(9_i8.mod_wrapping(2_i8), 1_i8);
@@ -770,7 +770,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_native_type_neg() {
         // neg_wrapping
         assert_eq!(8_i8.neg_wrapping(), -8_i8);
@@ -810,7 +810,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_native_type_pow() {
         // pow_wrapping
         assert_eq!(8_i8.pow_wrapping(2_u32), 64_i8);

--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -1098,6 +1098,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_boolean_array_builder() {
         // Test building a boolean array with ArrayData builder and offset
         // 000011011
@@ -1349,6 +1350,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_bitwise_unary_not() {
         let arr = BooleanArray::from(vec![true, false, true, false]);
         let result = arr.bitwise_unary(|x| !x);
@@ -1357,6 +1359,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_bitwise_unary_preserves_nulls() {
         let arr = BooleanArray::from(vec![Some(true), None, Some(false), Some(true)]);
         let result = arr.bitwise_unary(|x| !x);
@@ -1369,6 +1372,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_bitwise_unary_mut_unshared() {
         let arr = BooleanArray::from(vec![true, false, true, false]);
         let info = PointerInfo::new(&arr);
@@ -1379,6 +1383,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_bitwise_unary_mut_shared() {
         let arr = BooleanArray::from(vec![true, false, true, false]);
         let info = PointerInfo::new(&arr);
@@ -1392,6 +1397,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_bitwise_unary_mut_with_nulls() {
         let arr = BooleanArray::from(vec![Some(true), None, Some(false)]);
         let result = arr.bitwise_unary_mut(|x| !x).unwrap();
@@ -1573,6 +1579,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_bitwise_unary_sliced() {
         // Slicing creates a non-zero offset into the underlying buffer.
         let arr = BooleanArray::from(vec![true, false, true, true, false]);
@@ -1586,6 +1593,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_bitwise_unary_mut_sliced() {
         // Slicing shares the buffer, so _mut must return Err.
         let arr = BooleanArray::from(vec![true, false, true, true, false]);

--- a/arrow-array/src/array/boolean_array.rs
+++ b/arrow-array/src/array/boolean_array.rs
@@ -1098,7 +1098,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_boolean_array_builder() {
         // Test building a boolean array with ArrayData builder and offset
         // 000011011
@@ -1350,7 +1350,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_bitwise_unary_not() {
         let arr = BooleanArray::from(vec![true, false, true, false]);
         let result = arr.bitwise_unary(|x| !x);
@@ -1359,7 +1359,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_bitwise_unary_preserves_nulls() {
         let arr = BooleanArray::from(vec![Some(true), None, Some(false), Some(true)]);
         let result = arr.bitwise_unary(|x| !x);
@@ -1372,7 +1372,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_bitwise_unary_mut_unshared() {
         let arr = BooleanArray::from(vec![true, false, true, false]);
         let info = PointerInfo::new(&arr);
@@ -1383,7 +1383,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_bitwise_unary_mut_shared() {
         let arr = BooleanArray::from(vec![true, false, true, false]);
         let info = PointerInfo::new(&arr);
@@ -1397,7 +1397,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_bitwise_unary_mut_with_nulls() {
         let arr = BooleanArray::from(vec![Some(true), None, Some(false)]);
         let result = arr.bitwise_unary_mut(|x| !x).unwrap();
@@ -1579,7 +1579,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_bitwise_unary_sliced() {
         // Slicing creates a non-zero offset into the underlying buffer.
         let arr = BooleanArray::from(vec![true, false, true, true, false]);
@@ -1593,7 +1593,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_bitwise_unary_mut_sliced() {
         // Slicing shares the buffer, so _mut must return Err.
         let arr = BooleanArray::from(vec![true, false, true, true, false]);

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -1473,13 +1473,13 @@ mod test {
             // TODO: avoid requiring snappy for this file
             #[cfg(feature = "snappy")]
             "avro/alltypes_plain.avro",
-            #[cfg(feature = "snappy")]
+            #[cfg(all(feature = "snappy", not(miri)))]
             "avro/alltypes_plain.snappy.avro",
-            #[cfg(feature = "zstd")]
+            #[cfg(all(feature = "zstd", not(miri)))]
             "avro/alltypes_plain.zstandard.avro",
-            #[cfg(feature = "bzip2")]
+            #[cfg(all(feature = "bzip2", not(miri)))]
             "avro/alltypes_plain.bzip2.avro",
-            #[cfg(feature = "xz")]
+            #[cfg(all(feature = "xz", not(miri)))]
             "avro/alltypes_plain.xz.avro",
         ]
         .into_iter()
@@ -3263,6 +3263,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_skippable_types_project_each_field_individually() {
         let path = "test/data/skippable_types.avro";
         let full = read_file(path, 1024, false);
@@ -3640,6 +3641,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_union_schema_resolution_all_type_combinations() {
         let path = "test/data/union_fields.avro";
         let baseline = read_file(path, 1024, false);
@@ -8276,6 +8278,7 @@ mod test {
         );
     }
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn comprehensive_e2e_resolution_test() {
         use serde_json::Value;
         use std::collections::HashMap;

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -1473,6 +1473,7 @@ mod test {
             // TODO: avoid requiring snappy for this file
             #[cfg(feature = "snappy")]
             "avro/alltypes_plain.avro",
+            // Compression codecs are unsupported by Miri
             #[cfg(all(feature = "snappy", not(miri)))]
             "avro/alltypes_plain.snappy.avro",
             #[cfg(all(feature = "zstd", not(miri)))]

--- a/arrow-avro/src/writer/mod.rs
+++ b/arrow-avro/src/writer/mod.rs
@@ -826,6 +826,7 @@ mod tests {
             // TODO: avoid requiring snappy for this file
             #[cfg(feature = "snappy")]
             "avro/alltypes_plain.avro",
+            // Compression codecs are unsupported by Miri
             #[cfg(all(feature = "snappy", not(miri)))]
             "avro/alltypes_plain.snappy.avro",
             #[cfg(all(feature = "zstd", not(miri)))]
@@ -3522,7 +3523,7 @@ mod tests {
 
     #[cfg(not(feature = "avro_custom_types"))]
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_roundtrip_float16_no_custom_widens_to_float32() {
         assert_round_trip_widened(
             Arc::new(Float16Array::from(vec![
@@ -3787,7 +3788,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn e2e_types_and_schema_alignment() -> Result<(), AvroError> {
         // Values are chosen to:
         // - exercise full UInt64 range when `avro_custom_types` is enabled

--- a/arrow-avro/src/writer/mod.rs
+++ b/arrow-avro/src/writer/mod.rs
@@ -826,13 +826,13 @@ mod tests {
             // TODO: avoid requiring snappy for this file
             #[cfg(feature = "snappy")]
             "avro/alltypes_plain.avro",
-            #[cfg(feature = "snappy")]
+            #[cfg(all(feature = "snappy", not(miri)))]
             "avro/alltypes_plain.snappy.avro",
-            #[cfg(feature = "zstd")]
+            #[cfg(all(feature = "zstd", not(miri)))]
             "avro/alltypes_plain.zstandard.avro",
-            #[cfg(feature = "bzip2")]
+            #[cfg(all(feature = "bzip2", not(miri)))]
             "avro/alltypes_plain.bzip2.avro",
-            #[cfg(feature = "xz")]
+            #[cfg(all(feature = "xz", not(miri)))]
             "avro/alltypes_plain.xz.avro",
         ]
         .into_iter()
@@ -2686,6 +2686,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn comprehensive_e2e_test_roundtrip() -> Result<(), AvroError> {
         let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("test/data/comprehensive_e2e.avro");
@@ -3521,6 +3522,7 @@ mod tests {
 
     #[cfg(not(feature = "avro_custom_types"))]
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_roundtrip_float16_no_custom_widens_to_float32() {
         assert_round_trip_widened(
             Arc::new(Float16Array::from(vec![
@@ -3785,6 +3787,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn e2e_types_and_schema_alignment() -> Result<(), AvroError> {
         // Values are chosen to:
         // - exercise full UInt64 range when `avro_custom_types` is enabled

--- a/arrow-cast/src/base64.rs
+++ b/arrow-cast/src/base64.rs
@@ -103,6 +103,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_b64() {
         let mut rng = rng();
         let len = rng.random_range(1024..1050);

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -3410,6 +3410,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_float16_to_decimals() {
         let array = Float16Array::from(vec![
             Some(f16::from_f32(1.25)),
@@ -3783,6 +3784,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_decimal32_to_numeric() {
         let value_array: Vec<Option<i32>> = vec![Some(125), Some(225), Some(325), None, Some(525)];
         let array = create_decimal32_array(value_array, 8, 2).unwrap();
@@ -3791,6 +3793,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_decimal64_to_numeric() {
         let value_array: Vec<Option<i64>> = vec![Some(125), Some(225), Some(325), None, Some(525)];
         let array = create_decimal64_array(value_array, 8, 2).unwrap();
@@ -3799,6 +3802,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_decimal128_to_numeric() {
         let value_array: Vec<Option<i128>> = vec![Some(125), Some(225), Some(325), None, Some(525)];
         let array = create_decimal128_array(value_array, 38, 2).unwrap();
@@ -3916,6 +3920,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_decimal256_to_numeric() {
         let value_array: Vec<Option<i256>> = vec![
             Some(i256::from_i128(125)),
@@ -4105,6 +4110,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_decimal128_to_float16_overflow() {
         let array = create_decimal128_array(
             vec![
@@ -4132,6 +4138,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_decimal256_to_float16_overflow() {
         let array = create_decimal256_array(
             vec![
@@ -4159,6 +4166,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_decimal_to_numeric_negative_scale() {
         let value_array: Vec<Option<i256>> = vec![
             Some(i256::from_i128(125)),
@@ -4801,6 +4809,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_float_to_utf8view() {
         let inputs = vec![
             Arc::new(Float16Array::from(vec![
@@ -4858,6 +4867,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_string_to_f16() {
         let arrays = [
             Arc::new(StringViewArray::from(vec!["3", "4.56", "seven", "8.9"])) as ArrayRef,
@@ -5068,6 +5078,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_floating_to_timestamp() {
         let array = Int64Array::from(vec![Some(2), Some(10), None]);
         let expected = cast(&array, &DataType::Timestamp(TimeUnit::Microsecond, None)).unwrap();
@@ -5093,6 +5104,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_timestamp_to_floating() {
         let array = TimestampMillisecondArray::from(vec![Some(5), Some(1), None])
             .with_timezone("UTC".to_string());
@@ -7763,6 +7775,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_from_f64() {
         let f64_values: Vec<f64> = vec![
             i64::MIN as f64,
@@ -7932,6 +7945,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_from_f32() {
         let f32_values: Vec<f32> = vec![
             i32::MIN as f32,
@@ -8076,6 +8090,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_from_uint64() {
         let u64_values: Vec<u64> = vec![
             0,
@@ -8169,6 +8184,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_from_uint32() {
         let u32_values: Vec<u32> = vec![0, u8::MAX as u32, u16::MAX as u32, u32::MAX];
         let u32_array: ArrayRef = Arc::new(UInt32Array::from(u32_values));
@@ -8241,6 +8257,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_from_uint16() {
         let u16_values: Vec<u16> = vec![0, u8::MAX as u16, u16::MAX];
         let u16_array: ArrayRef = Arc::new(UInt16Array::from(u16_values));
@@ -8313,6 +8330,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_from_uint8() {
         let u8_values: Vec<u8> = vec![0, u8::MAX];
         let u8_array: ArrayRef = Arc::new(UInt8Array::from(u8_values));
@@ -8385,6 +8403,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_from_int64() {
         let i64_values: Vec<i64> = vec![
             i64::MIN,
@@ -8559,6 +8578,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_from_int32() {
         let i32_values: Vec<i32> = vec![
             i32::MIN,
@@ -8669,6 +8689,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_from_int16() {
         let i16_values: Vec<i16> = vec![i16::MIN, i8::MIN as i16, 0, i8::MAX as i16, i16::MAX];
         let i16_array: ArrayRef = Arc::new(Int16Array::from(i16_values));
@@ -8778,6 +8799,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_from_int8() {
         let i8_values: Vec<i8> = vec![i8::MIN, 0, i8::MAX];
         let i8_array = Int8Array::from(i8_values);
@@ -9311,6 +9333,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_can_cast_fsl_to_fsl() {
         let from_array = Arc::new(
             FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
@@ -10487,6 +10510,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_f64_to_decimal128() {
         // to reproduce https://github.com/apache/arrow-rs/issues/2997
 
@@ -10615,6 +10639,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_float16_to_decimal128_precision_overflow() {
         let array = Float16Array::from(vec![f16::from_f32(1.1)]);
         let array = Arc::new(array) as ArrayRef;
@@ -10643,6 +10668,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_float16_to_decimal256_precision_overflow() {
         let array = Float16Array::from(vec![f16::from_f32(1.1)]);
         let array = Arc::new(array) as ArrayRef;
@@ -10671,6 +10697,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_cast_float16_to_decimal128_non_finite() {
         let array = Float16Array::from(vec![f16::NAN, f16::INFINITY, f16::NEG_INFINITY]);
         let array = Arc::new(array) as ArrayRef;

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -3410,7 +3410,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_cast_float16_to_decimals() {
         let array = Float16Array::from(vec![
             Some(f16::from_f32(1.25)),
@@ -3784,7 +3784,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_cast_decimal32_to_numeric() {
         let value_array: Vec<Option<i32>> = vec![Some(125), Some(225), Some(325), None, Some(525)];
         let array = create_decimal32_array(value_array, 8, 2).unwrap();
@@ -3793,7 +3793,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_cast_decimal64_to_numeric() {
         let value_array: Vec<Option<i64>> = vec![Some(125), Some(225), Some(325), None, Some(525)];
         let array = create_decimal64_array(value_array, 8, 2).unwrap();
@@ -3802,7 +3802,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_cast_decimal128_to_numeric() {
         let value_array: Vec<Option<i128>> = vec![Some(125), Some(225), Some(325), None, Some(525)];
         let array = create_decimal128_array(value_array, 38, 2).unwrap();
@@ -3920,7 +3920,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_cast_decimal256_to_numeric() {
         let value_array: Vec<Option<i256>> = vec![
             Some(i256::from_i128(125)),
@@ -4110,7 +4110,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_decimal128_to_float16_overflow() {
         let array = create_decimal128_array(
             vec![
@@ -4138,7 +4138,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_decimal256_to_float16_overflow() {
         let array = create_decimal256_array(
             vec![
@@ -4166,7 +4166,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_decimal_to_numeric_negative_scale() {
         let value_array: Vec<Option<i256>> = vec![
             Some(i256::from_i128(125)),
@@ -4809,7 +4809,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_float_to_utf8view() {
         let inputs = vec![
             Arc::new(Float16Array::from(vec![
@@ -4867,7 +4867,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_string_to_f16() {
         let arrays = [
             Arc::new(StringViewArray::from(vec!["3", "4.56", "seven", "8.9"])) as ArrayRef,
@@ -5078,7 +5078,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_floating_to_timestamp() {
         let array = Int64Array::from(vec![Some(2), Some(10), None]);
         let expected = cast(&array, &DataType::Timestamp(TimeUnit::Microsecond, None)).unwrap();
@@ -5104,7 +5104,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_timestamp_to_floating() {
         let array = TimestampMillisecondArray::from(vec![Some(5), Some(1), None])
             .with_timezone("UTC".to_string());
@@ -7775,7 +7775,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_from_f64() {
         let f64_values: Vec<f64> = vec![
             i64::MIN as f64,
@@ -7945,7 +7945,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_from_f32() {
         let f32_values: Vec<f32> = vec![
             i32::MIN as f32,
@@ -8090,7 +8090,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_from_uint64() {
         let u64_values: Vec<u64> = vec![
             0,
@@ -8184,7 +8184,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_from_uint32() {
         let u32_values: Vec<u32> = vec![0, u8::MAX as u32, u16::MAX as u32, u32::MAX];
         let u32_array: ArrayRef = Arc::new(UInt32Array::from(u32_values));
@@ -8257,7 +8257,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_from_uint16() {
         let u16_values: Vec<u16> = vec![0, u8::MAX as u16, u16::MAX];
         let u16_array: ArrayRef = Arc::new(UInt16Array::from(u16_values));
@@ -8330,7 +8330,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_from_uint8() {
         let u8_values: Vec<u8> = vec![0, u8::MAX];
         let u8_array: ArrayRef = Arc::new(UInt8Array::from(u8_values));
@@ -8403,7 +8403,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_from_int64() {
         let i64_values: Vec<i64> = vec![
             i64::MIN,
@@ -8578,7 +8578,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_from_int32() {
         let i32_values: Vec<i32> = vec![
             i32::MIN,
@@ -8689,7 +8689,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_from_int16() {
         let i16_values: Vec<i16> = vec![i16::MIN, i8::MIN as i16, 0, i8::MAX as i16, i16::MAX];
         let i16_array: ArrayRef = Arc::new(Int16Array::from(i16_values));
@@ -8799,7 +8799,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_from_int8() {
         let i8_values: Vec<i8> = vec![i8::MIN, 0, i8::MAX];
         let i8_array = Int8Array::from(i8_values);
@@ -9333,7 +9333,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_can_cast_fsl_to_fsl() {
         let from_array = Arc::new(
             FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
@@ -10510,7 +10510,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_cast_f64_to_decimal128() {
         // to reproduce https://github.com/apache/arrow-rs/issues/2997
 
@@ -10639,7 +10639,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_float16_to_decimal128_precision_overflow() {
         let array = Float16Array::from(vec![f16::from_f32(1.1)]);
         let array = Arc::new(array) as ArrayRef;
@@ -10668,7 +10668,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_float16_to_decimal256_precision_overflow() {
         let array = Float16Array::from(vec![f16::from_f32(1.1)]);
         let array = Arc::new(array) as ArrayRef;
@@ -10697,7 +10697,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_cast_float16_to_decimal128_non_finite() {
         let array = Float16Array::from(vec![f16::NAN, f16::INFINITY, f16::NEG_INFINITY]);
         let array = Arc::new(array) as ArrayRef;

--- a/arrow-cast/src/pretty.rs
+++ b/arrow-cast/src/pretty.rs
@@ -1028,7 +1028,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_float16_display() {
         let values = vec![
             Some(f16::from_f32(f32::NAN)),

--- a/arrow-cast/src/pretty.rs
+++ b/arrow-cast/src/pretty.rs
@@ -1028,6 +1028,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_float16_display() {
         let values = vec![
             Some(f16::from_f32(f32::NAN)),

--- a/arrow-cmp/src/lib.rs
+++ b/arrow-cmp/src/lib.rs
@@ -585,6 +585,7 @@ mod tests {
         assert_eq!(Ordering::Less, cmp(0, 0));
     }
 
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     #[test]
     fn test_f16() {
         let array = Float16Array::from(vec![f16::from_f32(1.0), f16::from_f32(2.0)]);

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -3005,7 +3005,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_float_precision() {
         let data = [
             "f16,f32,f64",

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -1506,6 +1506,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_csv_with_schema_inference() {
         let mut file = File::open("test/data/uk_cities_with_headers.csv").unwrap();
 
@@ -1547,6 +1548,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_csv_with_schema_inference_no_headers() {
         let mut file = File::open("test/data/uk_cities.csv").unwrap();
 
@@ -1586,6 +1588,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_csv_builder_with_bounds() {
         let mut file = File::open("test/data/uk_cities.csv").unwrap();
 
@@ -1758,6 +1761,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_init_nulls_with_inference() {
         let format = Format::default().with_header(true).with_delimiter(b',');
 
@@ -1818,6 +1822,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_nulls_with_inference() {
         let mut file = File::open("test/data/various_types.csv").unwrap();
         let format = Format::default().with_header(true).with_delimiter(b'|');
@@ -1876,6 +1881,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_custom_nulls_with_inference() {
         let mut file = File::open("test/data/custom_null_test.csv").unwrap();
 
@@ -1912,6 +1918,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_scientific_notation_with_inference() {
         let mut file = File::open("test/data/scientific_notation_test.csv").unwrap();
         let format = Format::default().with_header(false).with_delimiter(b',');
@@ -1993,6 +2000,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_infer_field_schema() {
         assert_eq!(infer_field_schema("A"), DataType::Utf8);
         assert_eq!(infer_field_schema("\"123\""), DataType::Utf8);
@@ -2136,6 +2144,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_infer_schema_from_multiple_files() {
         let mut csv1 = NamedTempFile::new().unwrap();
         let mut csv2 = NamedTempFile::new().unwrap();
@@ -2650,6 +2659,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_buffered() {
         let tests = [
             ("test/data/uk_cities.csv", false, 37),
@@ -2810,6 +2820,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_inference() {
         let cases: &[(&[&str], DataType)] = &[
             (&[], DataType::Null),
@@ -2878,6 +2889,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_record_length_mismatch() {
         let csv = "\
         a,b,c\n\
@@ -2993,6 +3005,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_float_precision() {
         let data = [
             "f16,f32,f64",

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -3204,6 +3204,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_file_with_massive_column_count() {
         // 499_999 is upper limit for default settings (1_000_000)
         let limit = 600_000;
@@ -3771,7 +3772,7 @@ mod tests {
         use std::sync::Arc;
 
         use arrow_array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, make_array};
-        use arrow_buffer::Buffer;
+        use arrow_buffer::{Buffer, MutableBuffer};
         use arrow_data::ArrayData;
         use arrow_schema::{DataType, Field, IntervalUnit, Schema, TimeUnit};
 
@@ -3789,7 +3790,7 @@ mod tests {
             let width = data_type.primitive_width().unwrap();
             let data = ArrayData::builder(data_type)
                 .len(len)
-                .add_buffer(Buffer::from(vec![0_u8; len * width]))
+                .add_buffer(Buffer::from(MutableBuffer::from_len_zeroed(len * width)))
                 .build()
                 .unwrap();
 

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -3401,6 +3401,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn truncate_ipc_record_batch() {
         fn create_batch(rows: usize) -> RecordBatch {
             let schema = Schema::new(vec![
@@ -3600,6 +3601,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_large_slice_string() {
         let strings: Vec<_> = (0..8000)
             .map(|i| {
@@ -3615,6 +3617,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_large_slice_string_list() {
         let mut ls = ListBuilder::new(StringBuilder::new());
 
@@ -3637,6 +3640,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_large_slice_string_list_of_lists() {
         // The reason for the special test is to verify reencode_offsets which looks both at
         // the starting offset and the data offset.  So need a dataset where the starting_offset
@@ -3925,6 +3929,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn reencode_offsets_when_first_offset_is_not_zero() {
         let original_list = generate_list_data::<i32>();
         let original_data = original_list.into_data();
@@ -3979,6 +3984,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_lists() {
         let val_inner = Field::new_list_field(DataType::UInt32, true);
         let val_list_field = Field::new("val", DataType::List(Arc::new(val_inner)), false);
@@ -3991,6 +3997,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_empty_list() {
         let val_inner = Field::new_list_field(DataType::UInt32, true);
         let val_list_field = Field::new("val", DataType::List(Arc::new(val_inner)), false);
@@ -4006,6 +4013,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_large_lists() {
         let val_inner = Field::new_list_field(DataType::UInt32, true);
         let val_list_field = Field::new("val", DataType::LargeList(Arc::new(val_inner)), false);
@@ -4020,6 +4028,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_large_lists_non_zero_offset() {
         let val_inner = Field::new_list_field(DataType::UInt32, true);
         let val_list_field = Field::new("val", DataType::LargeList(Arc::new(val_inner)), false);
@@ -4031,6 +4040,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_large_lists_string_non_zero_offset() {
         let val_inner = Field::new_list_field(DataType::Utf8, true);
         let val_list_field = Field::new("val", DataType::LargeList(Arc::new(val_inner)), false);
@@ -4042,6 +4052,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_large_list_string_view_non_zero_offset() {
         let val_inner = Field::new_list_field(DataType::Utf8View, true);
         let val_list_field = Field::new("val", DataType::LargeList(Arc::new(val_inner)), false);
@@ -4063,6 +4074,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_nested_lists() {
         let inner_int = Arc::new(Field::new_list_field(DataType::UInt32, true));
         let inner_list_field = Arc::new(Field::new_list_field(DataType::List(inner_int), true));
@@ -4076,6 +4088,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_nested_lists_starting_at_zero() {
         let inner_int = Arc::new(Field::new("item", DataType::UInt32, true));
         let inner_list_field = Arc::new(Field::new("item", DataType::List(inner_int), true));
@@ -4089,6 +4102,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_map_array() {
         let keys = Arc::new(Field::new(
             Field::MAP_KEY_FIELD_DEFAULT_NAME,
@@ -4134,6 +4148,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_list_view_arrays() {
         let val_inner = Field::new_list_field(DataType::UInt32, true);
         let val_field = Field::new("val", DataType::ListView(Arc::new(val_inner)), true);
@@ -4147,6 +4162,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_large_list_view_arrays() {
         let val_inner = Field::new_list_field(DataType::UInt32, true);
         let val_field = Field::new("val", DataType::LargeListView(Arc::new(val_inner)), true);
@@ -4160,6 +4176,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn check_sliced_list_view_array() {
         let inner = Field::new_list_field(DataType::UInt32, true);
         let field = Field::new("val", DataType::ListView(Arc::new(inner)), true);
@@ -4176,6 +4193,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn check_sliced_large_list_view_array() {
         let inner = Field::new_list_field(DataType::UInt32, true);
         let field = Field::new("val", DataType::LargeListView(Arc::new(inner)), true);
@@ -4215,6 +4233,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn encode_nested_list_views() {
         let inner_int = Arc::new(Field::new_list_field(DataType::UInt32, true));
         let inner_list_field = Arc::new(Field::new_list_field(DataType::ListView(inner_int), true));
@@ -4604,7 +4623,7 @@ mod tests {
 
             let out: Vec<u8> = writer.into_inner().unwrap();
 
-            let buffer = Buffer::from_vec(out);
+            let buffer = Buffer::from_slice_ref(out);
             let trailer_start = buffer.len() - 10;
             let footer_len =
                 read_footer_length(buffer[trailer_start..].try_into().unwrap()).unwrap();
@@ -4659,7 +4678,7 @@ mod tests {
 
         let out: Vec<u8> = writer.into_inner().unwrap();
 
-        let buffer = Buffer::from_vec(out);
+        let buffer = Buffer::from_slice_ref(out);
         let trailer_start = buffer.len() - 10;
         let footer_len = read_footer_length(buffer[trailer_start..].try_into().unwrap()).unwrap();
         let footer = root_as_footer(&buffer[trailer_start - footer_len..trailer_start]).unwrap();

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -1571,6 +1571,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_timestamps() {
         test_timestamp::<TimestampSecondType>();
         test_timestamp::<TimestampMillisecondType>();

--- a/arrow-json/src/writer/mod.rs
+++ b/arrow-json/src/writer/mod.rs
@@ -1521,6 +1521,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_write_multi_batches() {
         let test_file = "test/data/basic.json";
 

--- a/arrow-json/src/writer/mod.rs
+++ b/arrow-json/src/writer/mod.rs
@@ -1521,7 +1521,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_write_multi_batches() {
         let test_file = "test/data/basic.json";
 

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -2469,6 +2469,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_eq_dyn_neq_dyn_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(10.0)]);
         let array2 = Float16Array::from(
@@ -2499,6 +2500,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_lt_dyn_lt_eq_dyn_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(11.0), f16::NAN]);
         let array2 = Float16Array::from(vec![f16::NAN, f16::NAN, f16::from_f32(8.0), f16::from_f32(9.0), f16::from_f32(10.0), f16::from_f32(1.0)]);
@@ -2530,6 +2532,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_gt_dyn_gt_eq_dyn_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(11.0), f16::NAN]);
         let array2 = Float16Array::from(vec![f16::NAN, f16::NAN, f16::from_f32(8.0), f16::from_f32(9.0), f16::from_f32(10.0), f16::from_f32(1.0)]);
@@ -2560,6 +2563,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_eq_dyn_scalar_neq_dyn_scalar_float_nan() {
         let array = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(10.0)]);
         let scalar = Float16Array::new_scalar(f16::NAN);
@@ -2588,6 +2592,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_lt_dyn_scalar_lt_eq_dyn_scalar_float_nan() {
         let array = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(10.0)]);
         let scalar = Float16Array::new_scalar(f16::NAN);
@@ -2617,6 +2622,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_gt_dyn_scalar_gt_eq_dyn_scalar_float_nan() {
         let array = Float16Array::from(vec![
            f16::NAN,
@@ -2858,6 +2864,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_eq_dyn_neq_dyn_dict_non_dict_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(10.0)]);
         let values = Float16Array::from(vec![f16::NAN, f16::from_f32(8.0), f16::from_f32(10.0)]);
@@ -2894,6 +2901,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_lt_dyn_lt_eq_dyn_dict_non_dict_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(11.0), f16::NAN]);
         let values = Float16Array::from(vec![f16::NAN, f16::from_f32(8.0), f16::from_f32(9.0), f16::from_f32(10.0), f16::from_f32(1.0)]);
@@ -2930,6 +2938,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_gt_dyn_gt_eq_dyn_dict_non_dict_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(11.0), f16::NAN]);
         let values = Float16Array::from(vec![f16::NAN, f16::from_f32(8.0), f16::from_f32(9.0), f16::from_f32(10.0), f16::from_f32(1.0)]);

--- a/arrow-ord/src/comparison.rs
+++ b/arrow-ord/src/comparison.rs
@@ -2469,7 +2469,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_eq_dyn_neq_dyn_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(10.0)]);
         let array2 = Float16Array::from(
@@ -2500,7 +2500,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_lt_dyn_lt_eq_dyn_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(11.0), f16::NAN]);
         let array2 = Float16Array::from(vec![f16::NAN, f16::NAN, f16::from_f32(8.0), f16::from_f32(9.0), f16::from_f32(10.0), f16::from_f32(1.0)]);
@@ -2532,7 +2532,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_gt_dyn_gt_eq_dyn_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(11.0), f16::NAN]);
         let array2 = Float16Array::from(vec![f16::NAN, f16::NAN, f16::from_f32(8.0), f16::from_f32(9.0), f16::from_f32(10.0), f16::from_f32(1.0)]);
@@ -2563,7 +2563,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_eq_dyn_scalar_neq_dyn_scalar_float_nan() {
         let array = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(10.0)]);
         let scalar = Float16Array::new_scalar(f16::NAN);
@@ -2592,7 +2592,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_lt_dyn_scalar_lt_eq_dyn_scalar_float_nan() {
         let array = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(10.0)]);
         let scalar = Float16Array::new_scalar(f16::NAN);
@@ -2622,7 +2622,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_gt_dyn_scalar_gt_eq_dyn_scalar_float_nan() {
         let array = Float16Array::from(vec![
            f16::NAN,
@@ -2864,7 +2864,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_eq_dyn_neq_dyn_dict_non_dict_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(10.0)]);
         let values = Float16Array::from(vec![f16::NAN, f16::from_f32(8.0), f16::from_f32(10.0)]);
@@ -2901,7 +2901,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_lt_dyn_lt_eq_dyn_dict_non_dict_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(11.0), f16::NAN]);
         let values = Float16Array::from(vec![f16::NAN, f16::from_f32(8.0), f16::from_f32(9.0), f16::from_f32(10.0), f16::from_f32(1.0)]);
@@ -2938,7 +2938,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_gt_dyn_gt_eq_dyn_dict_non_dict_float_nan() {
         let array1 = Float16Array::from(vec![f16::NAN, f16::from_f32(7.0), f16::from_f32(8.0), f16::from_f32(8.0), f16::from_f32(11.0), f16::NAN]);
         let values = Float16Array::from(vec![f16::NAN, f16::from_f32(8.0), f16::from_f32(9.0), f16::from_f32(10.0), f16::from_f32(1.0)]);

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -1622,6 +1622,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_sort_to_indices_primitives() {
         test_sort_to_indices_primitive_arrays::<Int8Type>(
             vec![None, Some(0), Some(2), Some(-1), Some(0), None],
@@ -2732,6 +2733,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_sort_primitives() {
         // default case
         test_sort_primitive_arrays::<UInt8Type>(
@@ -3628,6 +3630,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_sort_list() {
         test_sort_list_arrays::<Int8Type>(
             vec![

--- a/arrow-ord/src/sort.rs
+++ b/arrow-ord/src/sort.rs
@@ -1622,7 +1622,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_sort_to_indices_primitives() {
         test_sort_to_indices_primitive_arrays::<Int8Type>(
             vec![None, Some(0), Some(2), Some(-1), Some(0), None],
@@ -2733,7 +2733,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_sort_primitives() {
         // default case
         test_sort_primitive_arrays::<UInt8Type>(
@@ -3630,7 +3630,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_sort_list() {
         test_sort_list_arrays::<Int8Type>(
             vec![

--- a/arrow-select/src/coalesce.rs
+++ b/arrow-select/src/coalesce.rs
@@ -878,6 +878,7 @@ mod tests {
 
     /// Coalesce multiple batches, 80k rows, with a 0.1% selectivity filter
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_coalesce_filtered_001() {
         let mut filter_builder = RandomFilterBuilder {
             num_rows: 8000,
@@ -901,6 +902,7 @@ mod tests {
 
     /// Coalesce multiple batches, 80k rows, with a 1% selectivity filter
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_coalesce_filtered_01() {
         let mut filter_builder = RandomFilterBuilder {
             num_rows: 8000,
@@ -924,6 +926,7 @@ mod tests {
 
     /// Coalesce multiple batches, 80k rows, with a 10% selectivity filter
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_coalesce_filtered_10() {
         let mut filter_builder = RandomFilterBuilder {
             num_rows: 8000,
@@ -947,6 +950,7 @@ mod tests {
 
     /// Coalesce multiple batches, 8k rows, with a 90% selectivity filter
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_coalesce_filtered_90() {
         let mut filter_builder = RandomFilterBuilder {
             num_rows: 800,
@@ -970,6 +974,7 @@ mod tests {
 
     /// Coalesce multiple batches, 8k rows, with mixed filers, including 100%
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_coalesce_filtered_mixed() {
         let mut filter_builder = RandomFilterBuilder {
             num_rows: 800,
@@ -1016,6 +1021,7 @@ mod tests {
             .run();
     }
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_utf8_split() {
         Test::new("coalesce_utf8")
             // 4040 rows of utf8 strings in total, split into batches of 1024
@@ -1059,6 +1065,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_string_view_batch_large_no_compact() {
         // view with large strings (has buffers) but full --> no need to compact
         let batch = stringview_batch_repeated(1000, [Some("This string is longer than 12 bytes")]);
@@ -1149,6 +1156,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_string_view_mixed() {
         let large_view_batch =
             stringview_batch_repeated(1000, [Some("This string is longer than 12 bytes")]);
@@ -1208,6 +1216,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_string_view_many_small_compact() {
         // 200 rows alternating long (28) and short (≤12) strings.
         // Only the 100 long strings go into data buffers: 100 × 28 = 2800.
@@ -1253,6 +1262,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_string_view_many_small_boundary() {
         // The strings are designed to exactly fit into buffers that are powers of 2 long
         let batch = stringview_batch_repeated(100, [Some("This string is a power of two=32")]);
@@ -1283,6 +1293,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_string_view_large_small() {
         // The strings are 37 bytes long, so each batch has 100 * 28 = 2800 bytes
         let mixed_batch = stringview_batch_repeated(
@@ -1334,6 +1345,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_binary_view() {
         let values: Vec<Option<&[u8]>> = vec![
             Some(b"foo"),

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -799,6 +799,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_concat_13_incompatible_datatypes_should_not_include_all_of_them() {
         let re = concat(&[
             &PrimitiveArray::<Int64Type>::from(vec![Some(-1), Some(2), None]),

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -1732,6 +1732,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn concat_many_dictionary_list_arrays() {
         let number_of_unique_values = 8;
         let scalars = (0..80000)

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -799,7 +799,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Unsupported inline assembly
     fn test_concat_13_incompatible_datatypes_should_not_include_all_of_them() {
         let re = concat(&[
             &PrimitiveArray::<Int64Type>::from(vec![Some(-1), Some(2), None]),

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -2034,6 +2034,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_interleave_bytes_offset_overflow() {
         let indices: Vec<(usize, usize)> = vec![(0, 0); (i32::MAX >> 4) as usize];
         let text = ('a'..='z').collect::<String>();
@@ -2045,6 +2046,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_interleave_list_offset_overflow() {
         // Build a ListArray<i32> with a single row containing many elements
         let mut builder = GenericListBuilder::<i32, _>::new(Int32Builder::new());

--- a/arrow-select/src/nullif.rs
+++ b/arrow-select/src/nullif.rs
@@ -524,6 +524,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn nullif_fuzz() {
         let mut rng = StdRng::seed_from_u64(7337);
 

--- a/arrow-select/src/union_extract.rs
+++ b/arrow-select/src/union_extract.rs
@@ -442,6 +442,7 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_eq_scalar() {
         //multiple all equal chunks, so it's loop and sum logic it's tested
         //multiple chunks after, so it's loop logic it's tested

--- a/arrow-string/src/like.rs
+++ b/arrow-string/src/like.rs
@@ -464,7 +464,8 @@ mod tests {
     /// - `StringViewArray`
     /// - `DictionaryArray`
     macro_rules! test_utf8 {
-        ($test_name:ident, $left:expr, $right:expr, $op:expr, $expected:expr) => {
+        ($(#[$attr:meta])* $test_name:ident, $left:expr, $right:expr, $op:expr, $expected:expr) => {
+            $(#[$attr])*
             #[test]
             fn $test_name() {
                 let expected = BooleanArray::from($expected);
@@ -554,7 +555,8 @@ mod tests {
     /// - `StringViewArray`
     /// - `DictionaryArray`
     macro_rules! test_utf8_scalar {
-        ($test_name:ident, $left:expr, $right:expr, $op:expr, $expected:expr) => {
+        ($(#[$attr:meta])* $test_name:ident, $left:expr, $right:expr, $op:expr, $expected:expr) => {
+            $(#[$attr])*
             #[test]
             fn $test_name() {
                 let expected = BooleanArray::from($expected);
@@ -661,6 +663,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_like_scalar_escape_testing,
         vec![
             "varchar(255)",
@@ -816,6 +819,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_like_scalar_one,
         vec![
             "arrow",
@@ -870,6 +874,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_nlike_escape_testing,
         vec![
             "varchar(255)",
@@ -954,6 +959,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_nlike_scalar_one,
         vec![
             "arrow",
@@ -968,6 +974,7 @@ mod tests {
     );
 
     test_utf8!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_ilike,
         vec![
             "arrow",
@@ -984,6 +991,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         ilike_utf8_scalar_escape_testing,
         vec![
             "varchar(255)",
@@ -1054,6 +1062,7 @@ mod tests {
 
     // We only implement loose matching
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_ilike_unicode,
         vec![
             "FFkoß",
@@ -1072,6 +1081,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_ilike_unicode_starts,
         vec![
             "FFkoßsdlkdf",
@@ -1093,6 +1103,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_ilike_unicode_ends,
         vec![
             "sdlkdfFFkoß",
@@ -1114,6 +1125,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_ilike_unicode_contains,
         vec![
             "sdlkdfFkoßsdfs",
@@ -1163,6 +1175,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_ilike_unicode_complex,
         vec![
             "sdlkdfFooßsdfs",
@@ -1208,6 +1221,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_ilike_scalar_one,
         vec![
             "arrow",
@@ -1222,6 +1236,7 @@ mod tests {
     );
 
     test_utf8!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_nilike,
         vec![
             "arrow",
@@ -1238,6 +1253,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         nilike_utf8_scalar_escape_testing,
         vec![
             "varchar(255)",
@@ -1307,6 +1323,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_array_nilike_scalar_one,
         vec![
             "arrow",
@@ -1346,6 +1363,7 @@ mod tests {
     );
 
     test_utf8_scalar!(
+        #[cfg_attr(miri, ignore)] // Takes too long
         test_utf8_scalar_nullable_nlike,
         vec![
             Some("Earth"),
@@ -1418,6 +1436,7 @@ mod tests {
     );
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn string_null_like_pattern() {
         // Different patterns have different execution code paths
         for pattern in &[
@@ -1464,6 +1483,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn string_view_null_like_pattern() {
         // Different patterns have different execution code paths
         for pattern in &[
@@ -1576,6 +1596,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn like_escape() {
         // (value, pattern, expected)
         let test_cases = vec![
@@ -1817,6 +1838,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn like_escape_many() {
         // (value, pattern, expected)
         let test_cases = vec![


### PR DESCRIPTION
# Which issue does this PR close?
closes #10471 

# Rationale for this change
The Miri workflow currently covers only a subset of packages. This adds more miri coverage to detect unsafe code, Parquet crate remains excluded because it is tracked separately in #614.


# What changes are included in this PR?
- Adds Miri testing for arrow, arrow-avro, arrow-cast, arrow-csv, arrow-ipc, arrow-json, arrow-row, arrow-select, and arrow-string.
- Updates the gh action workflow path filters in `miri.yaml`, some crates were missing before
- adds ignore to tests that takes too long to run
- adds ignore to tests that were failing due to inline assembly
- Sets `INSTA_WORKSPACE_ROOT` to prevent snapshot tests from invoking unsupported subprocess operations under Miri

note: it takes about 50mins to run miri on my M3 laptop. when this pr gets merge i think it's expected to prolong the CI time in the miri workflow, but we can always add more parallel workers

# Are these changes tested?
i ran the following to test locally. 

- `rustup run nightly bash .github/workflows/miri.sh` (runs the whole miri suite)
- `cargo test`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`


# Are there any user-facing changes?
no, only tests

# AI disclosure
I used codex to draft this pr after i got the project and miri tests running on my laptop. I have reviewed all the code and have built, tested these changes. I am happy to own follow-ups too.
