### PR TITLE
Support casting strings to durations

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -61,8 +61,8 @@ use std::sync::Arc;
 
 use crate::display::{ArrayFormatter, FormatOptions};
 use crate::parse::{
-    Parser, parse_interval_day_time, parse_interval_month_day_nano, parse_interval_year_month,
-    string_to_datetime,
+    Parser, parse_duration, parse_interval_day_time, parse_interval_month_day_nano,
+    parse_interval_year_month, string_to_datetime,
 };
 use arrow_array::{builder::*, cast::*, temporal_conversions::*, timezone::Tz, types::*, *};
 use arrow_buffer::{ArrowNativeType, OffsetBuffer, i256};
@@ -278,6 +278,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
             | Timestamp(Microsecond, _)
             | Timestamp(Nanosecond, _)
             | Interval(_)
+            | Duration(_)
             | BinaryView,
         ) => true,
         (Utf8 | LargeUtf8, Utf8View) => true,
@@ -1307,6 +1308,18 @@ pub fn cast_with_options(
             Interval(IntervalUnit::MonthDayNano) => {
                 cast_string_to_month_day_nano_interval::<i32>(array, cast_options)
             }
+            Duration(TimeUnit::Second) => {
+                cast_string_to_duration::<i32, DurationSecondType>(array, cast_options)
+            }
+            Duration(TimeUnit::Millisecond) => {
+                cast_string_to_duration::<i32, DurationMillisecondType>(array, cast_options)
+            }
+            Duration(TimeUnit::Microsecond) => {
+                cast_string_to_duration::<i32, DurationMicrosecondType>(array, cast_options)
+            }
+            Duration(TimeUnit::Nanosecond) => {
+                cast_string_to_duration::<i32, DurationNanosecondType>(array, cast_options)
+            }
             _ => Err(ArrowError::CastError(format!(
                 "Casting from {from_type} to {to_type} not supported",
             ))),
@@ -1358,6 +1371,18 @@ pub fn cast_with_options(
             Interval(IntervalUnit::DayTime) => cast_view_to_day_time_interval(array, cast_options),
             Interval(IntervalUnit::MonthDayNano) => {
                 cast_view_to_month_day_nano_interval(array, cast_options)
+            }
+            Duration(TimeUnit::Second) => {
+                cast_view_to_duration::<DurationSecondType>(array, cast_options)
+            }
+            Duration(TimeUnit::Millisecond) => {
+                cast_view_to_duration::<DurationMillisecondType>(array, cast_options)
+            }
+            Duration(TimeUnit::Microsecond) => {
+                cast_view_to_duration::<DurationMicrosecondType>(array, cast_options)
+            }
+            Duration(TimeUnit::Nanosecond) => {
+                cast_view_to_duration::<DurationNanosecondType>(array, cast_options)
             }
             _ => Err(ArrowError::CastError(format!(
                 "Casting from {from_type} to {to_type} not supported",
@@ -1425,6 +1450,18 @@ pub fn cast_with_options(
             }
             Interval(IntervalUnit::MonthDayNano) => {
                 cast_string_to_month_day_nano_interval::<i64>(array, cast_options)
+            }
+            Duration(TimeUnit::Second) => {
+                cast_string_to_duration::<i64, DurationSecondType>(array, cast_options)
+            }
+            Duration(TimeUnit::Millisecond) => {
+                cast_string_to_duration::<i64, DurationMillisecondType>(array, cast_options)
+            }
+            Duration(TimeUnit::Microsecond) => {
+                cast_string_to_duration::<i64, DurationMicrosecondType>(array, cast_options)
+            }
+            Duration(TimeUnit::Nanosecond) => {
+                cast_string_to_duration::<i64, DurationNanosecondType>(array, cast_options)
             }
             _ => Err(ArrowError::CastError(format!(
                 "Casting from {from_type} to {to_type} not supported",
@@ -5894,6 +5931,152 @@ mod tests {
                 i64::MAX - 2
             )
         );
+    }
+
+    #[test]
+    fn test_cast_string_to_duration() {
+        let source = vec![
+            Some("2"),
+            Some("1.5 seconds"),
+            Some("2 minutes"),
+            Some("1 day"),
+            Some("PT0.000001S"),
+            Some("-PT0.000001S"),
+            Some("1 month"),
+            Some("foobar"),
+            None,
+        ];
+
+        macro_rules! test_duration {
+            ($duration_type:ty, $time_unit:expr, $expected:expr) => {{
+                let arrays: Vec<ArrayRef> = vec![
+                    Arc::new(StringArray::from(source.clone())),
+                    Arc::new(LargeStringArray::from(source.clone())),
+                    Arc::new(StringViewArray::from(source.clone())),
+                ];
+                let expected = PrimitiveArray::<$duration_type>::from($expected);
+
+                for array in arrays {
+                    let to_type = DataType::Duration($time_unit);
+                    assert!(can_cast_types(array.data_type(), &to_type));
+                    let actual = cast(&array, &to_type).unwrap();
+                    assert_eq!(actual.as_primitive::<$duration_type>(), &expected);
+                }
+            }};
+        }
+
+        test_duration!(
+            DurationSecondType,
+            TimeUnit::Second,
+            vec![
+                Some(2),
+                Some(1),
+                Some(120),
+                Some(86_400),
+                Some(0),
+                Some(0),
+                None,
+                None,
+                None,
+            ]
+        );
+        test_duration!(
+            DurationMillisecondType,
+            TimeUnit::Millisecond,
+            vec![
+                Some(2),
+                Some(1_500),
+                Some(120_000),
+                Some(86_400_000),
+                Some(0),
+                Some(0),
+                None,
+                None,
+                None,
+            ]
+        );
+        test_duration!(
+            DurationMicrosecondType,
+            TimeUnit::Microsecond,
+            vec![
+                Some(2),
+                Some(1_500_000),
+                Some(120_000_000),
+                Some(86_400_000_000),
+                Some(1),
+                Some(-1),
+                None,
+                None,
+                None,
+            ]
+        );
+        test_duration!(
+            DurationNanosecondType,
+            TimeUnit::Nanosecond,
+            vec![
+                Some(2),
+                Some(1_500_000_000),
+                Some(120_000_000_000),
+                Some(86_400_000_000_000),
+                Some(1_000),
+                Some(-1_000),
+                None,
+                None,
+                None,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_cast_string_to_duration_err() {
+        let array = StringArray::from(vec!["1 month"]);
+        let options = CastOptions {
+            safe: false,
+            format_options: FormatOptions::default(),
+        };
+        let error = cast_with_options(&array, &DataType::Duration(TimeUnit::Microsecond), &options)
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Cast error: Cannot cast 1 month to Duration(µs). Year and month fields are not supported."
+        );
+
+        let array = StringArray::from(vec!["foobar"]);
+        let error = cast_with_options(&array, &DataType::Duration(TimeUnit::Microsecond), &options)
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            r#"Parser error: Invalid input syntax for type interval: "foobar""#
+        );
+    }
+
+    #[test]
+    fn test_cast_duration_string_round_trip() {
+        let expected = DurationNanosecondArray::from(vec![
+            Some(1),
+            Some(-1),
+            Some(1_500_000_000),
+            Some(86_400_000_000_000),
+            None,
+        ]);
+
+        for duration_format in [
+            crate::display::DurationFormat::ISO8601,
+            crate::display::DurationFormat::Pretty,
+        ] {
+            let options = CastOptions {
+                safe: true,
+                format_options: FormatOptions::new().with_duration_format(duration_format),
+            };
+            let strings = cast_with_options(&expected, &DataType::Utf8, &options).unwrap();
+            let actual = cast_with_options(
+                &strings,
+                &DataType::Duration(TimeUnit::Nanosecond),
+                &options,
+            )
+            .unwrap();
+            assert_eq!(actual.as_primitive::<DurationNanosecondType>(), &expected);
+        }
     }
 
     #[test]

--- a/arrow-cast/src/cast/string.rs
+++ b/arrow-cast/src/cast/string.rs
@@ -258,6 +258,17 @@ pub(crate) fn cast_string_to_month_day_nano_interval<Offset: OffsetSizeTrait>(
     )
 }
 
+pub(crate) fn cast_string_to_duration<Offset, T>(
+    array: &dyn Array,
+    cast_options: &CastOptions,
+) -> Result<ArrayRef, ArrowError>
+where
+    Offset: OffsetSizeTrait,
+    T: ArrowTemporalType<Native = i64>,
+{
+    cast_string_to_interval::<Offset, _, T>(array, cast_options, parse_duration::<T>)
+}
+
 pub(crate) fn cast_view_to_interval<F, ArrowType>(
     array: &dyn Array,
     cast_options: &CastOptions,
@@ -302,6 +313,16 @@ pub(crate) fn cast_view_to_month_day_nano_interval(
         cast_options,
         parse_interval_month_day_nano,
     )
+}
+
+pub(crate) fn cast_view_to_duration<T>(
+    array: &dyn Array,
+    cast_options: &CastOptions,
+) -> Result<ArrayRef, ArrowError>
+where
+    T: ArrowTemporalType<Native = i64>,
+{
+    cast_view_to_interval::<_, T>(array, cast_options, parse_duration::<T>)
 }
 
 fn cast_string_to_interval_impl<'a, I, ArrowType, F>(

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -22,7 +22,7 @@ use arrow_array::ArrowNativeTypeOp;
 use arrow_array::timezone::Tz;
 use arrow_array::types::*;
 use arrow_buffer::ArrowNativeType;
-use arrow_schema::ArrowError;
+use arrow_schema::{ArrowError, DataType, TimeUnit};
 use chrono::prelude::*;
 use half::f16;
 use std::str::FromStr;
@@ -1090,11 +1090,82 @@ pub fn parse_interval_month_day_nano(
     parse_interval_month_day_nano_config(value, IntervalParseConfig::new(IntervalUnit::Month))
 }
 
+/// Parse a human-readable or ISO 8601 duration string to an Arrow duration value.
+///
+/// Human-readable durations use the same syntax as intervals, for example
+/// `2 days 3 hours 4.5 seconds`. Values without an explicit unit use the unit
+/// of `T`. Year and month fields are rejected because their lengths are not
+/// fixed. ISO 8601 strings produced by [`crate::display::DurationFormat::ISO8601`]
+/// are also supported.
+pub(crate) fn parse_duration<T: ArrowTemporalType<Native = i64>>(
+    value: &str,
+) -> Result<i64, ArrowError> {
+    let (default_unit, scale) = match T::DATA_TYPE {
+        DataType::Duration(TimeUnit::Second) => (IntervalUnit::Second, NANOS_PER_SECOND),
+        DataType::Duration(TimeUnit::Millisecond) => (IntervalUnit::Millisecond, NANOS_PER_MILLIS),
+        DataType::Duration(TimeUnit::Microsecond) => (IntervalUnit::Microsecond, 1_000),
+        DataType::Duration(TimeUnit::Nanosecond) => (IntervalUnit::Nanosecond, 1),
+        _ => unreachable!(),
+    };
+
+    let value = value.trim_ascii();
+
+    // Preserve the full i64 range for the common case of a unitless integer.
+    if let Ok(value) = value.parse::<i64>() {
+        return Ok(value);
+    }
+
+    // Duration display currently emits ISO 8601 values as a number of seconds,
+    // for example `PT1.5S` or `-PT1.5S`. Convert this to the interval parser's
+    // human-readable syntax so both representations share the same validation.
+    let normalized;
+    let value = if let Some(seconds) = value
+        .strip_prefix("PT")
+        .and_then(|value| value.strip_suffix('S'))
+    {
+        normalized = format!("{seconds} seconds");
+        normalized.as_str()
+    } else if let Some(seconds) = value
+        .strip_prefix("-PT")
+        .and_then(|value| value.strip_suffix('S'))
+    {
+        normalized = format!("-{seconds} seconds");
+        normalized.as_str()
+    } else {
+        value
+    };
+
+    let config = IntervalParseConfig::new(default_unit);
+    let components = parse_interval_components(value, &config)?;
+
+    if components.iter().any(|(_, unit)| {
+        matches!(
+            unit,
+            IntervalUnit::Century | IntervalUnit::Decade | IntervalUnit::Year | IntervalUnit::Month
+        )
+    }) {
+        return Err(ArrowError::CastError(format!(
+            "Cannot cast {value} to {}. Year and month fields are not supported.",
+            T::DATA_TYPE
+        )));
+    }
+
+    let interval = components
+        .into_iter()
+        .try_fold(Interval::default(), |result, (amount, unit)| {
+            result.add(amount, unit)
+        })?;
+    let nanos = i64::from(interval.days)
+        .mul_checked(NANOS_PER_DAY)?
+        .add_checked(interval.nanos)?;
+
+    Ok(nanos / scale)
+}
+
 const NANOS_PER_MILLIS: i64 = 1_000_000;
 const NANOS_PER_SECOND: i64 = 1_000 * NANOS_PER_MILLIS;
 const NANOS_PER_MINUTE: i64 = 60 * NANOS_PER_SECOND;
 const NANOS_PER_HOUR: i64 = 60 * NANOS_PER_MINUTE;
-#[cfg(test)]
 const NANOS_PER_DAY: i64 = 24 * NANOS_PER_HOUR;
 
 /// Config to parse interval strings


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #4555.

# Rationale for this change

`arrow-cast` can format durations as strings but does not currently support casting those strings back to duration arrays. This leaves duration casts asymmetric and prevents round-tripping formatted values.

# What changes are included in this PR?

- Allow `Utf8`, `LargeUtf8`, and `Utf8View` values to cast to all four duration units.
- Parse human-readable interval-style durations and the ISO 8601 representation emitted by the duration formatter.
- Treat unitless integers as values in the target duration unit.
- Reject year and month fields because they do not have fixed durations.
- Preserve safe-cast behavior by converting invalid inputs to nulls and returning errors for unsafe casts.

# Are these changes tested?

Yes. Tests cover all duration units, all supported string representations, safe and unsafe behavior, invalid calendar units, and ISO 8601 and pretty-format round trips.

Validation performed:

- `cargo test -p arrow-cast --lib` (363 passed)
- `cargo clippy -p arrow-cast --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`

# Are there any user-facing changes?

Yes. Users can now cast string arrays to duration arrays. This adds functionality without changing an existing public API.

# Tooling disclosure

Generative tooling assisted with the parser implementation, cast dispatch arms, tests, and PR wording. The full patch was locally reviewed and verified with the checks above.
