### PR TITLE
fix(variant): reject FixedSizeList shredding

### DIFF
--- a/parquet-variant-compute/src/shred_variant.rs
+++ b/parquet-variant-compute/src/shred_variant.rs
@@ -166,11 +166,6 @@ pub(crate) fn make_variant_to_shredded_variant_arrow_row_builder<'a>(
             )?;
             VariantToShreddedVariantRowBuilder::Array(typed_value_builder)
         }
-        DataType::FixedSizeList(..) => {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "{data_type} is not a valid variant shredding type"
-            )));
-        }
         // Supported shredded primitive types, see Variant shredding spec:
         // https://github.com/apache/parquet-format/blob/master/VariantShredding.md#shredded-value-types
         DataType::Boolean

--- a/parquet-variant-compute/src/shred_variant.rs
+++ b/parquet-variant-compute/src/shred_variant.rs
@@ -157,8 +157,7 @@ pub(crate) fn make_variant_to_shredded_variant_arrow_row_builder<'a>(
         DataType::List(_)
         | DataType::LargeList(_)
         | DataType::ListView(_)
-        | DataType::LargeListView(_)
-        | DataType::FixedSizeList(..) => {
+        | DataType::LargeListView(_) => {
             let typed_value_builder = VariantToShreddedArrayVariantRowBuilder::try_new(
                 data_type,
                 cast_options,
@@ -166,6 +165,11 @@ pub(crate) fn make_variant_to_shredded_variant_arrow_row_builder<'a>(
                 null_value,
             )?;
             VariantToShreddedVariantRowBuilder::Array(typed_value_builder)
+        }
+        DataType::FixedSizeList(..) => {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "{data_type} is not a valid variant shredding type"
+            )));
         }
         // Supported shredded primitive types, see Variant shredding spec:
         // https://github.com/apache/parquet-format/blob/master/VariantShredding.md#shredded-value-types
@@ -701,9 +705,9 @@ mod tests {
     use crate::variant_array::{all_null_value_column, binary_array_value, variant_from_arrays_at};
     use arrow::array::{
         Array, BinaryViewArray, Decimal32Array, Decimal64Array, Decimal128Array,
-        FixedSizeBinaryArray, FixedSizeListArray, Float64Array, GenericListArray,
-        GenericListViewArray, Int64Array, LargeBinaryArray, LargeStringArray, ListArray,
-        ListLikeArray, OffsetSizeTrait, PrimitiveArray, StringArray, StructArray,
+        FixedSizeBinaryArray, Float64Array, GenericListArray, GenericListViewArray, Int64Array,
+        LargeBinaryArray, LargeStringArray, ListArray, ListLikeArray, OffsetSizeTrait,
+        PrimitiveArray, StringArray, StructArray,
     };
     use arrow::datatypes::{
         ArrowPrimitiveType, DataType, Field, Fields, Int64Type, TimeUnit, UnionFields, UnionMode,
@@ -1473,6 +1477,7 @@ mod tests {
             DataType::Time32(TimeUnit::Second),
             DataType::Time64(TimeUnit::Nanosecond),
             DataType::Timestamp(TimeUnit::Millisecond, None),
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int64, true)), 2),
             DataType::FixedSizeBinary(17),
             DataType::Union(
                 UnionFields::from_fields(vec![
@@ -1646,85 +1651,6 @@ mod tests {
             &[Some(2), None, Some(0)],
             &[None, Some(Variant::from("fallback")), None],
             (&[Some(1), Some(2)], &[None, None]),
-        );
-    }
-
-    #[test]
-    fn test_array_shredding_as_fixed_size_list() {
-        let input = build_variant_array(vec![
-            VariantRow::List(vec![VariantValue::from(1i64), VariantValue::from(2i64)]),
-            VariantRow::Value(VariantValue::from("This should not be shredded")),
-            VariantRow::List(vec![VariantValue::from(3i64), VariantValue::from(4i64)]),
-        ]);
-
-        let list_schema =
-            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int64, true)), 2);
-        let result = shred_variant(&input, &list_schema).unwrap();
-        assert_eq!(result.len(), 3);
-
-        // The first row should be shredded, so the `value` field should be null and the
-        // `typed_value` field should contain the list
-        assert!(result.is_valid(0));
-        assert!(result.value_column().is_null(0));
-        assert!(result.typed_value_column().unwrap().is_valid(0));
-
-        // The second row should not be shredded because the provided schema for shredding did not
-        // match. Hence, the `value` field should contain the raw value and the `typed_value` field
-        // should be null.
-        assert!(result.is_valid(1));
-        assert!(result.value_column().is_valid(1));
-        assert!(result.typed_value_column().unwrap().is_null(1));
-
-        // The third row should be shredded, so the `value` field should be null and the
-        // `typed_value` field should contain the list
-        assert!(result.is_valid(2));
-        assert!(result.value_column().is_null(2));
-        assert!(result.typed_value_column().unwrap().is_valid(2));
-
-        let typed_value = result.typed_value_column().unwrap();
-        let fixed_size_list = typed_value
-            .as_any()
-            .downcast_ref::<FixedSizeListArray>()
-            .expect("Expected FixedSizeListArray");
-
-        // Verify that typed value is `FixedSizeList`.
-        assert_eq!(fixed_size_list.len(), 3);
-        assert_eq!(fixed_size_list.value_length(), 2);
-
-        // Verify that the first entry in the `FixedSizeList` contains the expected value.
-        let val0 = fixed_size_list.value(0);
-        let val0_struct = val0.as_any().downcast_ref::<StructArray>().unwrap();
-        let val0_typed = val0_struct.column_by_name("typed_value").unwrap();
-        let val0_ints = val0_typed.as_any().downcast_ref::<Int64Array>().unwrap();
-        assert_eq!(val0_ints.values(), &[1i64, 2i64]);
-
-        // Verify that second entry in the `FixedSizeList` cannot be shredded hence the value is
-        // invalid.
-        assert!(fixed_size_list.is_null(1));
-
-        // Verify that the third entry in the `FixedSizeList` contains the expected value.
-        let val2 = fixed_size_list.value(2);
-        let val2_struct = val2.as_any().downcast_ref::<StructArray>().unwrap();
-        let val2_typed = val2_struct.column_by_name("typed_value").unwrap();
-        let val2_ints = val2_typed.as_any().downcast_ref::<Int64Array>().unwrap();
-        assert_eq!(val2_ints.values(), &[3i64, 4i64]);
-    }
-
-    #[test]
-    fn test_array_shredding_as_fixed_size_list_wrong_size() {
-        let input = build_variant_array(vec![VariantRow::List(vec![
-            VariantValue::from(1i64),
-            VariantValue::from(2i64),
-            VariantValue::from(3i64),
-        ])]);
-        let list_schema =
-            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Int64, true)), 2);
-
-        let err = shred_variant(&input, &list_schema).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("Expected fixed size list of size 2, got size 3"),
-            "got: {err}",
         );
     }
 

--- a/parquet-variant-compute/src/unshred_variant.rs
+++ b/parquet-variant-compute/src/unshred_variant.rs
@@ -21,9 +21,8 @@ use crate::variant_array::{binary_array_value, validate_binary_array};
 use crate::{VariantArray, VariantValueArrayBuilder};
 use arrow::array::{
     Array, ArrayRef, AsArray as _, BinaryArray, BinaryViewArray, BooleanArray,
-    FixedSizeBinaryArray, FixedSizeListArray, GenericListArray, GenericListViewArray,
-    LargeBinaryArray, LargeStringArray, ListLikeArray, PrimitiveArray, StringArray,
-    StringViewArray, StructArray,
+    FixedSizeBinaryArray, GenericListArray, GenericListViewArray, LargeBinaryArray,
+    LargeStringArray, ListLikeArray, PrimitiveArray, StringArray, StringViewArray, StructArray,
 };
 use arrow::buffer::NullBuffer;
 use arrow::datatypes::{
@@ -185,7 +184,6 @@ enum UnshredVariantRowBuilder<'a> {
     LargeList(ListUnshredVariantBuilder<'a, GenericListArray<i64>>),
     ListView(ListUnshredVariantBuilder<'a, GenericListViewArray<i32>>),
     LargeListView(ListUnshredVariantBuilder<'a, GenericListViewArray<i64>>),
-    FixedSizeList(ListUnshredVariantBuilder<'a, FixedSizeListArray>),
     Struct(StructUnshredVariantBuilder<'a>),
     ValueOnly(ValueOnlyUnshredVariantBuilder<'a>),
     Null(NullUnshredVariantBuilder),
@@ -230,7 +228,6 @@ impl<'a> UnshredVariantRowBuilder<'a> {
             Self::LargeList(b) => b.append_row(builder, metadata, index),
             Self::ListView(b) => b.append_row(builder, metadata, index),
             Self::LargeListView(b) => b.append_row(builder, metadata, index),
-            Self::FixedSizeList(b) => b.append_row(builder, metadata, index),
             Self::Struct(b) => b.append_row(builder, metadata, index),
             Self::ValueOnly(b) => b.append_row(builder, metadata, index),
             Self::Null(b) => b.append_row(builder, metadata, index),
@@ -342,9 +339,6 @@ impl<'a> UnshredVariantRowBuilder<'a> {
                 value,
                 typed_value.as_list_view(),
             )?),
-            DataType::FixedSizeList(_, _) => Self::FixedSizeList(
-                ListUnshredVariantBuilder::try_new(value, typed_value.as_fixed_size_list())?,
-            ),
             _ => {
                 return Err(ArrowError::NotYetImplemented(format!(
                     "Unshredding not yet supported for type: {}",

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -291,7 +291,7 @@ impl VariantArray {
     ///    binary_view
     ///
     /// 3. An optional field named `typed_value` which can be any primitive type
-    ///    or be a list, large_list, list_view or struct
+    ///    or be a list, large_list, fixed_size_list, list_view or struct
     ///
     /// NOTE: It is also permissible for the metadata field to be
     /// Dictionary-Encoded, preferably (but not required) with an index type of
@@ -1236,7 +1236,7 @@ fn canonicalize_and_verify_data_type(data_type: &DataType) -> Result<Cow<'_, Dat
 
         // UUID maps to 16-byte fixed-size binary; no other width is allowed
         FixedSizeBinary(16) => borrow!(),
-        FixedSizeBinary(_) | FixedSizeList(..) => fail!(),
+        FixedSizeBinary(_) => fail!(),
 
         // List-like containers and struct are allowed, maps and unions are not
         List(field) => match canonicalize_and_verify_field(field)? {
@@ -1254,6 +1254,10 @@ fn canonicalize_and_verify_data_type(data_type: &DataType) -> Result<Cow<'_, Dat
         LargeListView(field) => match canonicalize_and_verify_field(field)? {
             Cow::Borrowed(_) => borrow!(),
             Cow::Owned(new_field) => Cow::Owned(DataType::LargeListView(new_field)),
+        },
+        FixedSizeList(field, size) => match canonicalize_and_verify_field(field)? {
+            Cow::Borrowed(_) => borrow!(),
+            Cow::Owned(new_field) => Cow::Owned(DataType::FixedSizeList(new_field, *size)),
         },
         // Struct is used by the internal layout, and can also represent a shredded variant object.
         Struct(fields) => {
@@ -1334,8 +1338,8 @@ mod test {
     use super::*;
     use arrow::array::{
         BinaryArray, BinaryViewArray, Decimal32Array, Decimal64Array, Decimal128Array,
-        FixedSizeBinaryArray, Int32Array, Int64Array, LargeBinaryArray, LargeListArray,
-        LargeListViewArray, ListArray, ListViewArray, Time64MicrosecondArray,
+        FixedSizeBinaryArray, FixedSizeListArray, Int32Array, Int64Array, LargeBinaryArray,
+        LargeListArray, LargeListViewArray, ListArray, ListViewArray, Time64MicrosecondArray,
     };
     use arrow::buffer::{OffsetBuffer, ScalarBuffer};
     use arrow_schema::{Field, Fields};
@@ -1535,6 +1539,10 @@ mod test {
             DataType::LargeList(make_item_binary_view()),
             DataType::ListView(make_item_binary_view()),
             DataType::LargeListView(make_item_binary_view()),
+            // Fixed-size list items
+            DataType::FixedSizeList(make_item_binary(), 2),
+            DataType::FixedSizeList(make_large_binary(), 2),
+            DataType::FixedSizeList(make_item_binary_view(), 2),
         ];
 
         for input in cases {
@@ -1575,6 +1583,12 @@ mod test {
                 ScalarBuffer::from(vec![0_i64, 2]),
                 ScalarBuffer::from(vec![2_i64, 1]),
                 values,
+                None,
+            )) as ArrayRef,
+            Arc::new(FixedSizeListArray::new(
+                Arc::new(Field::new("item", DataType::Int64, true)),
+                2,
+                Arc::new(Int64Array::from(vec![Some(1), None, Some(3), Some(4)])),
                 None,
             )) as ArrayRef,
         ];

--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -331,7 +331,8 @@ impl VariantArray {
     ///    binary_view
     ///
     /// 3. An optional field named `typed_value` which can be any primitive type
-    ///    or be a list, large_list, list_view or struct
+    ///    or be a list, large_list, fixed_size_list, list_view or struct. Fixed-size lists are
+    ///    normalized to variable-length lists on read.
     ///
     pub fn try_new(inner: &dyn Array) -> Result<Self> {
         // Canonicalize shredded typed_value fields (e.g. decimal narrowing)
@@ -1297,7 +1298,15 @@ fn canonicalize_and_verify_data_type_impl(
 
         // UUID maps to 16-byte fixed-size binary; no other width is allowed
         FixedSizeBinary(16) => borrow!(),
-        FixedSizeBinary(_) | FixedSizeList(..) => fail!(),
+        FixedSizeBinary(_) => fail!(),
+
+        // FixedSizeList is an Arrow-specific distinction. Normalize it to List on read so
+        // Variant data written by older arrow-rs versions remains readable without treating
+        // FixedSizeList as a supported shredding target.
+        FixedSizeList(field, _) => match canonicalize_and_verify_field(field)? {
+            Cow::Borrowed(_) => Cow::Owned(DataType::List(field.clone())),
+            Cow::Owned(new_field) => Cow::Owned(DataType::List(new_field)),
+        },
 
         // List-like containers and struct are allowed, maps and unions are not
         List(field) => match canonicalize_and_verify_field(field)? {
@@ -1398,9 +1407,9 @@ mod test {
     use super::*;
     use arrow::array::{
         BinaryArray, BinaryDictionaryBuilder, BinaryRunBuilder, BinaryViewArray, Decimal32Array,
-        Decimal64Array, Decimal128Array, FixedSizeBinaryArray, Int8Array, Int32Array, Int64Array,
-        LargeBinaryArray, LargeListArray, LargeListViewArray, ListArray, ListViewArray,
-        StringArray, Time64MicrosecondArray,
+        Decimal64Array, Decimal128Array, FixedSizeBinaryArray, FixedSizeListArray, Int8Array,
+        Int32Array, Int64Array, LargeBinaryArray, LargeListArray, LargeListViewArray, ListArray,
+        ListViewArray, StringArray, Time64MicrosecondArray,
     };
     use arrow::buffer::{OffsetBuffer, ScalarBuffer};
     use arrow_schema::{Field, Fields};
@@ -1716,6 +1725,33 @@ mod test {
                 typed_value.data_type(),
             );
         }
+    }
+
+    #[test]
+    fn variant_array_try_new_normalizes_fixed_size_list_typed_value() {
+        let element_values: ArrayRef =
+            ShreddedVariantFieldArray::perfectly_shredded(Arc::new(Int64Array::from(vec![
+                1, 2, 3, 4,
+            ])))
+            .into();
+        let item_field = Arc::new(Field::new("item", element_values.data_type().clone(), true));
+        let typed_value: ArrayRef = Arc::new(FixedSizeListArray::new(
+            item_field.clone(),
+            2,
+            element_values,
+            None,
+        ));
+        let input = make_variant_struct_with_typed_value(typed_value);
+
+        let variant_array = VariantArray::try_new(&input).unwrap();
+        assert_eq!(
+            variant_array.typed_value_column().unwrap().data_type(),
+            &DataType::List(item_field),
+        );
+
+        let unshredded = crate::unshred_variant(&variant_array).unwrap();
+        assert!(unshredded.typed_value_column().is_none());
+        assert_eq!(unshredded.len(), 2);
     }
 
     #[test]

--- a/parquet-variant-compute/src/variant_get.rs
+++ b/parquet-variant-compute/src/variant_get.rs
@@ -16,8 +16,8 @@
 // under the License.
 use arrow::{
     array::{
-        self, Array, ArrayRef, GenericListArray, GenericListViewArray, ListLikeArray, StructArray,
-        UInt64Array, make_array,
+        self, Array, ArrayRef, FixedSizeListArray, GenericListArray, GenericListViewArray,
+        ListLikeArray, StructArray, UInt64Array, make_array,
     },
     buffer::NullBuffer,
     compute::{CastOptions, take},
@@ -170,6 +170,9 @@ pub(crate) fn follow_shredded_path_element(
                 >(typed_value.as_ref(), *index)?,
                 DataType::LargeListView(_) => take_list_like_index_as_shredding_state::<
                     GenericListViewArray<i64>,
+                >(typed_value.as_ref(), *index)?,
+                DataType::FixedSizeList(_, _) => take_list_like_index_as_shredding_state::<
+                    FixedSizeListArray,
                 >(typed_value.as_ref(), *index)?,
                 _ => {
                     // JSONPath semantics: indexing a non-list yields no match.
@@ -1937,12 +1940,13 @@ mod test {
     type ShreddedListLikeArrayGen = fn() -> ArrayRef;
     type ShreddedListLikeCase = (&'static str, ShreddedListLikeArrayGen);
 
-    fn shredded_list_like_cases() -> [ShreddedListLikeCase; 4] {
+    fn shredded_list_like_cases() -> [ShreddedListLikeCase; 5] {
         [
             ("list", shredded_list_variant_array),
             ("large_list", shredded_large_list_variant_array),
             ("list_view", shredded_list_view_variant_array),
             ("large_list_view", shredded_large_list_view_variant_array),
+            ("fixed_size_list", shredded_fixed_size_list_variant_array),
         ]
     }
 
@@ -2106,6 +2110,13 @@ mod test {
             DataType::Utf8,
             true,
         ))))
+    }
+
+    fn shredded_fixed_size_list_variant_array() -> ArrayRef {
+        shredded_list_like_variant_array(DataType::FixedSizeList(
+            Arc::new(Field::new("item", DataType::Utf8, true)),
+            2,
+        ))
     }
 
     fn shredded_struct_with_list_variant_array() -> ArrayRef {

--- a/parquet/src/variant.rs
+++ b/parquet/src/variant.rs
@@ -147,11 +147,16 @@ mod tests {
     use crate::file::metadata::{ParquetMetaData, ParquetMetaDataReader};
     use crate::file::reader::ChunkReader;
     use arrow::util::test_util::parquet_test_data;
-    use arrow_array::{ArrayRef, RecordBatch};
-    use arrow_schema::Schema;
+    use arrow_array::{
+        Array, ArrayRef, BinaryViewArray, FixedSizeListArray, Int64Array, RecordBatch, StructArray,
+        new_null_array,
+    };
+    use arrow_schema::{DataType, Field, Fields, Schema};
     use bytes::Bytes;
-    use parquet_variant::{Variant, VariantBuilderExt};
-    use parquet_variant_compute::{VariantArray, VariantArrayBuilder, VariantType};
+    use parquet_variant::{EMPTY_VARIANT_METADATA_BYTES, Variant, VariantBuilderExt};
+    use parquet_variant_compute::{
+        VariantArray, VariantArrayBuilder, VariantType, unshred_variant,
+    };
     use std::path::PathBuf;
     use std::sync::Arc;
 
@@ -179,6 +184,52 @@ mod tests {
         assert!(var_array.is_valid(0));
         let var_value = var_array.value(0);
         assert_eq!(var_value, Variant::from("iceberg"));
+    }
+
+    #[test]
+    fn read_fixed_size_list_typed_value_as_list() {
+        let element_values: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3, 4]));
+        let element_value = new_null_array(&DataType::BinaryView, 4);
+        let element_fields = Fields::from(vec![
+            Field::new("value", DataType::BinaryView, true),
+            Field::new("typed_value", DataType::Int64, true),
+        ]);
+        let elements: ArrayRef = Arc::new(StructArray::new(
+            element_fields,
+            vec![element_value, element_values],
+            None,
+        ));
+        let item_field = Arc::new(Field::new("item", elements.data_type().clone(), true));
+        let typed_value: ArrayRef =
+            Arc::new(FixedSizeListArray::new(item_field, 2, elements, None));
+        let metadata: ArrayRef = Arc::new(BinaryViewArray::from_iter_values(std::iter::repeat_n(
+            EMPTY_VARIANT_METADATA_BYTES,
+            2,
+        )));
+        let value = new_null_array(&DataType::BinaryView, 2);
+        let fields = Fields::from(vec![
+            Field::new("metadata", DataType::BinaryView, false),
+            Field::new("value", DataType::BinaryView, true),
+            Field::new("typed_value", typed_value.data_type().clone(), true),
+        ]);
+        let source = StructArray::new(fields, vec![metadata, value, typed_value], None);
+        let field = Field::new("data", source.data_type().clone(), false);
+        let batch =
+            RecordBatch::try_new(Arc::new(Schema::new(vec![field])), vec![Arc::new(source)])
+                .unwrap();
+
+        let buffer = write_to_buffer(&batch);
+        let result = read_to_batch(Bytes::from(buffer));
+        let column = result.column_by_name("data").unwrap();
+        let variant = VariantArray::try_new(column).unwrap();
+        assert!(matches!(
+            variant.typed_value_column().unwrap().data_type(),
+            DataType::List(_)
+        ));
+
+        let unshredded = unshred_variant(&variant).unwrap();
+        assert!(unshredded.typed_value_column().is_none());
+        assert_eq!(unshredded.len(), 2);
     }
 
     /// Writes a variant to a parquet file and ensures the parquet logical type


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10616.

# Rationale for this change

The Variant shredding spec does not define `FixedSizeList` as a valid shredded `typed_value`. Keep writes strict by rejecting it in `shred_variant`, while normalizing legacy Arrow `FixedSizeList` metadata to `List` on read for backwards compatibility.

# What changes are included in this PR?

- Reject `DataType::FixedSizeList` when selecting a shredding type.
- Normalize `FixedSizeList` `typed_value` to `List` in `VariantArray::try_new`.
- Remove the FSL-specific path from `unshred_variant`.
- Add regression coverage for invalid shredding and persisted Parquet read/unshred.

# Are these changes tested?

- `cargo test -p parquet-variant-compute --lib`
- Persisted Parquet read/unshred regression for legacy FSL metadata.

# Are there any user-facing changes?

`shred_variant` rejects `FixedSizeList`; existing data with Arrow `FixedSizeList` metadata is read as a regular `List`.