### PR TITLE
Enable allow_attributes lint for arrow-avro

### DIFF
--- a/arrow-avro/src/compression.rs
+++ b/arrow-avro/src/compression.rs
@@ -47,7 +47,16 @@ pub enum CompressionCodec {
 }
 
 impl CompressionCodec {
-    #[allow(unused_variables)]
+    #[cfg_attr(
+        not(any(
+            feature = "deflate",
+            feature = "snappy",
+            feature = "zstd",
+            feature = "bzip2",
+            feature = "xz"
+        )),
+        expect(unused_variables)
+    )]
     pub(crate) fn decompress(&self, block: &[u8]) -> Result<Vec<u8>, AvroError> {
         match self {
             #[cfg(feature = "deflate")]
@@ -126,7 +135,16 @@ impl CompressionCodec {
         }
     }
 
-    #[allow(unused_variables)]
+    #[cfg_attr(
+        not(any(
+            feature = "deflate",
+            feature = "snappy",
+            feature = "zstd",
+            feature = "bzip2",
+            feature = "xz"
+        )),
+        expect(unused_variables)
+    )]
     pub(crate) fn compress(&self, data: &[u8]) -> Result<Vec<u8>, ArrowError> {
         match self {
             #[cfg(feature = "deflate")]

--- a/arrow-avro/src/lib.rs
+++ b/arrow-avro/src/lib.rs
@@ -217,6 +217,7 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 /// Core functionality for reading Avro data into Arrow arrays

--- a/arrow-avro/src/reader/async_reader/mod.rs
+++ b/arrow-avro/src/reader/async_reader/mod.rs
@@ -45,7 +45,7 @@ pub use spawn::SpawnedReader;
 mod store;
 
 use crate::errors::AvroError;
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cfg(feature = "object_store")]
 pub use store::AvroObjectReader;
 

--- a/arrow-avro/src/reader/async_reader/store.rs
+++ b/arrow-avro/src/reader/async_reader/store.rs
@@ -40,7 +40,7 @@ pub struct AvroObjectReader {
     runtime: Option<Handle>,
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl AvroObjectReader {
     /// Creates a new [`Self`] from a store implementation and file location.
     pub fn new(store: Arc<dyn ObjectStore>, path: Path) -> Self {
@@ -100,7 +100,7 @@ impl AvroObjectReader {
     }
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl AsyncFileReader for AvroObjectReader {
     fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes, AvroError>> {
         self.spawn(|store, path| async move { store.get_range(path, range).await }.boxed())

--- a/arrow-avro/src/reader/mod.rs
+++ b/arrow-avro/src/reader/mod.rs
@@ -504,7 +504,7 @@ pub mod async_reader;
 
 pub use header::{HeaderInfo, read_header_info};
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 #[cfg(feature = "object_store")]
 pub use async_reader::AvroObjectReader;
 #[cfg(feature = "async")]

--- a/arrow-avro/src/reader/vlq.rs
+++ b/arrow-avro/src/reader/vlq.rs
@@ -118,7 +118,7 @@ pub(crate) fn skip_varint(buf: &[u8]) -> Option<usize> {
 
 fn skip_varint_array(buf: [u8; 10]) -> Option<usize> {
     // Using buf.into_iter().enumerate() regresses performance by 1% on x86-64
-    #[allow(clippy::needless_range_loop)]
+    #[expect(clippy::needless_range_loop)]
     for idx in 0..9 {
         if buf[idx] < 0x80 {
             return Some(idx + 1);


### PR DESCRIPTION
# Which issue does this PR close?

- Part of #10458.

# Rationale for this change

The `arrow-avro` crate still used `#[allow(...)]` attributes, so it could not enable `clippy::allow_attributes` without failing Clippy.

# What changes are included in this PR?

- Enable `clippy::allow_attributes` as a deny-by-default crate lint.
- Replace active lint allowances with `#[expect(...)]`.
- Scope the compression helpers' `unused_variables` expectations to builds where all compression features are disabled.

# Are these changes tested?

Yes. The following checks pass:

- `cargo +stable-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu clippy -p arrow-avro --all-targets --all-features --no-deps -- -D warnings`
- `cargo +stable-x86_64-pc-windows-gnu clippy -p arrow-avro --all-targets --no-deps -- -D warnings`
- `cargo +stable-x86_64-pc-windows-gnu clippy -p arrow-avro --lib --no-default-features --no-deps -- -D warnings`
- `cargo +stable-x86_64-pc-windows-gnu test -p arrow-avro --all-features` (474 unit tests and 26 doctests passed; 1 doctest ignored)

# Are there any user-facing changes?

No.