### PR TITLE
Update release schedule on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,17 @@ Planned Release Schedule
 
 | Approximate Date | Version    | Notes                                   |
 | ---------------- | ---------- | --------------------------------------- |
-| June 2026        | [`59.1.0`] | Minor, NO breaking API changes          |
 | July 2026        | [`59.2.0`] | Minor, NO breaking API changes          |
 | August 2026      | [`60.0.0`] | Major, potentially breaking API changes |
+| September 2026   | [`60.1.0`] | Minor, NO breaking API changes          |
+| October 2026     | [`60.2.0`] | Minor, NO breaking API changes          |
+| November 2026    | [`61.0.0`] | Major, potentially breaking API changes |
 
-[`59.1.0`]: https://github.com/apache/arrow-rs/issues/9878
 [`59.2.0`]: https://github.com/apache/arrow-rs/issues/9879
 [`60.0.0`]: https://github.com/apache/arrow-rs/issues/9880
+[`60.1.0`]: https://github.com/apache/arrow-rs/issues/10525
+[`60.2.0`]: https://github.com/apache/arrow-rs/issues/10526
+[`61.0.0`]: https://github.com/apache/arrow-rs/issues/10527
 [ticket #5368]: https://github.com/apache/arrow-rs/issues/5368
 [semantic versioning]: https://semver.org/
 


### PR DESCRIPTION
# Which issue does this PR close?

- relate to https://github.com/apache/arrow-rs/issues/7392

# Rationale for this change

I need to keep this stuff written down somewhere otherwise I lose track of it

# What changes are included in this PR?

Update the release schedule of the README to reflect
- https://github.com/apache/arrow-rs/issues/7392

Specifically:
- Remove `59.1.0` (already released)
- Add `60.1.0`, `60.1.0` and `60.2.0`

# Are these changes tested?

No, documentation only change

# Are there any user-facing changes?

No API changes
