### PR TITLE
parquet-geospatial: fix wraparound bound width (#10534)

### DIFF
--- a/parquet-geospatial/src/bounding.rs
+++ b/parquet-geospatial/src/bounding.rs
@@ -115,7 +115,7 @@ impl GeometryBounder {
         // Check if our wraparound bounds are any better than our Cartesian bounds
         // If the Cartesian bounds are tighter, return them.
         let out_width = (self.x_left.hi() - self.wraparound_hint.lo())
-            + (self.wraparound_hint.hi() - self.x_right.hi());
+            + (self.wraparound_hint.hi() - self.x_right.lo());
         if out_all.width() < out_width {
             return out_all.into();
         }
@@ -585,6 +585,16 @@ mod test {
         // Wraparound where the wrapped box *is* better
         let bounds = wkt_bounds_with_wraparound(geoms, (-180, 180)).unwrap();
         assert_eq!(bounds.x(), (170, -170).into());
+
+        // The Cartesian bounds are tighter than the wraparound bounds.
+        let geoms = [
+            "POINT (-10 0)",
+            "POINT (-2 0)",
+            "POINT (170 0)",
+            "POINT (175 0)",
+        ];
+        let bounds = wkt_bounds_with_wraparound(geoms, (-180, 180)).unwrap();
+        assert_eq!(bounds.x(), (-10, 175).into());
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

  - Closes #10534.

  # Rationale for this change

  `GeometryBounder::x()` calculates the candidate wraparound width using
  `x_right.hi()`, although the returned interval starts at `x_right.lo()`.
  This can underestimate the wraparound width and select looser bounds,
  weakening row-group pruning.

  # What changes are included in this PR?

  Use `x_right.lo()` when calculating the wraparound width and add a
  regression case where the Cartesian bounds are narrower.

  # Are these changes tested?

  Yes:

  - `cargo test -p parquet-geospatial`
  - `cargo +stable fmt --all -- --check`
  - `cargo clippy -p parquet-geospatial --all-targets --all-features -- -D warnings`
  - `cargo clippy --workspace --all-targets --all-features -- -D warnings`
  - `git diff --check`

  # Are there any user-facing changes?

  Yes. Newly computed geospatial column statistics may use tighter Cartesian
  bounds when appropriate. There are no public API changes.