### PR TITLE
GH-10382: Fix CSV RecordBatchReader projected schema

### DIFF
--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -1701,6 +1701,29 @@ mod tests {
     }
 
     #[test]
+    fn test_csv_record_batch_reader_schema() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+
+        let cases = [None, Some(vec![]), Some(vec![1]), Some(vec![1, 0])];
+        for projection in cases {
+            let builder = ReaderBuilder::new(schema.clone());
+            let builder = match projection {
+                Some(projection) => builder.with_projection(projection),
+                None => builder,
+            };
+            let mut reader = builder.build(Cursor::new(b"1,2\n")).unwrap();
+
+            let reader_schema = RecordBatchReader::schema(&reader);
+            let batch = reader.next().unwrap().unwrap();
+
+            assert_eq!(reader_schema, batch.schema());
+        }
+    }
+
+    #[test]
     fn test_csv_with_dictionary() {
         let schema = Arc::new(Schema::new(vec![
             Field::new_dictionary("city", DataType::Int32, DataType::Utf8, false),

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -506,6 +506,8 @@ pub struct BufReader<R> {
     reader: R,
     /// The decoder
     decoder: Decoder,
+    /// Schema of the record batches produced by this reader
+    schema: SchemaRef,
 }
 
 impl<R> fmt::Debug for BufReader<R>
@@ -520,18 +522,6 @@ where
 }
 
 impl<R> BufReader<R> {
-    fn projected_schema(&self) -> SchemaRef {
-        match &self.decoder.projection {
-            Some(projection) => Arc::new(
-                self.decoder
-                    .schema
-                    .project(projection)
-                    .expect("invalid CSV projection"),
-            ),
-            None => self.decoder.schema.clone(),
-        }
-    }
-
     /// The number of rows padded because they had fewer fields than the schema
     ///
     /// Always 0 unless [`ReaderBuilder::with_truncated_rows`] was set to `true`.
@@ -575,7 +565,7 @@ impl<R: Read> Reader<R> {
     /// Returns the schema of the reader, useful for getting the schema without reading
     /// record batches
     pub fn schema(&self) -> SchemaRef {
-        self.projected_schema()
+        self.schema.clone()
     }
 }
 
@@ -609,7 +599,7 @@ impl<R: BufRead> Iterator for BufReader<R> {
 
 impl<R: BufRead> RecordBatchReader for BufReader<R> {
     fn schema(&self) -> SchemaRef {
-        self.projected_schema()
+        self.schema.clone()
     }
 }
 
@@ -735,8 +725,7 @@ impl Decoder {
         let rows = self.record_decoder.flush()?;
         let batch = parse(
             &rows,
-            self.schema.fields(),
-            Some(self.schema.metadata.clone()),
+            &self.schema,
             self.projection.as_ref(),
             self.line_number,
             &self.null_regex,
@@ -789,16 +778,17 @@ fn validate_header(rows: &StringRecords<'_>, fields: &Fields) -> Result<(), Arro
 /// Parses a slice of [`StringRecords`] into a [RecordBatch]
 fn parse(
     rows: &StringRecords<'_>,
-    fields: &Fields,
-    metadata: Option<Metadata>,
+    schema: &Schema,
     projection: Option<&Vec<usize>>,
     line_number: usize,
     null_regex: &NullRegex,
 ) -> Result<RecordBatch, ArrowError> {
+    let fields = schema.fields();
     let projection: Vec<usize> = match projection {
         Some(v) => v.clone(),
         None => fields.iter().enumerate().map(|(i, _)| i).collect(),
     };
+    let projected_schema = Arc::new(schema.project(&projection)?);
 
     let arrays: Result<Vec<ArrayRef>, _> = projection
         .iter()
@@ -1026,13 +1016,6 @@ fn parse(
             }
         })
         .collect();
-
-    let projected_fields: Fields = projection.iter().map(|i| fields[*i].clone()).collect();
-
-    let projected_schema = Arc::new(match metadata {
-        None => Schema::new(projected_fields),
-        Some(metadata) => Schema::new_with_metadata(projected_fields, metadata),
-    });
 
     arrays.and_then(|arr| {
         RecordBatch::try_new_with_options(
@@ -1355,9 +1338,15 @@ impl ReaderBuilder {
 
     /// Create a new `BufReader` from a buffered reader
     pub fn build_buffered<R: BufRead>(self, reader: R) -> Result<BufReader<R>, ArrowError> {
+        let schema = match &self.projection {
+            Some(projection) => Arc::new(self.schema.project(projection)?),
+            None => self.schema.clone(),
+        };
+
         Ok(BufReader {
             reader,
             decoder: self.build_decoder(),
+            schema,
         })
     }
 
@@ -1712,7 +1701,13 @@ mod tests {
             Field::new("b", DataType::Int32, false),
         ]));
 
-        let cases = [None, Some(vec![]), Some(vec![1]), Some(vec![1, 0])];
+        let cases = [
+            None,
+            Some(vec![]),
+            Some(vec![1]),
+            Some(vec![1, 0]),
+            Some(vec![1, 1]),
+        ];
         for projection in cases {
             let builder = ReaderBuilder::new(schema.clone());
             let builder = match projection {
@@ -1726,6 +1721,44 @@ mod tests {
 
             assert_eq!(reader_schema, batch.schema());
         }
+    }
+
+    #[test]
+    fn test_csv_reader_rejects_invalid_projection() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+
+        let result = ReaderBuilder::new(schema)
+            .with_projection(vec![2])
+            .build(Cursor::new(b"1,2\n"));
+
+        assert!(matches!(
+            result,
+            Err(ArrowError::SchemaError(message))
+                if message == "project index 2 out of bounds, max field 2"
+        ));
+    }
+
+    #[test]
+    fn test_csv_decoder_rejects_invalid_projection() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let mut decoder = ReaderBuilder::new(schema)
+            .with_projection(vec![2])
+            .build_decoder();
+
+        decoder.decode(b"1,2\n").unwrap();
+        let result = decoder.flush();
+
+        assert!(matches!(
+            result,
+            Err(ArrowError::SchemaError(message))
+                if message == "project index 2 out of bounds, max field 2"
+        ));
     }
 
     #[test]

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -520,6 +520,18 @@ where
 }
 
 impl<R> BufReader<R> {
+    fn projected_schema(&self) -> SchemaRef {
+        match &self.decoder.projection {
+            Some(projection) => Arc::new(
+                self.decoder
+                    .schema
+                    .project(projection)
+                    .expect("invalid CSV projection"),
+            ),
+            None => self.decoder.schema.clone(),
+        }
+    }
+
     /// The number of rows padded because they had fewer fields than the schema
     ///
     /// Always 0 unless [`ReaderBuilder::with_truncated_rows`] was set to `true`.
@@ -563,14 +575,7 @@ impl<R: Read> Reader<R> {
     /// Returns the schema of the reader, useful for getting the schema without reading
     /// record batches
     pub fn schema(&self) -> SchemaRef {
-        match &self.decoder.projection {
-            Some(projection) => {
-                let fields = self.decoder.schema.fields();
-                let projected = projection.iter().map(|i| fields[*i].clone());
-                Arc::new(Schema::new(projected.collect::<Fields>()))
-            }
-            None => self.decoder.schema.clone(),
-        }
+        self.projected_schema()
     }
 }
 
@@ -604,7 +609,7 @@ impl<R: BufRead> Iterator for BufReader<R> {
 
 impl<R: BufRead> RecordBatchReader for BufReader<R> {
     fn schema(&self) -> SchemaRef {
-        self.decoder.schema.clone()
+        self.projected_schema()
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10382.

# Rationale for this change

CSV readers configured with a projection yielded projected `RecordBatch` values, but the `RecordBatchReader::schema` implementation on `BufReader` still reported the unprojected input schema. This made the reader's advertised schema disagree with the batches it produced.

# What changes are included in this PR?

- Reuse a shared projected-schema helper for both CSV reader schema APIs.
- Build projected schemas with `Schema::project`.
- Add regression coverage for no projection, an empty projection, a single-column projection, and reordered columns.

# Are these changes tested?

Yes. The following checks passed locally:

- `cargo test -p arrow-csv --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy -p arrow-csv --all-targets --all-features -- -D warnings`
- `cargo clippy -p arrow-csv -- -D unused_crate_dependencies`
- `cargo clippy -p arrow-csv --all-features -- -D unused_crate_dependencies`
- `cargo clippy -p arrow-csv --no-default-features -- -D unused_crate_dependencies`

# Are there any user-facing changes?

Yes. `RecordBatchReader::schema` now reports the projected schema for projected CSV readers, matching the schema of the record batches they produce. There is no public API change.

# AI usage

OpenAI Codex assisted with implementing the shared projected-schema logic and regression test. I reviewed every generated change and can debug and maintain it.
