### PR TITLE
Enable `allow_attributes` lint for `arrow-buffer`

### DIFF
--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -57,7 +57,6 @@ enum DivRemError {
 }
 
 /// A signed 256-bit integer
-#[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Default, Eq, PartialEq, Hash)]
 #[repr(C)]
 pub struct i256 {
@@ -1752,7 +1751,7 @@ mod tests {
         }
     }
 
-    #[allow(clippy::op_ref)]
+    #[expect(clippy::op_ref)]
     fn test_reference_op(il: i256, ir: i256) {
         let r1 = il + ir;
         let r2 = &il + ir;

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -786,7 +786,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::float_cmp)]
+    #[expect(clippy::float_cmp)]
     fn test_as_typed_data() {
         check_as_typed_data!(&[1i8, 3i8, 6i8], i8);
         check_as_typed_data!(&[1u8, 3u8, 6u8], u8);

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -37,6 +37,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 pub mod alloc;

--- a/arrow-buffer/src/util/bit_chunk_iterator.rs
+++ b/arrow-buffer/src/util/bit_chunk_iterator.rs
@@ -349,7 +349,7 @@ impl Iterator for BitChunkIterator<'_> {
         }
 
         // cast to *const u64 should be fine since we are using read_unaligned below
-        #[allow(clippy::cast_ptr_alignment)]
+        #[expect(clippy::cast_ptr_alignment)]
         let raw_data = self.buffer.as_ptr() as *const u64;
 
         // bit-packed buffers are stored starting with the least-significant byte first
@@ -556,7 +556,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::assertions_on_constants)]
     fn test_unaligned_bit_chunk_iterator() {
         let buffer = Buffer::from(&[0xFF; 5]);
         let unaligned = UnalignedBitChunk::new(buffer.as_slice(), 0, 40);

--- a/arrow-buffer/src/util/bit_iterator.rs
+++ b/arrow-buffer/src/util/bit_iterator.rs
@@ -931,9 +931,9 @@ mod tests {
                     let mut actual = actual.clone();
                     let mut expected = expected.clone();
                     for _ in 0..expected.len() {
-                        #[allow(clippy::iter_nth_zero)]
+                        #[expect(clippy::iter_nth_zero)]
                         let actual_val = actual.nth(0);
-                        #[allow(clippy::iter_nth_zero)]
+                        #[expect(clippy::iter_nth_zero)]
                         let expected_val = expected.nth(0);
                         assert_eq!(actual_val, expected_val, "Failed on nth(0)");
                     }
@@ -971,7 +971,6 @@ mod tests {
                     let mut actual = actual.clone();
                     let mut expected = expected.clone();
                     for _ in 0..expected.len() {
-                        #[allow(clippy::iter_nth_zero)]
                         let actual_val = actual.nth_back(0);
                         let expected_val = expected.nth_back(0);
                         assert_eq!(actual_val, expected_val, "Failed on nth_back(0)");


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Part of #10458.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Enable `clippy::allow_attributes` for `arrow-buffer`

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Deny `clippy::allow_attributes` at the crate level.
- Replace active `allow` attributes with `expect`.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->
Yes.
`cargo clippy --workspace --all-targets --all-features -- -D warnings`

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
No.