### PR TITLE
bench: add string_view rank benchmarks

### DIFF
--- a/arrow/benches/sort_kernel.rs
+++ b/arrow/benches/sort_kernel.rs
@@ -318,6 +318,32 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("rank string[10] nulls 2^12", |b| {
         b.iter(|| hint::black_box(rank(&arr, None).unwrap()))
     });
+
+    // `Utf8View` takes the `byte_view_rank` path added in #10559, which reads
+    // values from the view layout rather than the contiguous buffer used by
+    // `bytes_rank` above. These mirror the `sort string_view` benchmarks so
+    // the two kernels stay consistent, and cover the fixed-length and
+    // variable-length shapes that decide how often a value spills out of the
+    // inline prefix into a separate buffer.
+    let arr = create_string_view_array_with_fixed_len(2usize.pow(12), 0.0, 10);
+    c.bench_function("rank string_view[10] 2^12", |b| {
+        b.iter(|| hint::black_box(rank(&arr, None).unwrap()))
+    });
+
+    let arr = create_string_view_array_with_fixed_len(2usize.pow(12), 0.5, 10);
+    c.bench_function("rank string_view[10] nulls 2^12", |b| {
+        b.iter(|| hint::black_box(rank(&arr, None).unwrap()))
+    });
+
+    let arr = create_string_view_array(2usize.pow(12), 0.0);
+    c.bench_function("rank string_view[0-400] 2^12", |b| {
+        b.iter(|| hint::black_box(rank(&arr, None).unwrap()))
+    });
+
+    let arr = create_string_view_array(2usize.pow(12), 0.5);
+    c.bench_function("rank string_view[0-400] nulls 2^12", |b| {
+        b.iter(|| hint::black_box(rank(&arr, None).unwrap()))
+    });
 }
 
 criterion_group!(benches, add_benchmark);

--- a/arrow/benches/sort_kernel.rs
+++ b/arrow/benches/sort_kernel.rs
@@ -319,12 +319,6 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| hint::black_box(rank(&arr, None).unwrap()))
     });
 
-    // `Utf8View` takes the `byte_view_rank` path added in #10559, which reads
-    // values from the view layout rather than the contiguous buffer used by
-    // `bytes_rank` above. These mirror the `sort string_view` benchmarks so
-    // the two kernels stay consistent, and cover the fixed-length and
-    // variable-length shapes that decide how often a value spills out of the
-    // inline prefix into a separate buffer.
     let arr = create_string_view_array_with_fixed_len(2usize.pow(12), 0.0, 10);
     c.bench_function("rank string_view[10] 2^12", |b| {
         b.iter(|| hint::black_box(rank(&arr, None).unwrap()))


### PR DESCRIPTION
# Which issue does this PR close?
None.

# Rationale for this change
arrow_ord::rank gained a Utf8View/BinaryView path (byte_view_rank) in #10559, but the rank benchmarks in arrow/benches/sort_kernel.rs were not updated—they only cover the primitive_rank (f32) and bytes_rank (string[10]) paths, so the new view path has no benchmark coverage. The sort/sort_to_indices benchmarks in the same file already cover string_view, so this brings rank in line with them.

byte_view_rank reads values from the view layout rather than the contiguous buffer used by bytes_rank, and the fixed- vs variable-length shapes decide how often a value spills out of the inline prefix into a separate buffer—both worth measuring on their own.

# What changes are included in this PR?
Adds rank string_view[10] and rank string_view[0-400] benchmarks (each with and without nulls), mirroring the existing sort string_view cases. Reuses the create_string_view_array* helpers from bench_util—no new helpers.

# Are there any user-facing changes?
No.

# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/10599