### PR TITLE
chore: speed up miri workflow & include arrow-cmp

### DIFF
--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -18,6 +18,7 @@ CRATES="
     -p arrow-data
     -p arrow-ipc
     -p arrow-json
+    -p arrow-cmp
     -p arrow-ord
     -p arrow-row
     -p arrow-schema
@@ -33,7 +34,7 @@ setup_miri() {
 }
 
 
-case $# in 
+case $# in
     0)
         setup_miri
 

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -42,6 +42,7 @@ on:
       - arrow-data/**
       - arrow-ipc/**
       - arrow-json/**
+      - arrow-cmp/**
       - arrow-ord/**
       - arrow-row/**
       - arrow-schema/**
@@ -57,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -75,4 +75,4 @@ jobs:
         env:
           RUST_BACKTRACE: full
           RUST_LOG: "trace"
-        run: bash .github/workflows/miri.sh ${{ matrix.partition }} 4
+        run: bash .github/workflows/miri.sh ${{ matrix.partition }} 6

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -69,8 +69,9 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Set up nextest
-        run: |
-          cargo install cargo-nextest --version 0.9.132 --locked
+        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed  # v2.85.6
+        with:
+          tool: nextest@0.9.132
       - name: Run Miri Checks
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Set up nextest
         uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed  # v2.85.6
         with:
-          tool: nextest@0.9.132
+          tool: nextest
       - name: Run Miri Checks
         env:
           RUST_BACKTRACE: full


### PR DESCRIPTION
before https://github.com/apache/arrow-rs/pull/10507 (running miri on more crates), miri took about 15-20 minutes on average. with the new PR it increased to a bit over 30 minutes because we're running more tests.

increase the partitions count to try get average runtime down, also use taiki-e to install nextest via binary to shave off 3 minutes spent on compiling nextest from source.

also include arrow-cmp (new crate) in the miri execution