### PR TITLE
Error instead of silent `Variant::Null` for unimplemented `typed_value` types

### DIFF
--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -1152,17 +1152,13 @@ fn typed_value_to_variant(typed_value: &ArrayRef, index: usize) -> Result<Varian
         }
         // todo other types here (note this is very similar to cast_to_variant.rs)
         // so it would be great to figure out how to share this code
-        _ => {
-            // We shouldn't panic in production code, but this is a
-            // placeholder until we implement more types
-            // https://github.com/apache/arrow-rs/issues/8091
-            debug_assert!(
-                false,
-                "Unsupported typed_value type: {}",
-                typed_value.data_type()
-            );
-            Ok(Variant::Null)
-        }
+        //
+        // Returning Variant::Null here would silently misreport stored values
+        // as null in release builds (https://github.com/apache/arrow-rs/issues/10597)
+        _ => Err(ArrowError::NotYetImplemented(format!(
+            "VariantArray does not yet support typed_value type: {}",
+            typed_value.data_type()
+        ))),
     }
 }
 
@@ -1815,4 +1811,24 @@ mod test {
         ),]),
         "Cast error: Cast failed at index 0 (array type: Decimal128(38, 10)): Invalid argument error: 123456789012345678901234567890123456789 is wider than max precision 38"
     );
+    #[test]
+    fn try_value_errors_on_unimplemented_typed_value_type() {
+        use crate::{json_to_variant, shred_variant};
+        use arrow::array::StringArray;
+
+        let json: ArrayRef = Arc::new(StringArray::from(vec![r#"{"qty": 3}"#]));
+        let variant = json_to_variant(&json).unwrap();
+        let shred_type = DataType::Struct(vec![Field::new("qty", DataType::Int64, true)].into());
+        let shredded = shred_variant(&variant, &shred_type).unwrap();
+        // Object-shredded typed_value is not yet implemented: reading it must
+        // error, never silently return Variant::Null
+        // https://github.com/apache/arrow-rs/issues/10597
+        let err = shredded.try_value(0).unwrap_err();
+        assert!(
+            err.to_string().starts_with(
+                "Not yet implemented: VariantArray does not yet support typed_value type"
+            ),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -1824,7 +1824,7 @@ mod test {
         let shredded = shred_variant(&variant, &shred_type).unwrap();
         // Object-shredded typed_value is not yet implemented: reading it must
         // error, never silently return Variant::Null
-        // https://github.com/apache/arrow-rs/issues/10597
+        // TODO: https://github.com/apache/arrow-rs/issues/10620
         let err = shredded.try_value(0).unwrap_err();
         assert!(
             err.to_string().starts_with(

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -1153,10 +1153,12 @@ fn typed_value_to_variant(typed_value: &ArrayRef, index: usize) -> Result<Varian
         // todo other types here (note this is very similar to cast_to_variant.rs)
         // so it would be great to figure out how to share this code
         //
-        // Returning Variant::Null here would silently misreport stored values
-        // as null in release builds (https://github.com/apache/arrow-rs/issues/10597)
+        // Composite shredded values may require combining `value` and
+        // `typed_value` and allocating new encoded bytes. `try_value` returns
+        // borrowed Variant, so callers must unshred the array first.
         _ => Err(ArrowError::NotYetImplemented(format!(
-            "VariantArray does not yet support typed_value type: {}",
+            "VariantArray::try_value cannot materialize typed_value of type {} \
+             as a borrowed Variant; call unshred_variant first",
             typed_value.data_type()
         ))),
     }
@@ -1826,7 +1828,7 @@ mod test {
         let err = shredded.try_value(0).unwrap_err();
         assert!(
             err.to_string().starts_with(
-                "Not yet implemented: VariantArray does not yet support typed_value type"
+                "Not yet implemented: VariantArray::try_value cannot materialize typed_value"
             ),
             "unexpected error: {err}"
         );


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10597.

# Rationale for this change

`typed_value_to_variant`'s fallback arm for unimplemented `typed_value` types was `debug_assert!(false)` + `Ok(Variant::Null)`. Release builds compile out the assert, so reading a row whose `typed_value` is valid but of an unimplemented type (e.g. an object-shredded `Struct`) silently misreported the stored value as `Variant::Null` — data that exists reads as null with no signal, while the same read panics in debug builds.

# What changes are included in this PR?

- The fallback arm returns `ArrowError::NotYetImplemented` instead — consistent across debug/release, and within `try_value`'s documented error contract ("Errors if the data in `typed_value` cannot be interpreted as a valid `Variant`").
- A regression test pinning that an object-shredded `typed_value` errors rather than returning `Variant::Null`.

Implementing the remaining conversions (objects/lists) is left for a follow-up — the borrowed `Variant<'_, '_>` return can't express an assembled object without owned bytes, so that is a larger change.

# Are there any user-facing changes?

`VariantArray::try_value` now returns an error (and `value` panics in release as it already did in debug) for unimplemented `typed_value` types, instead of silently returning `Variant::Null` in release builds.
