### PR TITLE
Enable `allow_attributes` lint for seven crates

### DIFF
--- a/arrow-flight/gen/src/main.rs
+++ b/arrow-flight/gen/src/main.rs
@@ -17,6 +17,8 @@
 
 //! Generates the Rust bindings for the Arrow Flight protobuf definitions.
 
+#![deny(clippy::allow_attributes)]
+
 use std::{fs::OpenOptions, io::Write, path::Path};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/arrow-integration-test/src/field.rs
+++ b/arrow-integration-test/src/field.rs
@@ -282,7 +282,7 @@ pub fn field_from_json(json: &serde_json::Value) -> Result<Field> {
                 _ => data_type,
             };
 
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let mut field = Field::new_dict(name, data_type, nullable, dict_id, dict_is_ordered);
             field.set_metadata(metadata);
             Ok(field)
@@ -311,7 +311,7 @@ pub fn field_to_json(field: &Field) -> serde_json::Value {
 
     match field.data_type() {
         DataType::Dictionary(index_type, value_type) => {
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let dict_id = field.dict_id().unwrap();
             serde_json::json!({
                 "name": field.name(),

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -34,6 +34,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano, ScalarBuffer};
 use hex::decode;
@@ -177,7 +178,6 @@ pub struct ArrowJsonBatch {
 
 /// A struct that partially reads the Arrow JSON dictionary batch
 #[derive(Deserialize, Serialize, Debug, Clone)]
-#[allow(non_snake_case)]
 pub struct ArrowJsonDictionaryBatch {
     /// The unique identifier for the dictionary
     pub id: i64,
@@ -869,7 +869,7 @@ pub fn array_from_json(
             Ok(Arc::new(array))
         }
         DataType::Dictionary(key_type, value_type) => {
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let dict_id = field.dict_id().ok_or_else(|| {
                 ArrowError::JsonError(format!("Unable to find dict_id for field {field}"))
             })?;
@@ -1129,12 +1129,12 @@ pub fn dictionary_array_from_json(
             let null_buf = create_null_buf(&json_col);
 
             // build the key data into a buffer, then construct values separately
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let key_field = Field::new_dict(
                 "key",
                 dict_key.clone(),
                 field.is_nullable(),
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 field
                     .dict_id()
                     .expect("Dictionary fields must have a dict_id value"),

--- a/arrow-integration-test/src/schema.rs
+++ b/arrow-integration-test/src/schema.rs
@@ -194,7 +194,7 @@ mod tests {
                 Field::new("c30", DataType::Duration(TimeUnit::Millisecond), false),
                 Field::new("c31", DataType::Duration(TimeUnit::Microsecond), false),
                 Field::new("c32", DataType::Duration(TimeUnit::Nanosecond), false),
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 Field::new_dict(
                     "c33",
                     DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),

--- a/arrow-integration-testing/src/flight_client_scenarios/middleware.rs
+++ b/arrow-integration-testing/src/flight_client_scenarios/middleware.rs
@@ -76,7 +76,6 @@ pub async fn run_scenario(host: &str, port: u16) -> Result {
     Ok(())
 }
 
-#[allow(clippy::result_large_err)]
 fn middleware_interceptor(mut req: Request<()>) -> Result<Request<()>, Status> {
     let metadata = req.metadata_mut();
     metadata.insert("x-middleware", "expected value".parse().unwrap());

--- a/arrow-integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
+++ b/arrow-integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
@@ -60,7 +60,7 @@ pub async fn scenario_setup(port: u16) -> Result {
 pub struct AuthBasicProtoScenarioImpl {
     username: Arc<str>,
     password: Arc<str>,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     peer_identity: Arc<Mutex<Option<String>>>,
 }
 

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -19,6 +19,7 @@
 
 // The unused_crate_dependencies lint does not work well for crates defining additional examples/bin targets
 #![allow(unused_crate_dependencies)]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 use serde_json::Value;
 

--- a/arrow/benches/csv_writer.rs
+++ b/arrow/benches/csv_writer.rs
@@ -54,7 +54,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("record_batches_to_csv", |b| {
         b.iter(|| {
-            #[allow(clippy::unit_arg)]
+            #[expect(clippy::unit_arg)]
             hint::black_box(for batch in &batches {
                 writer.write(batch).unwrap()
             });

--- a/arrow/benches/json_reader.rs
+++ b/arrow/benches/json_reader.rs
@@ -27,7 +27,6 @@ use std::hint;
 use std::io::Cursor;
 use std::sync::Arc;
 
-#[allow(deprecated)]
 fn do_bench(c: &mut Criterion, name: &str, json: &str, schema: SchemaRef) {
     c.bench_function(name, |b| {
         b.iter(|| {

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -393,6 +393,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![deny(clippy::redundant_clone)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]

--- a/arrow/tests/array_equal.rs
+++ b/arrow/tests/array_equal.rs
@@ -201,7 +201,7 @@ fn test_primitive_slice() {
     }
 }
 
-#[allow(clippy::eq_op)]
+#[expect(clippy::eq_op)]
 fn test_equal(lhs: &dyn Array, rhs: &dyn Array, expected: bool) {
     // equality is symmetric
     assert_eq!(lhs, lhs);

--- a/arrow/tests/array_transform.rs
+++ b/arrow/tests/array_transform.rs
@@ -29,7 +29,7 @@ use arrow_data::transform::MutableArrayData;
 use arrow_schema::{DataType, Field, Fields, UnionFields};
 use std::sync::Arc;
 
-#[allow(unused)]
+#[cfg_attr(feature = "force_validate", expect(dead_code))]
 fn create_decimal_array(array: Vec<Option<i128>>, precision: u8, scale: i8) -> Decimal128Array {
     array
         .into_iter()

--- a/arrow/tests/shrink_to_fit.rs
+++ b/arrow/tests/shrink_to_fit.rs
@@ -112,11 +112,10 @@ pub static GLOBAL_ALLOCATOR: TrackingAllocator = TrackingAllocator {
     allocator: std::alloc::System,
 };
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 // SAFETY:
 // We just do book-keeping and then let another allocator do all the actual work.
 unsafe impl std::alloc::GlobalAlloc for TrackingAllocator {
-    #[allow(clippy::let_and_return)]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         // SAFETY:
         // Just deferring

--- a/parquet-variant-json/src/lib.rs
+++ b/parquet-variant-json/src/lib.rs
@@ -31,6 +31,8 @@
 //!
 //! [Variant issue]: https://github.com/apache/arrow-rs/issues/6736
 
+#![deny(clippy::allow_attributes)]
+
 mod from_json;
 mod to_json;
 

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -23,6 +23,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 #![recursion_limit = "128"]
 

--- a/parquet_derive/src/parquet_field.rs
+++ b/parquet_derive/src/parquet_field.rs
@@ -484,8 +484,7 @@ impl Field {
     }
 }
 
-#[allow(clippy::enum_variant_names)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::enum_variant_names)]
 #[derive(Debug, PartialEq)]
 enum Type {
     Array(Box<Type>, syn::Expr),

--- a/parquet_derive_test/src/lib.rs
+++ b/parquet_derive_test/src/lib.rs
@@ -22,6 +22,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![allow(clippy::approx_constant)]
 
 use parquet_derive::{ParquetRecordReader, ParquetRecordWriter};


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Part of #10458.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Enable `clippy::allow_attributes` for a batch of crates

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Enable `clippy::allow_attributes` for `arrow`, `arrow-integration-test`, `arrow-integration-testing`, `arrow-flight/gen`, `parquet_derive`, `parquet_derive_test`, and `parquet-variant-json`.
- Replace active `allow` with `expect` attributes.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->
Yes.
`cargo clippy --workspace --all-targets --all-features -- -D warnings`

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
No.