### PR TITLE
bench(arrow): add sparse dictionary to view cast benchmarks

### DIFF
--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -202,6 +202,44 @@ fn build_nested_dict_array(size: usize) -> ArrayRef {
     Arc::new(DictionaryArray::new(outer_keys, Arc::new(inner)))
 }
 
+// Keys for a `size` row dictionary, spread over `distinct` values so a cast has to touch
+// the whole values buffer rather than a contiguous prefix of it.
+fn dict_keys(size: usize, distinct: usize) -> UInt64Array {
+    let mut rng = seedable_rng();
+    let range = Uniform::new(0, distinct as u64).unwrap();
+    UInt64Array::from_iter_values((0..size).map(|_| rng.sample(range)))
+}
+
+// `Dictionary<UInt64, Utf8>` of `size` rows over `distinct` values, each longer than 12
+// bytes so the resulting views reference the values buffer rather than inlining.
+//
+// The ratio of rows to distinct values is what matters when casting to a view: the cast
+// can either build one view per dictionary value and gather those with `take`, or build
+// one view per row directly against the values buffer. Which of the two is cheaper depends
+// on that ratio, so both a dense and a sparse shape are benchmarked below.
+fn build_string_dict_array(size: usize, distinct: usize) -> ArrayRef {
+    let values =
+        StringArray::from_iter_values((0..distinct).map(|i| format!("dictionary value {i:07}")));
+
+    Arc::new(DictionaryArray::new(
+        dict_keys(size, distinct),
+        Arc::new(values),
+    ))
+}
+
+// As `build_string_dict_array`, but with `Binary` values. Casting those to `Utf8View` has
+// to validate the dictionary values as UTF-8, which a `Utf8` source does not.
+fn build_binary_dict_array(size: usize, distinct: usize) -> ArrayRef {
+    let values = BinaryArray::from_iter_values(
+        (0..distinct).map(|i| format!("dictionary value {i:07}").into_bytes()),
+    );
+
+    Arc::new(DictionaryArray::new(
+        dict_keys(size, distinct),
+        Arc::new(values),
+    ))
+}
+
 // cast array from specified primitive array type to desired data type
 fn cast_array(array: &ArrayRef, to_type: DataType) {
     hint::black_box(cast(hint::black_box(array), hint::black_box(&to_type)).unwrap());
@@ -233,6 +271,11 @@ fn add_benchmark(c: &mut Criterion) {
     let nested_dict_array = build_nested_dict_array(10_000);
     let string_view_array = cast(&dict_array, &DataType::Utf8View).unwrap();
     let binary_view_array = cast(&string_view_array, &DataType::BinaryView).unwrap();
+
+    // the dictionary is far larger than the array is long, as after a selective filter.
+    // `dict_array` above is the opposite shape, many rows over few dictionary values.
+    let sparse_dict_array = build_string_dict_array(1_024, 32_768);
+    let sparse_binary_dict_array = build_binary_dict_array(1_024, 32_768);
 
     let string_float_array_normal = build_string_float_array(5_000, 0.1);
     let float64_array_cast_to_decimal = build_float64_array_for_cast_to_decimal(8_000, 0.1);
@@ -351,6 +394,12 @@ fn add_benchmark(c: &mut Criterion) {
     });
     c.bench_function("cast dict to string view", |b| {
         b.iter(|| cast_array(&dict_array, DataType::Utf8View))
+    });
+    c.bench_function("cast dict to string view (sparse)", |b| {
+        b.iter(|| cast_array(&sparse_dict_array, DataType::Utf8View))
+    });
+    c.bench_function("cast binary dict to string view (sparse)", |b| {
+        b.iter(|| cast_array(&sparse_binary_dict_array, DataType::Utf8View))
     });
     c.bench_function("cast nested dict to dict", |b| {
         b.iter(|| {

--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -210,29 +210,19 @@ fn dict_keys(size: usize, distinct: usize) -> UInt64Array {
     UInt64Array::from_iter_values((0..size).map(|_| rng.sample(range)))
 }
 
-// `Dictionary<UInt64, Utf8>` of `size` rows over `distinct` values, each longer than 12
-// bytes so the resulting views reference the values buffer rather than inlining.
+// `Dictionary<UInt64, Utf8>` of `size` rows over `distinct` values, alternating between
+// values short enough to inline into a view and longer ones that reference the buffer.
 //
-// The ratio of rows to distinct values is what matters when casting to a view: the cast
-// can either build one view per dictionary value and gather those with `take`, or build
-// one view per row directly against the values buffer. Which of the two is cheaper depends
-// on that ratio, so both a dense and a sparse shape are benchmarked below.
+// Different implementation paths may be taken based on the ratio of rows to distinct
+// values.
 fn build_string_dict_array(size: usize, distinct: usize) -> ArrayRef {
-    let values =
-        StringArray::from_iter_values((0..distinct).map(|i| format!("dictionary value {i:07}")));
-
-    Arc::new(DictionaryArray::new(
-        dict_keys(size, distinct),
-        Arc::new(values),
-    ))
-}
-
-// As `build_string_dict_array`, but with `Binary` values. Casting those to `Utf8View` has
-// to validate the dictionary values as UTF-8, which a `Utf8` source does not.
-fn build_binary_dict_array(size: usize, distinct: usize) -> ArrayRef {
-    let values = BinaryArray::from_iter_values(
-        (0..distinct).map(|i| format!("dictionary value {i:07}").into_bytes()),
-    );
+    let values = StringArray::from_iter_values((0..distinct).map(|i| {
+        if i % 2 == 0 {
+            format!("val {i}")
+        } else {
+            format!("dictionary value {i:07}")
+        }
+    }));
 
     Arc::new(DictionaryArray::new(
         dict_keys(size, distinct),
@@ -275,7 +265,11 @@ fn add_benchmark(c: &mut Criterion) {
     // the dictionary is far larger than the array is long, as after a selective filter.
     // `dict_array` above is the opposite shape, many rows over few dictionary values.
     let sparse_dict_array = build_string_dict_array(1_024, 32_768);
-    let sparse_binary_dict_array = build_binary_dict_array(1_024, 32_768);
+    let sparse_binary_dict_array = cast(
+        &sparse_dict_array,
+        &DataType::Dictionary(Box::new(DataType::UInt64), Box::new(DataType::Binary)),
+    )
+    .unwrap();
 
     let string_float_array_normal = build_string_float_array(5_000, 0.1);
     let float64_array_cast_to_decimal = build_float64_array_for_cast_to_decimal(8_000, 0.1);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->
None. Split out of #10436 at review request, so these land on main first and the bot can measure that PR against them.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
`cast_kernels` has one dictionary to view benchmark, at 10,000 rows over 3 values. Nothing covers the opposite shape, a dictionary much larger than the array, and nothing covers `dict<binary> -> utf8view`, which validates the values as UTF-8.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Two benchmarks, both 1024 rows over 32,768 values:

- `cast dict to string view (sparse)`. For #10436 this is a no regression check rather than an expected win, since main already takes the direct path at this shape
- `cast binary dict to string view (sparse)`. No dense counterpart, since that shape runs the same code either way

Keys come from `seedable_rng` so they spread across the dictionary, and values exceed 12 bytes so the views reference the buffer rather than inlining.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->
Benchmarks only, no library code touched. They build and run under `cargo bench -p arrow --features test_utils --bench cast_kernels`.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
No.