### PR TITLE
Enable `allow_attributes` lint for `parquet-geospatial`

### DIFF
--- a/parquet-geospatial/src/interval.rs
+++ b/parquet-geospatial/src/interval.rs
@@ -526,7 +526,7 @@ mod test {
 
     fn test_empty<T: IntervalTrait>(empty: T) {
         // Equals itself
-        #[allow(clippy::eq_op)]
+        #[expect(clippy::eq_op)]
         {
             assert_eq!(empty, empty);
         }

--- a/parquet-geospatial/src/lib.rs
+++ b/parquet-geospatial/src/lib.rs
@@ -20,6 +20,7 @@
 //! [Geometry and Geography Encoding]: https://github.com/apache/parquet-format/blob/master/Geospatial.md
 //! [Apache Parquet]: https://parquet.apache.org/
 
+#![deny(clippy::allow_attributes)]
 pub mod bounding;
 pub mod interval;
 pub mod testing;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Part of #10458.	

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Enable `clippy::allow_attributes` for `parquet-geospatial`

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Deny `clippy::allow_attributes` for the `parquet-geospatial` crate.
- Replace the intentional `clippy::eq_op` allowance with an expectation.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->
Yes
- `cargo clippy -p parquet-geospatial --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
No