### PR TITLE
perf: optimize loops for primitive types binary kernels. 

### DIFF
--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -17,9 +17,9 @@
 
 //! Kernels for operating on [`PrimitiveArray`]s
 
-use arrow_array::builder::BufferBuilder;
 use arrow_array::*;
 use arrow_buffer::ArrowNativeType;
+use arrow_buffer::Buffer;
 use arrow_buffer::MutableBuffer;
 use arrow_buffer::buffer::NullBuffer;
 use arrow_data::ArrayData;
@@ -124,13 +124,24 @@ where
 
     let nulls = NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref());
 
-    let values = a
-        .values()
-        .into_iter()
-        .zip(b.values())
-        .map(|(l, r)| op(*l, *r));
-
-    let buffer: Vec<_> = values.collect();
+    let len = a.len();
+    let byte_width = O::Native::get_byte_width();
+    let mut buffer = MutableBuffer::new(len * byte_width);
+    // Safety: we write every element in the loop below
+    unsafe { buffer.set_len(len * byte_width) };
+    let slice = unsafe {
+        std::slice::from_raw_parts_mut(buffer.as_mut_ptr() as *mut O::Native, len)
+    };
+    let a_vals = a.values();
+    let b_vals = b.values();
+    for idx in 0..len {
+        unsafe {
+            *slice.get_unchecked_mut(idx) = op(
+                *a_vals.get_unchecked(idx),
+                *b_vals.get_unchecked(idx),
+            );
+        }
+    }
     Ok(PrimitiveArray::new(buffer.into(), nulls))
 }
 
@@ -276,18 +287,16 @@ where
         let nulls =
             NullBuffer::union(a.logical_nulls().as_ref(), b.logical_nulls().as_ref()).unwrap();
 
-        let mut buffer = BufferBuilder::<O::Native>::new(len);
-        buffer.append_n_zeroed(len);
-        let slice = buffer.as_slice_mut();
+        let mut buffer = vec![O::Native::default(); len];
 
         nulls.try_for_each_valid_idx(|idx| {
             unsafe {
-                *slice.get_unchecked_mut(idx) = op(a.value_unchecked(idx), b.value_unchecked(idx))?
+                *buffer.get_unchecked_mut(idx) = op(a.value_unchecked(idx), b.value_unchecked(idx))?
             };
             Ok::<_, ArrowError>(())
         })?;
 
-        let values = buffer.finish().into();
+        let values = Buffer::from(buffer).into();
         Ok(PrimitiveArray::new(values, Some(nulls)))
     }
 }
@@ -379,11 +388,17 @@ where
     O: ArrowPrimitiveType,
     F: Fn(A::Item, B::Item) -> Result<O::Native, ArrowError>,
 {
-    let mut buffer = MutableBuffer::new(len * O::Native::get_byte_width());
+    let byte_width = O::Native::get_byte_width();
+    let mut buffer = MutableBuffer::new(len * byte_width);
+    // Safety: we write every element in the loop below
+    unsafe { buffer.set_len(len * byte_width) };
+    let slice = unsafe {
+        std::slice::from_raw_parts_mut(buffer.as_mut_ptr() as *mut O::Native, len)
+    };
     for idx in 0..len {
         unsafe {
-            buffer.push_unchecked(op(a.value_unchecked(idx), b.value_unchecked(idx))?);
-        };
+            *slice.get_unchecked_mut(idx) = op(a.value_unchecked(idx), b.value_unchecked(idx))?;
+        }
     }
     Ok(PrimitiveArray::new(buffer.into(), None))
 }

--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -376,8 +376,6 @@ fn create_union_null_buffer(
     }
 }
 
-/// This intentional inline(never) attribute helps LLVM optimize the loop.
-#[inline(never)]
 fn try_binary_no_nulls<A: ArrayAccessor, B: ArrayAccessor, F, O>(
     len: usize,
     a: A,


### PR DESCRIPTION
# Which issue does this PR close?

Part of #10245 

# Rationale for this change

Improves performance of the arithmetic kernels operating on primite types.

# What changes are included in this PR?

I read the issue and focused on try_binary and discovered a few other optimizations there. All mentions of benchmarks here refer to decimal_arithmetic benchmark which covers addition and subtraction on

binary: replaced iterator collect with a direct loop which LLVM can better optimize and avoids option checks. The loop overhead here is a large part of the runtime when the underlying op is simple. 

try_binary: in the null path uses Vec directly to create the buffer instead of going through the BufferBuilder. I tested it with a benchmark with 10-90% nulls and there is 5-9% improvement to the overall runtime. I don't think there's reason to include this benchmark in the library because it's very specific to this path and not general enough to be useful in the future.

try_binary_no_nulls: the typed array slice write can be vectorized more easily, Independent of that I verified that removing the no-inline annotation increases performance by additional 5% which makes sense with a more direct loop.

On average these changes increase the throughput of the kernels by 26-27% on same scale and 14-15% of different scale benchamrks for 32 and 64 bit types because the loop is a smaller fraction in the second case. 
```bash
decimal32_equal_scale/sub
                        time:   [917.00 ns 923.95 ns 932.62 ns]
                        thrpt:  [1.0980 Gelem/s 1.1083 Gelem/s 1.1167 Gelem/s]
                 change:
                        time:   [−23.032% −21.954% −20.901%] (p = 0.00 < 0.05)
                        thrpt:  [+26.424% +28.130% +29.924%]
decimal64_different_scale/add
                        time:   [1.9084 µs 1.9212 µs 1.9366 µs]
                        thrpt:  [528.77 Melem/s 533.00 Melem/s 536.59 Melem/s]
                 change:
                        time:   [−15.134% −14.025% −12.902%] (p = 0.00 < 0.05)
                        thrpt:  [+14.813% +16.313% +17.833%]
```

On 128 and 256 bit types there is around 5% speedup because of more complex math behind the underlying op. 

# Are these changes tested?

Yes, already covered by tests.

# Are there any user-facing changes?

No
