### PR TITLE
perf(arrow-json): mark NullableEncoder with inline

### DIFF
--- a/arrow-json/src/writer/encoder.rs
+++ b/arrow-json/src/writer/encoder.rs
@@ -262,21 +262,28 @@ pub struct NullableEncoder<'a> {
 
 impl<'a> NullableEncoder<'a> {
     /// Create a new encoder with a null buffer.
+    #[inline]
     pub fn new(encoder: Box<dyn Encoder + 'a>, nulls: Option<NullBuffer>) -> Self {
         Self { encoder, nulls }
     }
 
     /// Encode the value at index `idx` to `out`.
+    #[inline]
     pub fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
         self.encoder.encode(idx, out)
     }
 
     /// Returns whether the value at index `idx` is null.
+    #[inline]
     pub fn is_null(&self, idx: usize) -> bool {
-        self.nulls.as_ref().is_some_and(|nulls| nulls.is_null(idx))
+        match self.nulls {
+            Some(ref nulls) => nulls.is_null(idx),
+            None => false,
+        }
     }
 
     /// Returns whether the encoder has any nulls.
+    #[inline]
     pub fn has_nulls(&self) -> bool {
         match self.nulls {
             Some(ref nulls) => nulls.null_count() > 0,
@@ -286,6 +293,7 @@ impl<'a> NullableEncoder<'a> {
 }
 
 impl Encoder for NullableEncoder<'_> {
+    #[inline]
     fn encode(&mut self, idx: usize, out: &mut Vec<u8>) {
         self.encoder.encode(idx, out)
     }
@@ -482,6 +490,7 @@ struct FieldEncoder<'a> {
 }
 
 impl FieldEncoder<'_> {
+    #[inline]
     fn is_null(&self, idx: usize) -> bool {
         self.encoder.is_null(idx)
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

N/A.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
`StructArrayEncoder` calls `NullableEncoder::is_null` a lot, but the full call-chain was not marked `#[inline]`. 
Inlining gives a 2-5% perf improvement, which is more common for external crates implementing Encoders (with EncoderFactory) thanks to inlining across codegen units.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Inline primarily `NullableEncoder::is_null` to avoid call overhead per field of struct.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->
Should be covered by existing tests, and is easy to review.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
No.
