### PR TITLE
fix: shrink DataPageV2 buffer to fit before converting to Bytes

### DIFF
--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -1412,6 +1412,14 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                     }
                 };
 
+                // Shrink the buffer to fit its exact contents before converting
+                // to `Bytes`. The buffer has grown incrementally (rep levels, def
+                // levels, then compressed/uncompressed values) and may hold
+                // significant excess capacity. Without this, pages buffered for
+                // dictionary-encoded columns or held by the page writer retain
+                // that over-allocation for their entire lifetime — see #10448.
+                buffer.shrink_to_fit();
+
                 let data_page = Page::DataPageV2 {
                     buf: buffer.into(),
                     num_values: self.page_metrics.num_buffered_values,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #10448.

# Rationale for this change

The `add_data_page` function builds the DataPageV2 buffer by incrementally extending a Vec: first repetition levels, then definition levels, then values (compressed or uncompressed). This incremental growth via `extend_from_slice` can leave significant excess capacity.

The PARQUET_1_0 (DataPage v1) path already calls `shrink_to_fit` on its compressed buffer, but the PARQUET_2_0 path never reclaimed the excess capacity before converting the buffer to `Bytes` and handing it to the page writer.

For dictionary-encoded columns and deferred/buffered page writers, these pages can be retained in memory for extended periods. Each page carrying slack capacity contributes to inflated peak RSS.

# What changes are included in this PR?

Adds a `buffer.shrink_to_fit()` call immediately before the `Page::DataPageV2` construction in `add_data_page`, matching the v1 path's existing behavior.

# Are there any user-facing changes?

No API changes. Pages produced by the writer now carry no slack capacity, which may reduce peak memory usage for workloads that use DataPage v2 (the default for `parquet::file::properties::WriterProperties` when `data_page_version` is set to `V2`).

# Are these changes tested?

The existing DataPageV2 test suite (100 tests in `column::writer::tests`) all pass, including roundtrip and compression tests. The change is a memory-management detail and does not alter the serialized page format.