### PR TITLE
Enable allow_attributes lint for arrow-arith

### DIFF
--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -421,7 +421,6 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    #[allow(deprecated)]
     fn test_unary_f64_slice() {
         let input = Float64Array::from(vec![Some(5.1f64), None, Some(6.8), None, Some(7.2)]);
         let input_slice = input.slice(1, 4);

--- a/arrow-arith/src/lib.rs
+++ b/arrow-arith/src/lib.rs
@@ -22,6 +22,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 pub mod aggregate;
 #[doc(hidden)] // Kernels to be removed in a future release


### PR DESCRIPTION
# Which issue does this PR close?

Part of #10458.

# Rationale for this change

Enable clippy::allow_attributes for arrow-arith so future lint suppressions use expectations and stale suppressions are detectable. The existing allow(deprecated) on test_unary_f64_slice no longer suppresses a warning, so it can be removed.

# What changes are included in this PR?

- Deny clippy::allow_attributes in the arrow-arith crate.
- Remove the stale deprecated lint suppression from test_unary_f64_slice.

# Are these changes tested?

- cargo fmt --all -- --check
- cargo clippy -p arrow-arith --all-targets --all-features --no-deps -- -D warnings
- cargo test -p arrow-arith --all-features (231 unit tests and 16 doc tests passed)
- cargo check -p arrow-arith --all-targets --all-features

# Are there any user-facing changes?

No.

# AI assistance

Codex was used to identify the lint occurrence, draft the minimal edit, and run the validation commands. I reviewed the full diff and verified the change with formatting, Clippy, tests, and compilation checks.