### PR TITLE
fix(ffi): preserve dictionary ordered flag when importing FFI schema

### DIFF
--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -649,7 +649,9 @@ impl TryFrom<&FFI_ArrowSchema> for Field {
 
     fn try_from(c_schema: &FFI_ArrowSchema) -> Result<Self, ArrowError> {
         let dtype = DataType::try_from(c_schema)?;
-        let mut field = Field::new(c_schema.name().unwrap_or(""), dtype, c_schema.nullable());
+        let mut field =
+            Field::new(c_schema.name().unwrap_or(""), dtype, c_schema.nullable())
+                .with_dict_is_ordered(c_schema.dictionary_ordered());
         field.set_metadata(c_schema.metadata()?);
         Ok(field)
     }
@@ -988,6 +990,40 @@ mod tests {
 
         let arrow_schema = FFI_ArrowSchema::try_from(schema).unwrap();
         assert!(arrow_schema.child(0).dictionary_ordered());
+    }
+
+    #[test]
+    fn test_dictionary_ordered_roundtrip() {
+        #[allow(deprecated)]
+        let field = Field::new_dict(
+            "dict",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            false,
+            0,
+            true,
+        );
+
+        // Export to FFI schema
+        let ffi = FFI_ArrowSchema::try_from(&field).unwrap();
+        assert!(ffi.dictionary_ordered());
+
+        // Import back — the ordered flag must survive the round trip
+        let roundtripped = Field::try_from(&ffi).unwrap();
+        assert_eq!(roundtripped.dict_is_ordered(), Some(true));
+
+        // Also check that an unordered dictionary round-trips as unordered
+        #[allow(deprecated)]
+        let unordered = Field::new_dict(
+            "dict",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            false,
+            0,
+            false,
+        );
+        let ffi_unordered = FFI_ArrowSchema::try_from(&unordered).unwrap();
+        assert!(!ffi_unordered.dictionary_ordered());
+        let roundtripped_unordered = Field::try_from(&ffi_unordered).unwrap();
+        assert_eq!(roundtripped_unordered.dict_is_ordered(), Some(false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When converting an `FFI_ArrowSchema` (C Data Interface) into a `Field`, the
dictionary ordered flag is silently dropped. `FFI_ArrowSchema::dictionary_ordered()`
reads the `ARROW_FLAG_DICTIONARY_ORDERED` bit (`0b1`) from `ArrowSchema.flags`
correctly — but `impl TryFrom<&FFI_ArrowSchema> for Field` never applies it to the
resulting `Field`.

As a result, a dictionary field exported with `dict_is_ordered = true` always comes
back as `dict_is_ordered = false` after an FFI round trip.

## Fix

One-line change: call `.with_dict_is_ordered(c_schema.dictionary_ordered())` when
constructing the `Field` in the `TryFrom<&FFI_ArrowSchema>` impl.

```rust
// Before
let mut field = Field::new(c_schema.name().unwrap_or(""), dtype, c_schema.nullable());

// After
let mut field = Field::new(c_schema.name().unwrap_or(""), dtype, c_schema.nullable())
    .with_dict_is_ordered(c_schema.dictionary_ordered());
```

`with_dict_is_ordered` is a no-op on non-dictionary types, so this is safe for all
schema types.

## Test

Adds `test_dictionary_ordered_roundtrip` that verifies both the ordered and
unordered paths survive an export/import round trip through the C Data Interface.

Fixes #10513
