### PR TITLE
fix(arrow-schema): Persist dictionary ordered flag on FFI schema import

### DIFF
--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -649,8 +649,9 @@ impl TryFrom<&FFI_ArrowSchema> for Field {
 
     fn try_from(c_schema: &FFI_ArrowSchema) -> Result<Self, ArrowError> {
         let dtype = DataType::try_from(c_schema)?;
-        let mut field = Field::new(c_schema.name().unwrap_or(""), dtype, c_schema.nullable());
-        field.set_metadata(c_schema.metadata()?);
+        let field = Field::new(c_schema.name().unwrap_or(""), dtype, c_schema.nullable())
+            .with_dict_is_ordered(c_schema.dictionary_ordered())
+            .with_metadata(c_schema.metadata()?);
         Ok(field)
     }
 }
@@ -988,6 +989,10 @@ mod tests {
 
         let arrow_schema = FFI_ArrowSchema::try_from(schema).unwrap();
         assert!(arrow_schema.child(0).dictionary_ordered());
+
+        // Round-trip: the ordered flag must be preserved when converting back to a Field.
+        let field = Field::try_from(arrow_schema.child(0)).unwrap();
+        assert_eq!(field.dict_is_ordered(), Some(true));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10513.

# Rationale for this change

See issue.

# What changes are included in this PR?

n/a

# Are these changes tested?

Unit test is added.

# Are there any user-facing changes?

n/a
