### PR TITLE
Enable `allow_attributes` lint for some crates

### DIFF
--- a/arrow-cmp/src/lib.rs
+++ b/arrow-cmp/src/lib.rs
@@ -29,6 +29,7 @@
 //! downstream user of `arrow-array` to compile the comparator machinery whether
 //! they need it or not.
 
+#![deny(clippy::allow_attributes)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
 

--- a/arrow-csv/src/lib.rs
+++ b/arrow-csv/src/lib.rs
@@ -24,6 +24,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 pub mod reader;

--- a/arrow-json/benches/serde.rs
+++ b/arrow-json/benches/serde.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 
 const ROWS: usize = 1 << 18;
 
-#[allow(deprecated)]
 fn do_bench<R: Serialize>(c: &mut Criterion, name: &str, rows: &[R], schema: &Schema) {
     let schema = Arc::new(schema.clone());
     c.bench_function(name, |b| {

--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -80,6 +80,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
 
@@ -276,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(invalid_from_utf8)]
+    #[expect(invalid_from_utf8)]
     fn test_json_roundtrip_binary() {
         let not_utf8: &[u8] = b"Not UTF8 \xa0\xa1!";
         assert!(str::from_utf8(not_utf8).is_err());

--- a/arrow-json/src/reader/decimal_array.rs
+++ b/arrow-json/src/reader/decimal_array.rs
@@ -53,7 +53,7 @@ where
     fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError> {
         let mut builder = PrimitiveBuilder::<D>::with_capacity(pos.len());
 
-        #[allow(unused)] // initial value overwritten without ever being read
+        #[expect(unused_assignments)] // initial value overwritten without ever being read
         let mut anchor = String::default();
         for p in pos {
             let value = match tape.get(*p) {

--- a/arrow-ord/src/lib.rs
+++ b/arrow-ord/src/lib.rs
@@ -48,6 +48,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 pub mod cmp;
 #[doc(hidden)]

--- a/arrow-pyarrow/src/lib.rs
+++ b/arrow-pyarrow/src/lib.rs
@@ -69,6 +69,8 @@
 //! Input hints name the pyarrow classes only, and are therefore narrower than what is accepted: the
 //! PyCapsule interface is duck-typed and has no canonical Python type to name.
 
+#![deny(clippy::allow_attributes)]
+
 use std::convert::{From, TryFrom};
 use std::ffi::CStr;
 use std::ptr::NonNull;

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -158,6 +158,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};

--- a/arrow-select/src/lib.rs
+++ b/arrow-select/src/lib.rs
@@ -22,6 +22,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 pub mod coalesce;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Part of #10458.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Enable `clippy::allow_attributes` for a batch of crates

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Enable `clippy::allow_attributes` for `arrow-cmp`, `arrow-csv`, `arrow-json`, `arrow-ord`, `arrow-pyarrow`, `arrow-row`, and `arrow-select`.
- Replace active `allow` with `expect` attributes.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->
Yes.
`cargo clippy --workspace --all-targets --all-features -- -D warnings`

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
No.