### PR TITLE
Enable allow_attributes lint for arrow-data

### DIFF
--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -2016,7 +2016,6 @@ pub enum BufferSpec {
     BitMap,
     /// Buffer is always null. Unused currently in Rust implementation,
     /// (used in C++ for Union type)
-    #[allow(dead_code)]
     AlwaysNull,
 }
 
@@ -2136,7 +2135,6 @@ impl ArrayDataBuilder {
     }
 
     #[inline]
-    #[allow(clippy::len_without_is_empty)]
     /// Sets the length of the [ArrayData]
     pub const fn len(mut self, n: usize) -> Self {
         self.len = n;
@@ -2600,7 +2598,6 @@ mod tests {
         assert!(!int_data.ptr_eq(&float_data));
         assert!(int_data.ptr_eq(&int_data));
 
-        #[allow(clippy::redundant_clone)]
         let int_data_clone = int_data.clone();
         assert_eq!(int_data, int_data_clone);
         assert!(int_data.ptr_eq(&int_data_clone));
@@ -2628,7 +2625,6 @@ mod tests {
 
         assert!(string_data.ptr_eq(&string_data));
 
-        #[allow(clippy::redundant_clone)]
         let string_data_cloned = string_data.clone();
         assert!(string_data_cloned.ptr_eq(&string_data));
         assert!(string_data.ptr_eq(&string_data_cloned));

--- a/arrow-data/src/equal/union.rs
+++ b/arrow-data/src/equal/union.rs
@@ -20,7 +20,7 @@ use arrow_schema::{DataType, UnionFields, UnionMode};
 
 use super::equal_range;
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn equal_dense(
     lhs: &ArrayData,
     rhs: &ArrayData,

--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -119,7 +119,7 @@ fn align_nulls(data_offset: usize, nulls: Option<&NullBuffer>) -> Option<Buffer>
 }
 
 struct ArrayPrivateData {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     buffers: Vec<Option<Buffer>>,
     buffers_ptr: Box<[*const c_void]>,
     children: Box<[*mut FFI_ArrowArray]>,

--- a/arrow-data/src/lib.rs
+++ b/arrow-data/src/lib.rs
@@ -24,6 +24,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 mod data;
 pub use data::*;

--- a/arrow-data/src/transform/mod.rs
+++ b/arrow-data/src/transform/mod.rs
@@ -138,7 +138,7 @@ pub struct MutableArrayData<'a> {
     ///
     /// Note this is "dead code" because all actual references to the arrays are
     /// stored in closures for extending values and nulls.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     arrays: Vec<&'a ArrayData>,
 
     /// In progress output array: The data being written TO


### PR DESCRIPTION
# Which issue does this PR close?

- Part of #10458.

# Rationale for this change

Enable the Clippy lint that rejects new allow attributes in arrow-data, so stale lint suppressions become detectable rather than accumulating.

# What changes are included in this PR?

- Deny clippy::allow_attributes at the arrow-data crate root.
- Replace the three still-active suppressions with expect attributes.
- Remove four stale suppressions that no longer hide a lint.

# Are these changes tested?

- cargo +1.97.1-x86_64-pc-windows-gnu fmt --all -- --check
- cargo +1.97.1-x86_64-pc-windows-gnu clippy -p arrow-data --all-targets --all-features -- -D warnings
- cargo +1.97.1-x86_64-pc-windows-gnu test -p arrow-data --all-features (44 unit tests and 14 doctests passed)
- git diff --check

# Are there any user-facing changes?

No.

# AI assistance

OpenAI Codex was used to inspect the lint occurrences, make the minimal edits, and run the validation commands. AI assistance was used throughout; the complete diff and every Clippy diagnostic were checked during the run.