### PR TITLE
Enable `allow_attributes` lint for `arrow-cast`

### DIFF
--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -157,7 +157,7 @@ impl DecimalCast for i256 {
 /// exceeds the supported precomputed precision table `O::MAX_FOR_EACH_PRECISION`.
 /// In that case, the caller should treat this as an overflow for the output scale
 /// and handle it accordingly (e.g., return a cast error).
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 fn make_upscaler<I: DecimalType, O: DecimalType>(
     input_precision: u8,
     input_scale: i8,
@@ -206,7 +206,7 @@ where
 /// In this scenario, any value would round to zero (e.g., dividing by 10^k where k exceeds the
 /// available precision). Callers should therefore produce zero values (preserving nulls) rather
 /// than returning an error.
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 fn make_downscaler<I: DecimalType, O: DecimalType>(
     input_precision: u8,
     input_scale: i8,

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -12336,7 +12336,7 @@ mod tests {
     };
 
     #[test]
-    #[allow(clippy::assertions_on_constants)]
+    #[expect(clippy::assertions_on_constants)]
     fn test_const_options() {
         assert!(CAST_OPTIONS.safe)
     }

--- a/arrow-cast/src/lib.rs
+++ b/arrow-cast/src/lib.rs
@@ -22,6 +22,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 pub mod cast;
 pub use cast::*;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Part of #10458.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Enable `clippy::allow_attributes` for the `arrow-cast` crate

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Deny `clippy::allow_attributes` at the crate level.
- Replace the existing clippy `allow` attributes with `expect`.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->
Yes.
`cargo clippy --workspace --all-targets --all-features -- -D warnings`

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
No.