### PR TITLE
[Arrow] Move parquet-variant-compute StructArrayBuilder to arrow-array

### DIFF
--- a/arrow-array/src/builder/mod.rs
+++ b/arrow-array/src/builder/mod.rs
@@ -261,6 +261,8 @@ mod primitive_run_builder;
 pub use primitive_run_builder::*;
 mod struct_builder;
 pub use struct_builder::*;
+mod struct_array_builder;
+pub use struct_array_builder::*;
 mod generic_bytes_dictionary_builder;
 pub use generic_bytes_dictionary_builder::*;
 mod generic_byte_run_builder;

--- a/arrow-array/src/builder/struct_array_builder.rs
+++ b/arrow-array/src/builder/struct_array_builder.rs
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::{ArrayRef, StructArray};
+use arrow_buffer::NullBuffer;
+use arrow_schema::{Field, FieldRef, Fields};
+use std::sync::Arc;
+
+/// Builds a [`StructArray`] from completed child arrays.
+///
+/// Unlike [`StructBuilder`](super::StructBuilder), which incrementally builds
+/// child arrays, this builder assembles arrays that have already been built.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use arrow_array::builder::StructArrayBuilder;
+/// use arrow_array::{Array, ArrayRef, Int32Array, StringArray};
+///
+/// let names = Arc::new(StringArray::from(vec!["one", "two"])) as ArrayRef;
+/// let values = Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef;
+/// let array = StructArrayBuilder::new()
+///     .with_field("name", names, false)
+///     .with_field("value", values, false)
+///     .build();
+///
+/// assert_eq!(array.len(), 2);
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct StructArrayBuilder {
+    fields: Vec<FieldRef>,
+    arrays: Vec<ArrayRef>,
+    nulls: Option<NullBuffer>,
+}
+
+impl StructArrayBuilder {
+    /// Creates a new empty [`StructArrayBuilder`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds an array with a field constructed from its data type.
+    pub fn with_field(
+        mut self,
+        field_name: impl Into<String>,
+        array: ArrayRef,
+        nullable: bool,
+    ) -> Self {
+        self.fields.push(Arc::new(Field::new(
+            field_name,
+            array.data_type().clone(),
+            nullable,
+        )));
+        self.arrays.push(array);
+        self
+    }
+
+    /// Adds an array using a caller-supplied field.
+    ///
+    /// This preserves field metadata that would be lost if the field were
+    /// constructed from the array's data type alone.
+    pub fn with_field_ref(mut self, field: FieldRef, array: ArrayRef) -> Self {
+        self.fields.push(field);
+        self.arrays.push(array);
+        self
+    }
+
+    /// Sets the top-level null buffer for the struct array.
+    pub fn with_nulls(mut self, nulls: NullBuffer) -> Self {
+        self.nulls = Some(nulls);
+        self
+    }
+
+    /// Builds the [`StructArray`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the fields, child arrays, or null buffer have incompatible
+    /// data types or lengths.
+    pub fn build(self) -> StructArray {
+        StructArray::new(Fields::from(self.fields), self.arrays, self.nulls)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Array, Int32Array, StringArray};
+    use arrow_schema::DataType;
+    use std::collections::HashMap;
+
+    #[test]
+    fn build_from_completed_arrays() {
+        let names = Arc::new(StringArray::from(vec!["one", "two"])) as ArrayRef;
+        let values = Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef;
+        let metadata = HashMap::from([("key".to_string(), "value".to_string())]);
+        let value_field =
+            Arc::new(Field::new("value", DataType::Int32, false).with_metadata(metadata.clone()));
+        let nulls = NullBuffer::from(vec![true, false]);
+
+        let array = StructArrayBuilder::new()
+            .with_field("name", names, false)
+            .with_field_ref(value_field, values)
+            .with_nulls(nulls.clone())
+            .build();
+
+        assert_eq!(array.len(), 2);
+        assert_eq!(array.column_names(), &["name", "value"]);
+        assert_eq!(array.fields()[1].metadata(), &metadata);
+        assert_eq!(array.nulls(), Some(&nulls));
+    }
+}

--- a/arrow-array/src/builder/struct_array_builder.rs
+++ b/arrow-array/src/builder/struct_array_builder.rs
@@ -124,4 +124,31 @@ mod tests {
         assert_eq!(array.fields()[1].metadata(), &metadata);
         assert_eq!(array.nulls(), Some(&nulls));
     }
+
+    #[test]
+    #[should_panic(
+        expected = "Incorrect array length for StructArray field \\\"value\\\", expected 2 got 1"
+    )]
+    fn build_panics_on_mismatched_child_lengths() {
+        let names = Arc::new(StringArray::from(vec!["one", "two"])) as ArrayRef;
+        let values = Arc::new(Int32Array::from(vec![1])) as ArrayRef;
+
+        StructArrayBuilder::new()
+            .with_field("name", names, false)
+            .with_field("value", values, false)
+            .build();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Incorrect datatype for StructArray field \\\"value\\\", expected Int64 got Int32"
+    )]
+    fn build_panics_on_mismatched_field_data_type() {
+        let value_field = Arc::new(Field::new("value", DataType::Int64, false));
+        let values = Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef;
+
+        StructArrayBuilder::new()
+            .with_field_ref(value_field, values)
+            .build();
+    }
 }

--- a/arrow-array/src/builder/struct_array_builder.rs
+++ b/arrow-array/src/builder/struct_array_builder.rs
@@ -17,7 +17,7 @@
 
 use crate::{ArrayRef, StructArray};
 use arrow_buffer::NullBuffer;
-use arrow_schema::{Field, FieldRef, Fields};
+use arrow_schema::{ArrowError, Field, FieldRef, Fields};
 use std::sync::Arc;
 
 /// Builds a [`StructArray`] from completed child arrays.
@@ -37,7 +37,8 @@ use std::sync::Arc;
 /// let array = StructArrayBuilder::new()
 ///     .with_field("name", names, false)
 ///     .with_field("value", values, false)
-///     .build();
+///     .build()
+///     .unwrap();
 ///
 /// assert_eq!(array.len(), 2);
 /// ```
@@ -88,12 +89,12 @@ impl StructArrayBuilder {
 
     /// Builds the [`StructArray`].
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the fields, child arrays, or null buffer have incompatible
-    /// data types or lengths.
-    pub fn build(self) -> StructArray {
-        StructArray::new(Fields::from(self.fields), self.arrays, self.nulls)
+    /// Returns an error if the fields, child arrays, or null buffer have
+    /// incompatible data types or lengths.
+    pub fn build(self) -> Result<StructArray, ArrowError> {
+        StructArray::try_new(Fields::from(self.fields), self.arrays, self.nulls)
     }
 }
 
@@ -117,7 +118,8 @@ mod tests {
             .with_field("name", names, false)
             .with_field_ref(value_field, values)
             .with_nulls(nulls.clone())
-            .build();
+            .build()
+            .unwrap();
 
         assert_eq!(array.len(), 2);
         assert_eq!(array.column_names(), &["name", "value"]);
@@ -126,29 +128,35 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "Incorrect array length for StructArray field \\\"value\\\", expected 2 got 1"
-    )]
-    fn build_panics_on_mismatched_child_lengths() {
+    fn build_errors_on_mismatched_child_lengths() {
         let names = Arc::new(StringArray::from(vec!["one", "two"])) as ArrayRef;
         let values = Arc::new(Int32Array::from(vec![1])) as ArrayRef;
 
-        StructArrayBuilder::new()
+        let err = StructArrayBuilder::new()
             .with_field("name", names, false)
             .with_field("value", values, false)
-            .build();
+            .build()
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Invalid argument error: Incorrect array length for StructArray field \"value\", expected 2 got 1"
+        );
     }
 
     #[test]
-    #[should_panic(
-        expected = "Incorrect datatype for StructArray field \\\"value\\\", expected Int64 got Int32"
-    )]
-    fn build_panics_on_mismatched_field_data_type() {
+    fn build_errors_on_mismatched_field_data_type() {
         let value_field = Arc::new(Field::new("value", DataType::Int64, false));
         let values = Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef;
 
-        StructArrayBuilder::new()
+        let err = StructArrayBuilder::new()
             .with_field_ref(value_field, values)
-            .build();
+            .build()
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Invalid argument error: Incorrect datatype for StructArray field \"value\", expected Int64 got Int32"
+        );
     }
 }

--- a/parquet-variant-compute/src/shred_variant.rs
+++ b/parquet-variant-compute/src/shred_variant.rs
@@ -17,13 +17,13 @@
 
 //! Module for shredding VariantArray with a given schema.
 
-use crate::variant_array::{ShreddedVariantFieldArray, StructArrayBuilder};
+use crate::variant_array::ShreddedVariantFieldArray;
 use crate::variant_to_arrow::{
     ArrayVariantToArrowRowBuilder, PrimitiveVariantToArrowRowBuilder,
     make_primitive_variant_to_arrow_row_builder,
 };
 use crate::{VariantArray, VariantValueArrayBuilder};
-use arrow::array::{ArrayRef, BinaryViewArray, NullBufferBuilder};
+use arrow::array::{ArrayRef, BinaryViewArray, NullBufferBuilder, StructArrayBuilder};
 use arrow::buffer::NullBuffer;
 use arrow::compute::CastOptions;
 use arrow::datatypes::{DataType, Field, FieldRef, Fields, TimeUnit};

--- a/parquet-variant-compute/src/shred_variant.rs
+++ b/parquet-variant-compute/src/shred_variant.rs
@@ -461,7 +461,7 @@ impl<'a> VariantToShreddedObjectVariantRowBuilder<'a> {
         }
         Ok((
             self.value_builder.build()?,
-            Arc::new(builder.build()),
+            Arc::new(builder.build()?),
             self.nulls.finish(),
         ))
     }

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -22,7 +22,7 @@ use crate::type_conversion::{
     generic_conversion_single_value, generic_conversion_single_value_with_result,
     primitive_conversion_single_value,
 };
-use arrow::array::{Array, ArrayRef, AsArray, StructArray, new_null_array};
+use arrow::array::{Array, ArrayRef, AsArray, StructArray, StructArrayBuilder, new_null_array};
 use arrow::buffer::NullBuffer;
 use arrow::compute::cast;
 use arrow::datatypes::{
@@ -32,7 +32,7 @@ use arrow::datatypes::{
 };
 use arrow::error::Result;
 use arrow_schema::extension::{ExtensionType, Uuid as UuidExtension};
-use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields, TimeUnit};
+use arrow_schema::{ArrowError, DataType, Field, FieldRef, TimeUnit};
 use chrono::{DateTime, NaiveTime};
 use parquet_variant::{
     Uuid, Variant, VariantDecimal4, VariantDecimal8, VariantDecimal16, VariantDecimalType as _,
@@ -947,55 +947,6 @@ fn typed_value_field(array: &ArrayRef) -> FieldRef {
         field = field.with_extension_type(UuidExtension);
     }
     Arc::new(field)
-}
-
-/// Builds struct arrays from component fields
-///
-/// TODO: move to arrow crate
-#[derive(Debug, Default, Clone)]
-pub(crate) struct StructArrayBuilder {
-    fields: Vec<FieldRef>,
-    arrays: Vec<ArrayRef>,
-    nulls: Option<NullBuffer>,
-}
-
-impl StructArrayBuilder {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    /// Add an array to this struct array as a field with the specified name.
-    pub fn with_field(mut self, field_name: &str, array: ArrayRef, nullable: bool) -> Self {
-        let field = Field::new(field_name, array.data_type().clone(), nullable);
-        self.fields.push(Arc::new(field));
-        self.arrays.push(array);
-        self
-    }
-
-    /// Add an array to this struct array using a caller-supplied [`FieldRef`].
-    ///
-    /// Use this when the field carries metadata (e.g. an extension type) that
-    /// would be lost if the field were synthesized from the array's data type alone.
-    pub fn with_field_ref(mut self, field: FieldRef, array: ArrayRef) -> Self {
-        self.fields.push(field);
-        self.arrays.push(array);
-        self
-    }
-
-    /// Set the null buffer for this struct array.
-    pub fn with_nulls(mut self, nulls: NullBuffer) -> Self {
-        self.nulls = Some(nulls);
-        self
-    }
-
-    pub fn build(self) -> StructArray {
-        let Self {
-            fields,
-            arrays,
-            nulls,
-        } = self;
-        StructArray::new(Fields::from(fields), arrays, nulls)
-    }
 }
 
 /// returns the non-null element at index as a Variant

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -23,8 +23,8 @@ use crate::type_conversion::{
     primitive_conversion_single_value,
 };
 use arrow::array::{
-    Array, ArrayRef, AsArray, StructArray, downcast_dictionary_array, downcast_run_array,
-    new_null_array,
+    Array, ArrayRef, AsArray, StructArray, StructArrayBuilder, downcast_dictionary_array,
+    downcast_run_array, new_null_array,
 };
 use arrow::buffer::NullBuffer;
 use arrow::compute::cast;
@@ -35,7 +35,7 @@ use arrow::datatypes::{
 };
 use arrow::error::Result;
 use arrow_schema::extension::{ExtensionType, Uuid as UuidExtension};
-use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields, TimeUnit};
+use arrow_schema::{ArrowError, DataType, Field, FieldRef, TimeUnit};
 use chrono::{DateTime, NaiveTime};
 use parquet_variant::{
     Uuid, Variant, VariantDecimal4, VariantDecimal8, VariantDecimal16, VariantDecimalType as _,
@@ -1003,55 +1003,6 @@ fn typed_value_field(array: &ArrayRef) -> FieldRef {
         field = field.with_extension_type(UuidExtension);
     }
     Arc::new(field)
-}
-
-/// Builds struct arrays from component fields
-///
-/// TODO: move to arrow crate
-#[derive(Debug, Default, Clone)]
-pub(crate) struct StructArrayBuilder {
-    fields: Vec<FieldRef>,
-    arrays: Vec<ArrayRef>,
-    nulls: Option<NullBuffer>,
-}
-
-impl StructArrayBuilder {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    /// Add an array to this struct array as a field with the specified name.
-    pub fn with_field(mut self, field_name: &str, array: ArrayRef, nullable: bool) -> Self {
-        let field = Field::new(field_name, array.data_type().clone(), nullable);
-        self.fields.push(Arc::new(field));
-        self.arrays.push(array);
-        self
-    }
-
-    /// Add an array to this struct array using a caller-supplied [`FieldRef`].
-    ///
-    /// Use this when the field carries metadata (e.g. an extension type) that
-    /// would be lost if the field were synthesized from the array's data type alone.
-    pub fn with_field_ref(mut self, field: FieldRef, array: ArrayRef) -> Self {
-        self.fields.push(field);
-        self.arrays.push(array);
-        self
-    }
-
-    /// Set the null buffer for this struct array.
-    pub fn with_nulls(mut self, nulls: NullBuffer) -> Self {
-        self.nulls = Some(nulls);
-        self
-    }
-
-    pub fn build(self) -> StructArray {
-        let Self {
-            fields,
-            arrays,
-            nulls,
-        } = self;
-        StructArray::new(Fields::from(fields), arrays, nulls)
-    }
 }
 
 /// returns the non-null element at index as a Variant

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -418,7 +418,7 @@ impl VariantArray {
         }
 
         Self {
-            inner: builder.build(),
+            inner: builder.build().unwrap(),
             metadata,
             shredding_state: ShreddingState::new(value, typed_value),
         }
@@ -834,7 +834,7 @@ impl ShreddedVariantFieldArray {
         }
 
         Self {
-            inner: builder.build(),
+            inner: builder.build().unwrap(),
             shredding_state: ShreddingState::new(value, typed_value),
         }
     }
@@ -1391,7 +1391,8 @@ mod test {
         let struct_array = StructArrayBuilder::new()
             .with_field("metadata", Arc::new(metadata), false)
             .with_field("typed_value", typed_value, true)
-            .build();
+            .build()
+            .unwrap();
         assert!(struct_array.column_by_name("value").is_none());
 
         let variant_array = VariantArray::try_new(&struct_array).unwrap();
@@ -1532,6 +1533,7 @@ mod test {
             .with_field("value", value, true)
             .with_field("typed_value", typed_value, true)
             .build()
+            .unwrap()
     }
 
     #[test]
@@ -1555,10 +1557,12 @@ mod test {
         let leaf = FixedSizeBinaryArray::try_from_iter(std::iter::repeat_n([0u8; 16], 1)).unwrap();
         let inner = StructArrayBuilder::new()
             .with_field("typed_value", Arc::new(leaf), true)
-            .build();
+            .build()
+            .unwrap();
         let object = StructArrayBuilder::new()
             .with_field("id", Arc::new(inner), false)
-            .build();
+            .build()
+            .unwrap();
         let input = make_variant_struct_with_typed_value(Arc::new(object));
 
         // typed_value (struct) -> id (struct) -> typed_value (the FixedSizeBinary(16) UUID leaf).

--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -505,9 +505,7 @@ mod test {
     use std::sync::Arc;
 
     use super::{GetOptions, requested_field_is_shredded, variant_get};
-    use crate::variant_array::{
-        ShreddedVariantFieldArray, StructArrayBuilder, all_null_value_column,
-    };
+    use crate::variant_array::{ShreddedVariantFieldArray, all_null_value_column};
     use crate::{
         ShreddedSchemaBuilder, VariantArray, VariantArrayBuilder, cast_to_variant, json_to_variant,
         shred_variant,
@@ -518,7 +516,7 @@ mod test {
         FixedSizeListArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array,
         Int64Array, Int64Builder, LargeBinaryArray, LargeListArray, LargeListViewArray,
         LargeStringArray, ListArray, ListBuilder, ListViewArray, MapBuilder, NullArray,
-        NullBuilder, StringArray, StringBuilder, StringViewArray, StructArray,
+        NullBuilder, StringArray, StringBuilder, StringViewArray, StructArray, StructArrayBuilder,
         Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
         UnionArray,
     };

--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -506,9 +506,7 @@ mod test {
     use std::sync::Arc;
 
     use super::{GetOptions, requested_field_is_shredded, variant_get};
-    use crate::variant_array::{
-        ShreddedVariantFieldArray, StructArrayBuilder, all_null_value_column,
-    };
+    use crate::variant_array::{ShreddedVariantFieldArray, all_null_value_column};
     use crate::{
         ShreddedSchemaBuilder, VariantArray, VariantArrayBuilder, cast_to_variant, json_to_variant,
         shred_variant,
@@ -519,7 +517,7 @@ mod test {
         FixedSizeListArray, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array,
         Int64Array, Int64Builder, LargeBinaryArray, LargeListArray, LargeListViewArray,
         LargeStringArray, ListArray, ListBuilder, ListViewArray, MapBuilder, NullArray,
-        NullBuilder, StringArray, StringBuilder, StringViewArray, StructArray,
+        NullBuilder, StringArray, StringBuilder, StringViewArray, StructArray, StructArrayBuilder,
         Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
     };
     use arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};

--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -3781,7 +3781,8 @@ mod test {
         let outer_typed_value = StructArrayBuilder::new()
             .with_field("inner", ArrayRef::from(inner), false)
             .with_nulls(outer_typed_value_nulls)
-            .build();
+            .build()
+            .unwrap();
 
         let outer =
             ShreddedVariantFieldArray::perfectly_shredded(Arc::new(outer_typed_value) as ArrayRef);
@@ -3795,7 +3796,8 @@ mod test {
         let typed_value = StructArrayBuilder::new()
             .with_field("outer", ArrayRef::from(outer), false)
             .with_nulls(typed_value_nulls)
-            .build();
+            .build()
+            .unwrap();
 
         // Build final VariantArray with top-level nulls
         let metadata_array =
@@ -3867,7 +3869,8 @@ mod test {
         // Create main typed_value struct (only contains shredded fields)
         let typed_value_struct = StructArrayBuilder::new()
             .with_field("x", ArrayRef::from(x_field_shredded), false)
-            .build();
+            .build()
+            .unwrap();
 
         // Build VariantArray with both value and typed_value (PartiallyShredded)
         // Top-level null is encoded in the main StructArray's null mask


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10618.

# Rationale for this change

`parquet-variant-compute` contains a local helper for assembling a `StructArray` from completed child arrays. The helper is generally useful Arrow functionality and should live in `arrow-array` instead of being duplicated in a Variant-specific crate.

# What changes are included in this PR?

- Add a public `StructArrayBuilder` for completed child arrays to `arrow-array`.
- Support synthesized fields, caller-provided `FieldRef` values that retain metadata, and an optional top-level null buffer.
- Replace the local `parquet-variant-compute` implementation with the shared builder.
- Add API documentation, an example, and unit coverage.

# Are these changes tested?

Yes.

- `cargo test -p arrow-array struct_array_builder` (16 tests passed)
- `cargo test -p parquet-variant-compute` (347 unit tests and 13 doctests passed)

# Are there any user-facing changes?

Yes. `arrow-array` exposes a new builder API for assembling `StructArray` values from completed children. Existing APIs are unchanged.


## AI assistance

I investigated the existing builder design, determined the scope of the API extraction, and reviewed and refined the resulting API and implementation. OpenAI Codex assisted with code exploration, drafting, and test preparation.