### PR TITLE
perf: word-at-a-time bit deposit in mask-backed RowSelection::and_then

### DIFF
--- a/arrow-buffer/src/util/bit_chunk_iterator.rs
+++ b/arrow-buffer/src/util/bit_chunk_iterator.rs
@@ -324,7 +324,7 @@ impl<'a> BitChunks<'a> {
 
     /// Returns an iterator over chunks of 64 bits, with the remaining bits zero padded to 64-bits
     #[inline]
-    pub fn iter_padded(&self) -> impl Iterator<Item = u64> + 'a {
+    pub fn iter_padded(&self) -> impl Iterator<Item = u64> + use<'a> {
         self.iter().chain(std::iter::once(self.remainder_bits()))
     }
 }

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -104,57 +104,101 @@ fn bench_mask_backed_algebra(c: &mut Criterion, selection_ratio: f64) {
     }
 }
 
-/// Benchmarks mask-backed `and_then`, taken when both operands are mask-backed.
+/// Registers one mask-backed `and_then` case under `group/label`.
+fn bench_and_then_case(
+    c: &mut Criterion,
+    group: &str,
+    label: String,
+    outer: &RowSelection,
+    inner: &RowSelection,
+) {
+    c.bench_with_input(
+        BenchmarkId::new(group, label),
+        &(outer, inner),
+        |b, (outer, inner)| b.iter(|| hint::black_box(outer.and_then(inner))),
+    );
+}
+
+/// A mask-backed selection over `len` rows selecting only the row at `index`.
+fn single_row_selection(len: usize, index: usize) -> RowSelection {
+    RowSelection::from_boolean_buffer(BooleanBuffer::from_iter((0..len).map(|i| i == index)))
+}
+
+/// A mask-backed selection over [`MASK_ALGEBRA_ROWS`] selecting every
+/// `period`-th row.
+fn periodic_selection(period: usize) -> RowSelection {
+    RowSelection::from_boolean_buffer(BooleanBuffer::from_iter(
+        (0..MASK_ALGEBRA_ROWS).map(|i| i % period == 0),
+    ))
+}
+
+/// Benchmarks mask-backed `and_then`, grouped into three case families:
 ///
-/// `and_then` deposits the bits of `other` onto the set positions of the outer
-/// mask, so its cost depends on the outer mask's density and clustering.
-/// `other` must have exactly `outer.row_count()` rows, so operands are built
+/// 1. `outer_*/inner_random_third` — outer shape sweep against the inner
+///    produced by a moderately selective filter.
+/// 2. `outer_sparse_1pct/inner_*` — inner shape sweep over a sparse outer;
+///    sparse and front-clustered inners exercise the early exit.
+/// 3. `outer_dense_90pct/inner_*` — dense outer with a sparse inner, where
+///    the word-wise kernel wins the most over per-set-bit iteration.
+///
+/// `inner` must have exactly `outer.row_count()` rows, so operands are built
 /// per case rather than shared with the other algebra benchmarks.
 fn bench_mask_backed_and_then(c: &mut Criterion, selection_ratio: f64) {
-    let cases: Vec<(&str, RowSelection)> = vec![
+    const GROUP: &str = "mask_and_then";
+
+    // Family 1: outer shape sweep, inner random ~33%
+    let outer_cases: Vec<(&str, RowSelection)> = vec![
         (
-            "sparse_1pct",
+            "outer_sparse_1pct",
             mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.01),
         ),
         (
-            "random_third",
+            "outer_random_third",
             mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, selection_ratio),
         ),
         (
-            "random_third_offset3",
+            "outer_random_third_offset3",
             mask_algebra_operand(MASK_ALGEBRA_ROWS, 3, selection_ratio),
         ),
         (
-            "dense_90pct",
+            "outer_dense_90pct",
             mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.9),
         ),
         (
-            "run32",
+            "outer_run32",
             RowSelection::from_boolean_buffer(generate_run_length_mask(MASK_ALGEBRA_ROWS, 32)),
         ),
     ];
-
-    for (label, outer) in cases {
-        let other = mask_algebra_operand(outer.row_count(), 3, selection_ratio);
-        c.bench_with_input(
-            BenchmarkId::new("mask_and_then", label),
-            &(&outer, &other),
-            |b, (outer, other)| b.iter(|| hint::black_box(outer.and_then(other))),
+    for (label, outer) in &outer_cases {
+        let inner = mask_algebra_operand(outer.row_count(), 3, selection_ratio);
+        bench_and_then_case(
+            c,
+            GROUP,
+            format!("{label}/inner_random_third"),
+            outer,
+            &inner,
         );
     }
 
-    // Sparse or clustered inner masks: once every set bit of `other` has been
-    // deposited the rest of the output is all zeros, so these shapes bound how
-    // much of the outer mask actually needs to be walked.
+    // A weakly selective inner: the densest shape that still avoids the
+    // all-ones fast path, maximizing per-word deposit work.
+    let outer = mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, selection_ratio);
+    let inner = mask_algebra_operand(outer.row_count(), 3, 0.9);
+    bench_and_then_case(
+        c,
+        GROUP,
+        "outer_random_third/inner_dense_90pct".to_string(),
+        &outer,
+        &inner,
+    );
+
+    // Family 2: inner shape sweep, outer sparse 1%. Once every set bit of
+    // `inner` has been deposited the rest of the output is all zeros, so
+    // these shapes bound how much of the outer mask needs to be walked.
     let outer = mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.01);
     let selected = outer.row_count();
     let inner_cases: Vec<(&str, RowSelection)> = vec![
-        (
-            "inner_first_only",
-            RowSelection::from_boolean_buffer(BooleanBuffer::from_iter(
-                (0..selected).map(|i| i == 0),
-            )),
-        ),
+        ("inner_first_only", single_row_selection(selected, 0)),
         (
             "inner_front_cluster",
             RowSelection::from_boolean_buffer(BooleanBuffer::from_iter(
@@ -165,12 +209,68 @@ fn bench_mask_backed_and_then(c: &mut Criterion, selection_ratio: f64) {
             "inner_sparse_0_1pct",
             mask_algebra_operand(selected, 0, 0.001),
         ),
+        (
+            "inner_last_only",
+            single_row_selection(selected, selected - 1),
+        ),
     ];
-    for (label, other) in inner_cases {
-        c.bench_with_input(
-            BenchmarkId::new("mask_and_then", format!("sparse_1pct/{label}")),
-            &(&outer, &other),
-            |b, (outer, other)| b.iter(|| hint::black_box(outer.and_then(other))),
+    for (label, inner) in &inner_cases {
+        bench_and_then_case(
+            c,
+            GROUP,
+            format!("outer_sparse_1pct/{label}"),
+            &outer,
+            inner,
+        );
+    }
+
+    // Family 3: dense outer, sparse inner
+    let outer = mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.9);
+    let selected = outer.row_count();
+    let inner = single_row_selection(selected, selected - 1);
+    bench_and_then_case(
+        c,
+        GROUP,
+        "outer_dense_90pct/inner_last_only".to_string(),
+        &outer,
+        &inner,
+    );
+}
+
+/// Benchmarks shapes near the sparse/dense kernel dispatch boundary of
+/// mask-backed `and_then`.
+///
+/// The dispatch estimates `20 * (selected + 16 * other_true_count)` against
+/// `len`, so with a single-bit inner the boundary sits at an outer density of
+/// 1/20 words (`every_20`), and with a random ~33% inner at an outer period
+/// of ~126. A discontinuity across adjacent cases would indicate a misplaced
+/// threshold.
+fn bench_mask_backed_and_then_boundary(c: &mut Criterion, selection_ratio: f64) {
+    const GROUP: &str = "mask_and_then_boundary";
+
+    // Family 1: periodic outer, single-bit inner; boundary at `every_20`
+    for period in [32, 24, 20, 16, 8] {
+        let outer = periodic_selection(period);
+        let inner = single_row_selection(outer.row_count(), outer.row_count() - 1);
+        bench_and_then_case(
+            c,
+            GROUP,
+            format!("outer_every_{period}/inner_last_only"),
+            &outer,
+            &inner,
+        );
+    }
+
+    // Family 2: periodic outer, random ~33% inner; boundary at ~`every_126`
+    for period in [200, 133, 100, 50] {
+        let outer = periodic_selection(period);
+        let inner = mask_algebra_operand(outer.row_count(), 3, selection_ratio);
+        bench_and_then_case(
+            c,
+            GROUP,
+            format!("outer_every_{period}/inner_random_third"),
+            &outer,
+            &inner,
         );
     }
 }
@@ -275,6 +375,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     bench_mask_backed_algebra(c, selection_ratio);
     bench_mask_backed_and_then(c, selection_ratio);
+    bench_mask_backed_and_then_boundary(c, selection_ratio);
     bench_mask_backed_conversion(c, total_rows, selection_ratio);
 }
 

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -104,6 +104,46 @@ fn bench_mask_backed_algebra(c: &mut Criterion, selection_ratio: f64) {
     }
 }
 
+/// Benchmarks mask-backed `and_then`, taken when both operands are mask-backed.
+///
+/// `and_then` deposits the bits of `other` onto the set positions of the outer
+/// mask, so its cost depends on the outer mask's density and clustering.
+/// `other` must have exactly `outer.row_count()` rows, so operands are built
+/// per case rather than shared with the other algebra benchmarks.
+fn bench_mask_backed_and_then(c: &mut Criterion, selection_ratio: f64) {
+    let mut cases: Vec<(&str, RowSelection)> = vec![
+        (
+            "sparse_1pct",
+            mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.01),
+        ),
+        (
+            "random_third",
+            mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, selection_ratio),
+        ),
+        (
+            "random_third_offset3",
+            mask_algebra_operand(MASK_ALGEBRA_ROWS, 3, selection_ratio),
+        ),
+        (
+            "dense_90pct",
+            mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.9),
+        ),
+    ];
+    cases.push((
+        "run32",
+        RowSelection::from_boolean_buffer(generate_run_length_mask(MASK_ALGEBRA_ROWS, 32)),
+    ));
+
+    for (label, outer) in cases {
+        let other = mask_algebra_operand(outer.row_count(), 3, selection_ratio);
+        c.bench_with_input(
+            BenchmarkId::new("mask_and_then", label),
+            &(&outer, &other),
+            |b, (outer, other)| b.iter(|| hint::black_box(outer.and_then(other))),
+        );
+    }
+}
+
 /// Benchmarks converting a mask-backed [`RowSelection`] into [`RowSelector`]s.
 ///
 /// `RowSelection::iter` caches the RLE form, so a caller that iterates before
@@ -203,6 +243,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     bench_mask_backed_algebra(c, selection_ratio);
+    bench_mask_backed_and_then(c, selection_ratio);
     bench_mask_backed_conversion(c, total_rows, selection_ratio);
 }
 

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -111,7 +111,7 @@ fn bench_mask_backed_algebra(c: &mut Criterion, selection_ratio: f64) {
 /// `other` must have exactly `outer.row_count()` rows, so operands are built
 /// per case rather than shared with the other algebra benchmarks.
 fn bench_mask_backed_and_then(c: &mut Criterion, selection_ratio: f64) {
-    let mut cases: Vec<(&str, RowSelection)> = vec![
+    let cases: Vec<(&str, RowSelection)> = vec![
         (
             "sparse_1pct",
             mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.01),
@@ -128,11 +128,11 @@ fn bench_mask_backed_and_then(c: &mut Criterion, selection_ratio: f64) {
             "dense_90pct",
             mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.9),
         ),
+        (
+            "run32",
+            RowSelection::from_boolean_buffer(generate_run_length_mask(MASK_ALGEBRA_ROWS, 32)),
+        ),
     ];
-    cases.push((
-        "run32",
-        RowSelection::from_boolean_buffer(generate_run_length_mask(MASK_ALGEBRA_ROWS, 32)),
-    ));
 
     for (label, outer) in cases {
         let other = mask_algebra_operand(outer.row_count(), 3, selection_ratio);

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -142,6 +142,37 @@ fn bench_mask_backed_and_then(c: &mut Criterion, selection_ratio: f64) {
             |b, (outer, other)| b.iter(|| hint::black_box(outer.and_then(other))),
         );
     }
+
+    // Sparse or clustered inner masks: once every set bit of `other` has been
+    // deposited the rest of the output is all zeros, so these shapes bound how
+    // much of the outer mask actually needs to be walked.
+    let outer = mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.01);
+    let selected = outer.row_count();
+    let inner_cases: Vec<(&str, RowSelection)> = vec![
+        (
+            "inner_first_only",
+            RowSelection::from_boolean_buffer(BooleanBuffer::from_iter(
+                (0..selected).map(|i| i == 0),
+            )),
+        ),
+        (
+            "inner_front_cluster",
+            RowSelection::from_boolean_buffer(BooleanBuffer::from_iter(
+                (0..selected).map(|i| i < selected / 100),
+            )),
+        ),
+        (
+            "inner_sparse_0_1pct",
+            mask_algebra_operand(selected, 0, 0.001),
+        ),
+    ];
+    for (label, other) in inner_cases {
+        c.bench_with_input(
+            BenchmarkId::new("mask_and_then", format!("sparse_1pct/{label}")),
+            &(&outer, &other),
+            |b, (outer, other)| b.iter(|| hint::black_box(outer.and_then(other))),
+        );
+    }
 }
 
 /// Benchmarks converting a mask-backed [`RowSelection`] into [`RowSelector`]s.

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -192,9 +192,8 @@ fn bench_mask_backed_and_then(c: &mut Criterion, selection_ratio: f64) {
         &inner,
     );
 
-    // Family 2: inner shape sweep, outer sparse 1%. Once every set bit of
-    // `inner` has been deposited the rest of the output is all zeros, so
-    // these shapes bound how much of the outer mask needs to be walked.
+    // Family 2: inner shape sweep, outer sparse 1% — all route to the sparse
+    // kernel.
     let outer = mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.01);
     let selected = outer.row_count();
     let inner_cases: Vec<(&str, RowSelection)> = vec![
@@ -224,27 +223,43 @@ fn bench_mask_backed_and_then(c: &mut Criterion, selection_ratio: f64) {
         );
     }
 
-    // Family 3: dense outer, sparse inner
+    // Family 3: dense outer, sparse inners — all route to the dense kernel.
+    // Front-loaded inners exercise its early exit; a trailing bit forces a
+    // full walk.
     let outer = mask_algebra_operand(MASK_ALGEBRA_ROWS, 0, 0.9);
     let selected = outer.row_count();
-    let inner = single_row_selection(selected, selected - 1);
-    bench_and_then_case(
-        c,
-        GROUP,
-        "outer_dense_90pct/inner_last_only".to_string(),
-        &outer,
-        &inner,
-    );
+    let inner_cases: Vec<(&str, RowSelection)> = vec![
+        ("inner_first_only", single_row_selection(selected, 0)),
+        (
+            "inner_front_cluster",
+            RowSelection::from_boolean_buffer(BooleanBuffer::from_iter(
+                (0..selected).map(|i| i < selected / 100),
+            )),
+        ),
+        (
+            "inner_last_only",
+            single_row_selection(selected, selected - 1),
+        ),
+    ];
+    for (label, inner) in &inner_cases {
+        bench_and_then_case(
+            c,
+            GROUP,
+            format!("outer_dense_90pct/{label}"),
+            &outer,
+            inner,
+        );
+    }
 }
 
 /// Benchmarks shapes near the sparse/dense kernel dispatch boundary of
 /// mask-backed `and_then`.
 ///
-/// The dispatch estimates `20 * (selected + 16 * other_true_count)` against
-/// `len`, so with a single-bit inner the boundary sits at an outer density of
-/// 1/20 words (`every_20`), and with a random ~33% inner at an outer period
-/// of ~126. A discontinuity across adjacent cases would indicate a misplaced
-/// threshold.
+/// The dispatch estimates `selected + 16 * other_true_count` against
+/// `len / 20`, so with a single-bit inner the boundary sits at an outer
+/// density of 1/20 words (`every_20`), and with a random ~33% inner at an
+/// outer period of ~126. A discontinuity across adjacent cases would indicate
+/// a misplaced threshold.
 fn bench_mask_backed_and_then_boundary(c: &mut Criterion, selection_ratio: f64) {
     const GROUP: &str = "mask_and_then_boundary";
 

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -352,6 +352,18 @@ where
     builder.finish()
 }
 
+/// Applies `other` to the selected rows of `mask`, both mask-backed.
+///
+/// After validation and the trivial fast paths, dispatches between two
+/// kernels on the operands' set-bit counts:
+///
+/// - [`and_then_masks_sparse`] visits only set bits: ~`selected_count`
+///   set-index steps plus an append per `other` set bit.
+/// - [`and_then_masks_dense`] visits every 64-bit word of `mask` exactly
+///   once, regardless of how many bits are set.
+///
+/// Each is the faster choice in its own regime; the dispatch compares their
+/// cost models.
 fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer {
     let selected_count = mask.count_set_bits();
     match other.len().cmp(&selected_count) {
@@ -368,9 +380,56 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
         return mask.clone();
     }
 
-    // Deposit the bits of `other` into the set positions of `mask`, one
-    // 64-bit word of `mask` at a time: a word with `k` set bits consumes the
-    // next `k` bits of `other`.
+    // Cost model fitted from kernel sweeps over regular, random and
+    // clustered bit patterns: relative to a sparse set-index step, a sparse
+    // append costs ~16x and the dense kernel ~`len / 20` in total. Ties favor
+    // the sparse kernel: its wins over the dense kernel are pattern-dependent
+    // while its losses are bounded, so this never regresses the shapes it
+    // replaced while keeping the dense kernel's larger wins.
+    let sparse_cost = selected_count + 16 * other_true_count;
+    if 20 * sparse_cost < mask.len() {
+        and_then_masks_sparse(mask, other)
+    } else {
+        and_then_masks_dense(mask, other, other_true_count)
+    }
+}
+
+/// Sparse kernel of [`and_then_masks`]: iterates the set bits of both sides
+/// instead of every word of `mask`, bulk-filling the unset gaps.
+fn and_then_masks_sparse(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer {
+    let mut builder = BooleanBufferBuilder::new(mask.len());
+    let mut outer_set_indices = mask.set_indices();
+    let mut next_selected_ordinal = 0usize;
+    let mut cursor = 0usize;
+
+    for selected_ordinal in other.set_indices() {
+        let skip = selected_ordinal - next_selected_ordinal;
+        let set_idx = outer_set_indices
+            .nth(skip)
+            .expect("validated other length matches selected row count");
+        if set_idx > cursor {
+            builder.append_n(set_idx - cursor, false);
+        }
+        builder.append(true);
+        cursor = set_idx + 1;
+        next_selected_ordinal = selected_ordinal + 1;
+    }
+
+    if cursor < mask.len() {
+        builder.append_n(mask.len() - cursor, false);
+    }
+
+    builder.finish()
+}
+
+/// Dense kernel of [`and_then_masks`]: deposits the bits of `other` onto the
+/// set positions of `mask`, one 64-bit word of `mask` at a time — a word with
+/// `k` set bits consumes the next `k` bits of `other`.
+fn and_then_masks_dense(
+    mask: &BooleanBuffer,
+    other: &BooleanBuffer,
+    other_true_count: usize,
+) -> BooleanBuffer {
     let mut other_bits = bit_stream(other);
     let mask_chunks = mask.bit_chunks();
     let mut buffer = MutableBuffer::from_len_zeroed(mask_chunks.num_u64s() * 8);
@@ -381,6 +440,10 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
     // `num_u64s` has no remainder word
     let out_words = buffer.typed_data_mut::<u64>().iter_mut();
     for (out, word) in out_words.zip(mask_chunks.iter_padded()) {
+        // A zero word selects nothing and its output is already zeroed
+        if word == 0 {
+            continue;
+        }
         let deposited = deposit_word(word, &mut other_bits);
         remaining -= deposited.count_ones() as usize;
         // BooleanBuffer words are little-endian
@@ -827,6 +890,42 @@ mod tests {
                 .collect();
 
             assert_eq!(actual, expected, "true_count={true_count}");
+        }
+    }
+
+    #[test]
+    fn test_mask_and_then_mask_sparse_fallback() {
+        // Sparse mask over a large domain with few `other` set bits routes to
+        // the per-set-bit fallback path.
+        let len = 200_000;
+        let outer_bits: Vec<bool> = (0..len).map(|i| i % 997 == 0).collect();
+        let selected = outer_bits.iter().filter(|&&bit| bit).count();
+        assert!(
+            20 * (selected + 16 * selected) < len,
+            "must take sparse path"
+        );
+
+        let inner_patterns: Vec<Vec<bool>> = vec![
+            (0..selected).map(|i| i == 0).collect(),
+            (0..selected).map(|i| i + 1 == selected).collect(),
+            (0..selected).map(|i| i % 79 == 3).collect(),
+        ];
+
+        for (case, inner_bits) in inner_patterns.into_iter().enumerate() {
+            let outer = RowSelection::from_boolean_buffer(BooleanBuffer::from(outer_bits.clone()));
+            let inner = RowSelection::from_boolean_buffer(BooleanBuffer::from(inner_bits.clone()));
+
+            let result = outer.and_then(&inner);
+            let result = result.as_mask().expect("mask backing");
+            let actual: Vec<_> = (0..result.len()).map(|i| result.value(i)).collect();
+
+            let mut inner_iter = inner_bits.into_iter();
+            let expected: Vec<_> = outer_bits
+                .iter()
+                .map(|&selected| selected && inner_iter.next().expect("matching inner length"))
+                .collect();
+
+            assert_eq!(actual, expected, "case={case}");
         }
     }
 

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -371,7 +371,7 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
     // Deposit the bits of `other` into the set positions of `mask`, one
     // 64-bit word of `mask` at a time: a word with `k` set bits consumes the
     // next `k` bits of `other`.
-    let mut other_bits = BitStream::new(other);
+    let mut other_bits = bit_stream(other);
     let mask_chunks = mask.bit_chunks();
     let words = mask_chunks
         .iter()
@@ -388,6 +388,9 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
 
 /// Scatter the next `mask.count_ones()` bits of `bits` onto the set positions
 /// of `mask`, preserving order.
+///
+/// This is the software equivalent of the x86_64 BMI2 `_pdep_u64` instruction,
+/// should platform-specific acceleration ever be worthwhile.
 fn deposit_word<I: Iterator<Item = u64>>(mask: u64, bits: &mut BitStream<I>) -> u64 {
     let mut mask = mask;
     let mut bits = bits.take(mask.count_ones() as usize);
@@ -412,22 +415,12 @@ struct BitStream<I: Iterator<Item = u64>> {
     available: usize,
 }
 
-impl<'a>
-    BitStream<
-        std::iter::Chain<
-            arrow_buffer::bit_chunk_iterator::BitChunkIterator<'a>,
-            std::iter::Once<u64>,
-        >,
-    >
-{
-    fn new(buffer: &'a BooleanBuffer) -> Self {
-        let chunks = buffer.bit_chunks();
-        let remainder = chunks.remainder_bits();
-        Self {
-            words: chunks.iter().chain(std::iter::once(remainder)),
-            current: 0,
-            available: 0,
-        }
+/// Creates a [`BitStream`] over the bits of `buffer`.
+fn bit_stream(buffer: &BooleanBuffer) -> BitStream<impl Iterator<Item = u64> + '_> {
+    BitStream {
+        words: buffer.bit_chunks().iter_padded(),
+        current: 0,
+        available: 0,
     }
 }
 

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -377,7 +377,8 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
         .iter()
         // BooleanBuffer words are little-endian
         .map(|word| deposit_word(word, &mut other_bits).to_le());
-    // Soundness: `BitChunks::iter` correctly reports its upper bound
+    // Soundness: `BitChunkIterator` is an `ExactSizeIterator`, so the upper
+    // bound reported through `map` is exact
     let mut buffer = unsafe { MutableBuffer::from_trusted_len_iter(words) };
 
     let remainder_bytes = mask_chunks.remainder_len().div_ceil(8);
@@ -394,15 +395,15 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
 /// should platform-specific acceleration ever be worthwhile.
 fn deposit_word<I: Iterator<Item = u64>>(mask: u64, bits: &mut BitStream<I>) -> u64 {
     let mut mask = mask;
-    let mut bits = bits.take(mask.count_ones() as usize);
+    let mut value = bits.take(mask.count_ones() as usize);
     let mut out = 0u64;
-    // Once `bits` is exhausted the remaining set positions all deposit zeros
-    while bits != 0 {
+    // Once `value` is exhausted the remaining set positions all deposit zeros
+    while value != 0 {
         let lowest = mask & mask.wrapping_neg();
-        if bits & 1 == 1 {
+        if value & 1 == 1 {
             out |= lowest;
         }
-        bits >>= 1;
+        value >>= 1;
         mask &= mask - 1;
     }
     out

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -375,7 +375,8 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
     let mask_chunks = mask.bit_chunks();
     let words = mask_chunks
         .iter()
-        .map(|word| deposit_word(word, &mut other_bits));
+        // BooleanBuffer words are little-endian
+        .map(|word| deposit_word(word, &mut other_bits).to_le());
     // Soundness: `BitChunks::iter` correctly reports its upper bound
     let mut buffer = unsafe { MutableBuffer::from_trusted_len_iter(words) };
 
@@ -747,6 +748,51 @@ mod tests {
             actual_bits,
             vec![false, false, true, false, false, false, true, false]
         );
+    }
+
+    #[test]
+    fn test_mask_and_then_mask_word_boundaries_and_offsets() {
+        for len in [0, 1, 7, 8, 9, 63, 64, 65, 127, 128, 129] {
+            for outer_offset in 0..8 {
+                for inner_offset in 0..8 {
+                    let outer_storage: Vec<_> = (0..len + outer_offset)
+                        .map(|i| (i * 17 + len * 3 + outer_offset) % 11 < 6)
+                        .collect();
+                    let outer_bits = outer_storage[outer_offset..].to_vec();
+                    let selected_count = outer_bits.iter().filter(|&&bit| bit).count();
+
+                    let inner_storage: Vec<_> = (0..selected_count + inner_offset)
+                        .map(|i| (i * 13 + len + inner_offset * 5) % 7 < 3)
+                        .collect();
+                    let inner_bits = inner_storage[inner_offset..].to_vec();
+
+                    let outer = RowSelection::from_boolean_buffer(
+                        BooleanBuffer::from(outer_storage).slice(outer_offset, len),
+                    );
+                    let inner = RowSelection::from_boolean_buffer(
+                        BooleanBuffer::from(inner_storage).slice(inner_offset, selected_count),
+                    );
+
+                    let result = outer.and_then(&inner);
+                    let result = result.as_mask().expect("mask backing");
+                    let actual: Vec<_> = (0..result.len()).map(|i| result.value(i)).collect();
+
+                    let mut inner_bits = inner_bits.into_iter();
+                    let expected: Vec<_> = outer_bits
+                        .into_iter()
+                        .map(|selected| {
+                            selected && inner_bits.next().expect("matching inner length")
+                        })
+                        .collect();
+                    assert!(inner_bits.next().is_none());
+
+                    assert_eq!(
+                        actual, expected,
+                        "len={len}, outer_offset={outer_offset}, inner_offset={inner_offset}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -23,7 +23,7 @@
 //! [`BooleanBuffer`] masks.
 
 use super::{MaskRunIter, RowSelection, RowSelectionInner, RowSelector};
-use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder};
+use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, MutableBuffer};
 use std::cmp::Ordering;
 use std::iter::Peekable;
 
@@ -368,29 +368,94 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
         return mask.clone();
     }
 
-    let mut builder = BooleanBufferBuilder::new(mask.len());
-    let mut outer_set_indices = mask.set_indices();
-    let mut next_selected_ordinal = 0usize;
-    let mut cursor = 0usize;
+    // Deposit the bits of `other` into the set positions of `mask`, one
+    // 64-bit word of `mask` at a time: a word with `k` set bits consumes the
+    // next `k` bits of `other`.
+    let mut other_bits = BitStream::new(other);
+    let mask_chunks = mask.bit_chunks();
+    let words = mask_chunks
+        .iter()
+        .map(|word| deposit_word(word, &mut other_bits));
+    // Soundness: `BitChunks::iter` correctly reports its upper bound
+    let mut buffer = unsafe { MutableBuffer::from_trusted_len_iter(words) };
 
-    for selected_ordinal in other.set_indices() {
-        let skip = selected_ordinal - next_selected_ordinal;
-        let set_idx = outer_set_indices
-            .nth(skip)
-            .expect("validated other length matches selected row count");
-        if set_idx > cursor {
-            builder.append_n(set_idx - cursor, false);
+    let remainder_bytes = mask_chunks.remainder_len().div_ceil(8);
+    let remainder = deposit_word(mask_chunks.remainder_bits(), &mut other_bits);
+    buffer.extend_from_slice(&remainder.to_le_bytes()[..remainder_bytes]);
+
+    BooleanBuffer::new(buffer.into(), 0, mask.len())
+}
+
+/// Scatter the next `mask.count_ones()` bits of `bits` onto the set positions
+/// of `mask`, preserving order.
+fn deposit_word<I: Iterator<Item = u64>>(mask: u64, bits: &mut BitStream<I>) -> u64 {
+    let mut mask = mask;
+    let mut bits = bits.take(mask.count_ones() as usize);
+    let mut out = 0u64;
+    // Once `bits` is exhausted the remaining set positions all deposit zeros
+    while bits != 0 {
+        let lowest = mask & mask.wrapping_neg();
+        if bits & 1 == 1 {
+            out |= lowest;
         }
-        builder.append(true);
-        cursor = set_idx + 1;
-        next_selected_ordinal = selected_ordinal + 1;
+        bits >>= 1;
+        mask &= mask - 1;
     }
+    out
+}
 
-    if cursor < mask.len() {
-        builder.append_n(mask.len() - cursor, false);
+/// Sequential little-endian reader of the bits of a [`BooleanBuffer`].
+struct BitStream<I: Iterator<Item = u64>> {
+    words: I,
+    /// Low `available` bits are the next unconsumed bits; higher bits are zero
+    current: u64,
+    available: usize,
+}
+
+impl<'a>
+    BitStream<
+        std::iter::Chain<
+            arrow_buffer::bit_chunk_iterator::BitChunkIterator<'a>,
+            std::iter::Once<u64>,
+        >,
+    >
+{
+    fn new(buffer: &'a BooleanBuffer) -> Self {
+        let chunks = buffer.bit_chunks();
+        let remainder = chunks.remainder_bits();
+        Self {
+            words: chunks.iter().chain(std::iter::once(remainder)),
+            current: 0,
+            available: 0,
+        }
     }
+}
 
-    builder.finish()
+impl<I: Iterator<Item = u64>> BitStream<I> {
+    /// Consume the next `k` bits (`k <= 64`), returned in the low bits
+    fn take(&mut self, k: usize) -> u64 {
+        debug_assert!(k <= 64);
+        if k == 0 {
+            return 0;
+        }
+        let mut value = self.current;
+        if k <= self.available {
+            self.available -= k;
+            self.current = if k == 64 { 0 } else { self.current >> k };
+        } else {
+            let have = self.available;
+            let next = self.words.next().unwrap_or(0);
+            // `have < k <= 64` keeps this shift in range
+            value |= next << have;
+            let used = k - have;
+            self.current = if used == 64 { 0 } else { next >> used };
+            self.available = 64 - used;
+        }
+        if k < 64 {
+            value &= (1u64 << k) - 1;
+        }
+        value
+    }
 }
 
 #[cfg(test)]

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -373,17 +373,23 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
     // next `k` bits of `other`.
     let mut other_bits = bit_stream(other);
     let mask_chunks = mask.bit_chunks();
-    let words = mask_chunks
-        .iter()
+    let mut buffer = MutableBuffer::from_len_zeroed(mask_chunks.num_u64s() * 8);
+    // Once every set bit of `other` has been deposited the rest of the output
+    // is all zeros, so stop walking `mask` and leave the pre-zeroed tail as is.
+    let mut remaining = other_true_count;
+    // `iter_padded` always pads a trailing word; `zip` drops it when
+    // `num_u64s` has no remainder word
+    let out_words = buffer.typed_data_mut::<u64>().iter_mut();
+    for (out, word) in out_words.zip(mask_chunks.iter_padded()) {
+        let deposited = deposit_word(word, &mut other_bits);
+        remaining -= deposited.count_ones() as usize;
         // BooleanBuffer words are little-endian
-        .map(|word| deposit_word(word, &mut other_bits).to_le());
-    // Soundness: `BitChunkIterator` is an `ExactSizeIterator`, so the upper
-    // bound reported through `map` is exact
-    let mut buffer = unsafe { MutableBuffer::from_trusted_len_iter(words) };
-
-    let remainder_bytes = mask_chunks.remainder_len().div_ceil(8);
-    let remainder = deposit_word(mask_chunks.remainder_bits(), &mut other_bits);
-    buffer.extend_from_slice(&remainder.to_le_bytes()[..remainder_bytes]);
+        *out = deposited.to_le();
+        if remaining == 0 {
+            break;
+        }
+    }
+    buffer.truncate(mask_chunks.num_bytes());
 
     BooleanBuffer::new(buffer.into(), 0, mask.len())
 }
@@ -793,6 +799,34 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn test_mask_and_then_mask_sparse_inner_early_exit() {
+        // All of `other`'s set bits sit at the front, so the deposit loop
+        // stops early and the multi-word tail is bulk zero-filled.
+        let len = 1000;
+        let outer_bits: Vec<bool> = (0..len).map(|i| i % 7 == 0).collect();
+        let selected = outer_bits.iter().filter(|&&bit| bit).count();
+
+        for true_count in [1, 2, 64, selected - 1, selected] {
+            let inner_bits: Vec<bool> = (0..selected).map(|i| i < true_count).collect();
+
+            let outer = RowSelection::from_boolean_buffer(BooleanBuffer::from(outer_bits.clone()));
+            let inner = RowSelection::from_boolean_buffer(BooleanBuffer::from(inner_bits.clone()));
+
+            let result = outer.and_then(&inner);
+            let result = result.as_mask().expect("mask backing");
+            let actual: Vec<_> = (0..result.len()).map(|i| result.value(i)).collect();
+
+            let mut inner_iter = inner_bits.into_iter();
+            let expected: Vec<_> = outer_bits
+                .iter()
+                .map(|&selected| selected && inner_iter.next().expect("matching inner length"))
+                .collect();
+
+            assert_eq!(actual, expected, "true_count={true_count}");
         }
     }
 

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -352,18 +352,13 @@ where
     builder.finish()
 }
 
-/// Applies `other` to the selected rows of `mask`, both mask-backed.
-///
-/// After validation and the trivial fast paths, dispatches between two
-/// kernels on the operands' set-bit counts:
+/// Applies `other` to the selected rows of `mask`, dispatching between two
+/// kernels by estimated cost:
 ///
 /// - [`and_then_masks_sparse`] visits only set bits: ~`selected_count`
 ///   set-index steps plus an append per `other` set bit.
 /// - [`and_then_masks_dense`] visits every 64-bit word of `mask` exactly
 ///   once, regardless of how many bits are set.
-///
-/// Each is the faster choice in its own regime; the dispatch compares their
-/// cost models.
 fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer {
     let selected_count = mask.count_set_bits();
     match other.len().cmp(&selected_count) {
@@ -380,14 +375,11 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
         return mask.clone();
     }
 
-    // Cost model fitted from kernel sweeps over regular, random and
-    // clustered bit patterns: relative to a sparse set-index step, a sparse
-    // append costs ~16x and the dense kernel ~`len / 20` in total. Ties favor
-    // the sparse kernel: its wins over the dense kernel are pattern-dependent
-    // while its losses are bounded, so this never regresses the shapes it
-    // replaced while keeping the dense kernel's larger wins.
-    let sparse_cost = selected_count + 16 * other_true_count;
-    if 20 * sparse_cost < mask.len() {
+    // Empirically a sparse append costs ~16 set-index steps and the dense
+    // kernel ~`len / 20` steps; ties go sparse. Saturation guards 32-bit
+    // overflow.
+    let sparse_cost = selected_count.saturating_add(other_true_count.saturating_mul(16));
+    if sparse_cost <= mask.len() / 20 {
         and_then_masks_sparse(mask, other)
     } else {
         and_then_masks_dense(mask, other, other_true_count)
@@ -422,9 +414,8 @@ fn and_then_masks_sparse(mask: &BooleanBuffer, other: &BooleanBuffer) -> Boolean
     builder.finish()
 }
 
-/// Dense kernel of [`and_then_masks`]: deposits the bits of `other` onto the
-/// set positions of `mask`, one 64-bit word of `mask` at a time — a word with
-/// `k` set bits consumes the next `k` bits of `other`.
+/// Dense kernel of [`and_then_masks`]: a word of `mask` with `k` set bits
+/// consumes and deposits the next `k` bits of `other`.
 fn and_then_masks_dense(
     mask: &BooleanBuffer,
     other: &BooleanBuffer,
@@ -433,11 +424,10 @@ fn and_then_masks_dense(
     let mut other_bits = bit_stream(other);
     let mask_chunks = mask.bit_chunks();
     let mut buffer = MutableBuffer::from_len_zeroed(mask_chunks.num_u64s() * 8);
-    // Once every set bit of `other` has been deposited the rest of the output
-    // is all zeros, so stop walking `mask` and leave the pre-zeroed tail as is.
+    // The pre-zeroed tail is already correct once every set bit of `other`
+    // has been deposited
     let mut remaining = other_true_count;
-    // `iter_padded` always pads a trailing word; `zip` drops it when
-    // `num_u64s` has no remainder word
+    // `zip` drops `iter_padded`'s trailing pad word when there is no remainder
     let out_words = buffer.typed_data_mut::<u64>().iter_mut();
     for (out, word) in out_words.zip(mask_chunks.iter_padded()) {
         // A zero word selects nothing and its output is already zeroed
@@ -458,10 +448,7 @@ fn and_then_masks_dense(
 }
 
 /// Scatter the next `mask.count_ones()` bits of `bits` onto the set positions
-/// of `mask`, preserving order.
-///
-/// This is the software equivalent of the x86_64 BMI2 `_pdep_u64` instruction,
-/// should platform-specific acceleration ever be worthwhile.
+/// of `mask`, preserving order — a software `_pdep_u64`.
 fn deposit_word<I: Iterator<Item = u64>>(mask: u64, bits: &mut BitStream<I>) -> u64 {
     let mut mask = mask;
     let mut value = bits.take(mask.count_ones() as usize);
@@ -901,7 +888,7 @@ mod tests {
         let outer_bits: Vec<bool> = (0..len).map(|i| i % 997 == 0).collect();
         let selected = outer_bits.iter().filter(|&&bit| bit).count();
         assert!(
-            20 * (selected + 16 * selected) < len,
+            selected + 16 * selected <= len / 20,
             "must take sparse path"
         );
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #10592.

# Rationale for this change

`and_then_masks` runs once per predicate per row group during filter pushdown when selections are mask-backed. The current per-set-bit implementation is slow for large or dense selections.

# What changes are included in this PR?

- Rewrite `and_then_masks` as a dispatch between two kernels:
  - a **dense kernel** that deposits the next `k` bits of `other` onto each 64-bit word of `mask` with `k` set bits, with word-wise output, an early exit once every set bit of `other` is deposited (the zero-initialized tail is already correct), and a cheap skip for all-zero mask words;
  - a **sparse kernel** (the previous per-set-bit implementation) that iterates the set bits of both sides and bulk-fills the gaps.

  The dispatch uses a cost model fitted from kernel sweeps over regular, random and clustered bit patterns (`selected + 16 * other_true_count <= len / 20` → sparse, saturating on 32-bit targets). Ties favor the sparse kernel, so no shape regresses against the existing implementation while the dense kernel's larger wins are kept.
- Reorganize the `row_selector` benchmarks (this path previously had no coverage) into labeled families — outer shape sweep, inner shape sweep, dense-outer/sparse-inner early-exit shapes — plus a `mask_and_then_boundary` group sampling both sides of the dispatch boundary.
- One-line `arrow-buffer` change: `BitChunks::iter_padded` gains a `+ use<'a>` precise-capturing annotation. The edition 2024 migration made its RPIT implicitly capture the `&self` borrow, so the returned iterator could no longer outlive the temporary `BitChunks` — even though the body only borrows the underlying buffer (`'a`). The annotation restores the edition-2021 semantics of the existing `+ 'a` bound, letting the dense kernel build its bit stream on `iter_padded` instead of hand-rolling the chunk/remainder chain. Per the Cargo semver reference ([capturing generic parameters in RPIT](https://doc.rust-lang.org/cargo/reference/semver.html#generic-rpit-capture)), capturing *fewer* generic parameters in an RPIT is a minor (non-breaking) change.

# Benchmark results

`row_selector::mask_and_then`, 3M rows (aarch64 macOS), all numbers measured on the same machine in the same session:

| outer mask | inner mask | main | this PR | change |
|---|---|---|---|---|
| random 1% | random 33% | 337 µs | 247 µs | −27% |
| random 33% | random 33% | 4.43 ms | 1.03 ms | −77% |
| random 90% | random 33% | 9.13 ms | 2.07 ms | −77% |
| run32 (50%) | random 33% | 4.98 ms | 1.17 ms | −76% |
| random 33% | random 90% | 7.37 ms | 1.08 ms | −85% |
| random 90% | single trailing true | 1.87 ms | 142 µs | −92% |
| random 1% | single leading true | 9.0 µs | 9.0 µs | parity |
| random 1% | single trailing true | 194 µs | 186 µs | parity |

Sparse-by-sparse shapes route to the sparse kernel — the same algorithm as `main` — so they are at parity by construction; the `mask_and_then_boundary` group confirms the crossover is smooth (no step across adjacent cases). The dense kernel's early exit shows as a gradient over the dense outer as the inner's last set bit moves forward: 146 µs (trailing bit) → 36 µs (front cluster) → 13 µs (leading bit).

# Are these changes tested?

Covered by existing `selection` tests (66 pass), including randomized equivalence tests, word-boundary/offset sweeps for the dense kernel, and dedicated tests for the early exit and the sparse-kernel dispatch. Bit-for-bit equivalent, performance only.

# Are there any user-facing changes?

No behavioral changes. The `BitChunks::iter_padded` return type now captures fewer lifetimes (`+ use<'a>`), a non-breaking relaxation of a public API.
