### PR TITLE
chore: install CI tools using taiki-e action

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed  # v2.85.6
+        with:
+          tool: cargo-audit
       - name: Run audit check
         run: cargo audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,11 +119,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup-builder
-      - name: Install cargo-msrv (if needed)
-        # cargo-msrv binary may be cached by the cargo cache step in setup-builder, and cargo install will error if it is already installed
-        # --locked uses cargo-msrv's pinned Cargo.lock; without it an unpinned transitive
-        # dep (aws-runtime) resolves to a version that fails to compile (E0282)
-        run: if which cargo-msrv ; then echo "using existing cargo-msrv binary" ; else cargo install cargo-msrv --locked ; fi
+      - name: Install cargo-msrv
+        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed  # v2.85.6
+        with:
+          tool: cargo-msrv
       - name: Check all packages
         run: |
           # run `cargo msrv verify --manifest-path "path/to/Cargo.toml"` to see problematic dependencies


### PR DESCRIPTION
Closes #10583.

Replace source builds of `cargo-audit` and `cargo-msrv` in CI with
prebuilt binary installation via `taiki-e/install-action`.

This keeps the audit and MSRV verification commands unchanged while
avoiding compilation from source during CI setup.

## Testing

- `actionlint .github/workflows/audit.yml .github/workflows/rust.yml`
- YAML parsing
- `git diff --check`