### PR TITLE
Add value field accessors for list, fixedsizelist, listview, map & run arrays

### DIFF
--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -340,7 +340,7 @@ impl FixedSizeListArray {
     }
 
     /// The field that describes the values of this list.
-    pub fn field(&self) -> &FieldRef {
+    pub fn value_field(&self) -> &FieldRef {
         match &self.data_type {
             DataType::FixedSizeList(f, _) => f,
             _ => unreachable!(),

--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -339,6 +339,14 @@ impl FixedSizeListArray {
         (f, self.value_length, self.values, self.nulls)
     }
 
+    /// The field that describes the values of this list.
+    pub fn field(&self) -> &FieldRef {
+        match &self.data_type {
+            DataType::FixedSizeList(f, _) => f,
+            _ => unreachable!(),
+        }
+    }
+
     /// Returns a reference to the values of this list.
     pub fn values(&self) -> &ArrayRef {
         &self.values

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -322,6 +322,14 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
         (f, self.value_offsets, self.values, self.nulls)
     }
 
+    /// The field that describes the values of this list.
+    pub fn field(&self) -> &Arc<arrow_schema::Field> {
+        match &self.data_type {
+            DataType::List(f) | DataType::LargeList(f) => f,
+            _ => unreachable!(),
+        }
+    }
+
     /// Returns a reference to the offsets of this list
     ///
     /// Unlike [`Self::value_offsets`] this returns the [`OffsetBuffer`]

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -323,7 +323,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
     }
 
     /// The field that describes the values of this list.
-    pub fn field(&self) -> &FieldRef {
+    pub fn value_field(&self) -> &FieldRef {
         match &self.data_type {
             DataType::List(f) | DataType::LargeList(f) => f,
             _ => unreachable!(),

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -323,7 +323,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
     }
 
     /// The field that describes the values of this list.
-    pub fn field(&self) -> &Arc<arrow_schema::Field> {
+    pub fn field(&self) -> &FieldRef {
         match &self.data_type {
             DataType::List(f) | DataType::LargeList(f) => f,
             _ => unreachable!(),

--- a/arrow-array/src/array/list_view_array.rs
+++ b/arrow-array/src/array/list_view_array.rs
@@ -288,7 +288,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericListViewArray<OffsetSize> {
     }
 
     /// The field that describes the values of this list.
-    pub fn field(&self) -> &FieldRef {
+    pub fn value_field(&self) -> &FieldRef {
         match &self.data_type {
             DataType::ListView(f) | DataType::LargeListView(f) => f,
             _ => unreachable!(),

--- a/arrow-array/src/array/list_view_array.rs
+++ b/arrow-array/src/array/list_view_array.rs
@@ -287,6 +287,14 @@ impl<OffsetSize: OffsetSizeTrait> GenericListViewArray<OffsetSize> {
         )
     }
 
+    /// The field that describes the values of this list.
+    pub fn field(&self) -> &FieldRef {
+        match &self.data_type {
+            DataType::ListView(f) | DataType::LargeListView(f) => f,
+            _ => unreachable!(),
+        }
+    }
+
     /// Returns a reference to the offsets of this list
     ///
     /// Unlike [`Self::value_offsets`] this returns the [`ScalarBuffer`]

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -188,6 +188,25 @@ impl MapArray {
         (f, self.value_offsets, self.entries, self.nulls, ordered)
     }
 
+    /// The field that describes the entries of this map.
+    ///
+    /// The field's type is always a [`DataType::Struct`] of the key and value fields,
+    /// see [`Self::entries_fields`].
+    pub fn entries_field(&self) -> &FieldRef {
+        match &self.data_type {
+            DataType::Map(f, _) => f,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Are the entries of this map sorted by key?
+    pub fn ordered(&self) -> bool {
+        match &self.data_type {
+            DataType::Map(_, ordered) => *ordered,
+            _ => unreachable!(),
+        }
+    }
+
     /// Returns a reference to the offsets of this map
     ///
     /// Unlike [`Self::value_offsets`] this returns the [`OffsetBuffer`]

--- a/arrow-array/src/array/run_array.rs
+++ b/arrow-array/src/array/run_array.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use arrow_buffer::{ArrowNativeType, BooleanBufferBuilder, NullBuffer, RunEndBuffer, ScalarBuffer};
 use arrow_data::{ArrayData, ArrayDataBuilder};
-use arrow_schema::{ArrowError, DataType, Field};
+use arrow_schema::{ArrowError, DataType, Field, FieldRef};
 
 use crate::{
     Array, ArrayAccessor, ArrayRef, PrimitiveArray,
@@ -204,6 +204,22 @@ impl<R: RunEndIndexType> RunArray<R> {
     /// Deconstruct this array into its constituent parts
     pub fn into_parts(self) -> (DataType, RunEndBuffer<R::Native>, ArrayRef) {
         (self.data_type, self.run_ends, self.values)
+    }
+
+    /// The field that describes the run ends of this array.
+    pub fn run_ends_field(&self) -> &FieldRef {
+        match &self.data_type {
+            DataType::RunEndEncoded(f, _) => f,
+            _ => unreachable!(),
+        }
+    }
+
+    /// The field that describes the values of this array.
+    pub fn values_field(&self) -> &FieldRef {
+        match &self.data_type {
+            DataType::RunEndEncoded(_, f) => f,
+            _ => unreachable!(),
+        }
     }
 
     /// Returns a reference to the [`RunEndBuffer`].


### PR DESCRIPTION
# Which issue does this PR close?
None

# Rationale for this change
Given a `ListArray` I want to easily answer questions like "is the field nullable?" and "what is the underlying data type?". Now we can!

Same for other arrays (`FixedSizeListArray` etc)

# What changes are included in this PR?
- `ListArray::value_field()`
- `FixedSizeListArray::value_field()`
- `GenericListViewArray::value_field() (ListView + LargeListView)`
- `MapArray::entries_field(), MapArray::ordered()`
- `RunArray::run_ends_field(), RunArray::values_field()`

# Are these changes tested?
No

# Are there any user-facing changes?
Yes