### PR TITLE
feat(arrow-schema): add BigDecimal canonical extension type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "half",
  "hashbrown 0.17.1",
  "libc",
+ "num-bigint 0.5.1",
  "num-complex",
  "num-integer",
  "num-traits",

--- a/arrow-array/Cargo.toml
+++ b/arrow-array/Cargo.toml
@@ -59,6 +59,7 @@ chrono-tz = { version = "0.10", optional = true }
 futures = { version = "0.3", optional = true }
 num-complex = { version = "0.4.6", default-features = false, features = ["std"] }
 num-integer = { version = "0.1.46", default-features = false, features = ["std"] }
+num-bigint = { version = "0.5.0", default-features = false, features = ["std"], optional = true }
 num-traits = { version = "0.2.19", default-features = false, features = ["std"] }
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
 hashbrown = { version = "0.17.0", default-features = false }
@@ -68,6 +69,7 @@ all-features = true
 
 [features]
 async = ["dep:futures"]
+canonical_extension_types = ["arrow-schema/canonical_extension_types", "dep:num-bigint"]
 ffi = ["arrow-schema/ffi", "arrow-data/ffi", "dep:libc"]
 force_validate = []
 # Enable memory tracking support

--- a/arrow-array/src/big_decimal.rs
+++ b/arrow-array/src/big_decimal.rs
@@ -1,0 +1,829 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Array support for the canonical `arrow.big_decimal` extension type.
+//!
+//! Rust represents extension types as metadata on an Arrow [`Field`]. This
+//! module supplies the value codec and a typed wrapper over the physical
+//! [`BinaryViewArray`]. Use [`BigDecimal`] from `arrow_schema::extension` when
+//! constructing the corresponding field.
+//!
+//! [`BigDecimalArray`] is a validated logical view and deliberately does not
+//! implement [`Array`]. Record batches contain its [`BinaryViewArray`] storage,
+//! with the logical extension carried by [`Field`] metadata. Use
+//! [`BigDecimalArray::into_storage`] when writing and
+//! [`BigDecimalArray::try_from_array`] to recover the view after reading.
+//!
+//! [`Field`]: arrow_schema::Field
+
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+use arrow_buffer::i256;
+use arrow_schema::extension::BigDecimal;
+use arrow_schema::{ArrowError, Field};
+use num_bigint::{BigInt, BigUint};
+use num_integer::Integer;
+use num_traits::{Signed, ToPrimitive, Zero};
+
+use crate::builder::{ArrayBuilder, BinaryViewBuilder};
+use crate::types::{Decimal128Type, Decimal256Type, validate_decimal_precision_and_scale};
+use crate::{Array, BinaryViewArray, Decimal128Array, Decimal256Array};
+
+/// The number of header and scale bytes before a finite magnitude.
+pub const BIG_DECIMAL_PREFIX_LENGTH: usize = 3;
+
+/// Numeric categories encoded in the first byte of a BigDecimal value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum BigDecimalClass {
+    /// Negative signaling NaN.
+    NegativeSignalingNaN = 0x00,
+    /// Negative quiet NaN.
+    NegativeQuietNaN = 0x01,
+    /// Negative infinity.
+    NegativeInfinity = 0x02,
+    /// Negative finite number.
+    NegativeFinite = 0x03,
+    /// Positive finite number, including positive zero.
+    PositiveFinite = 0x04,
+    /// Positive infinity.
+    PositiveInfinity = 0x05,
+    /// Positive quiet NaN.
+    PositiveQuietNaN = 0x06,
+    /// Positive signaling NaN.
+    PositiveSignalingNaN = 0x07,
+}
+
+impl BigDecimalClass {
+    /// Returns true for either finite class.
+    pub fn is_finite(self) -> bool {
+        matches!(self, Self::NegativeFinite | Self::PositiveFinite)
+    }
+
+    /// Returns true for an infinity class.
+    pub fn is_infinite(self) -> bool {
+        matches!(self, Self::NegativeInfinity | Self::PositiveInfinity)
+    }
+
+    /// Returns true for any quiet or signaling NaN class.
+    pub fn is_nan(self) -> bool {
+        matches!(
+            self,
+            Self::NegativeSignalingNaN
+                | Self::NegativeQuietNaN
+                | Self::PositiveQuietNaN
+                | Self::PositiveSignalingNaN
+        )
+    }
+
+    /// Returns true for a negative class.
+    pub fn is_negative(self) -> bool {
+        matches!(
+            self,
+            Self::NegativeSignalingNaN
+                | Self::NegativeQuietNaN
+                | Self::NegativeInfinity
+                | Self::NegativeFinite
+        )
+    }
+}
+
+impl TryFrom<u8> for BigDecimalClass {
+    type Error = ArrowError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(Self::NegativeSignalingNaN),
+            0x01 => Ok(Self::NegativeQuietNaN),
+            0x02 => Ok(Self::NegativeInfinity),
+            0x03 => Ok(Self::NegativeFinite),
+            0x04 => Ok(Self::PositiveFinite),
+            0x05 => Ok(Self::PositiveInfinity),
+            0x06 => Ok(Self::PositiveQuietNaN),
+            0x07 => Ok(Self::PositiveSignalingNaN),
+            _ => Err(ArrowError::InvalidArgumentError(format!(
+                "Invalid BigDecimal class byte: 0x{value:02X}"
+            ))),
+        }
+    }
+}
+
+/// A decoded BigDecimal value.
+///
+/// Finite values represent `magnitude * 10^-scale`, with the sign carried by
+/// [`Self::class`]. This preserves distinct encodings of equal mathematical
+/// values, including negative zero and negative scales.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BigDecimalValue {
+    class: BigDecimalClass,
+    scale: i16,
+    magnitude: Vec<u8>,
+}
+
+impl BigDecimalValue {
+    /// Constructs a value from an unsigned little-endian magnitude and
+    /// validates class-specific invariants.
+    ///
+    /// Finite magnitudes must contain at least one byte and use their minimal
+    /// representation. Non-finite values must pass an empty magnitude.
+    pub fn try_new(
+        class: BigDecimalClass,
+        scale: i16,
+        magnitude: impl AsRef<[u8]>,
+    ) -> Result<Self, ArrowError> {
+        let magnitude = magnitude.as_ref();
+        if !class.is_finite() && (scale != 0 || !magnitude.is_empty()) {
+            return Err(ArrowError::InvalidArgumentError(
+                "Non-finite BigDecimal values must have scale zero and no magnitude".to_owned(),
+            ));
+        }
+        if class.is_finite() && magnitude.is_empty() {
+            return Err(ArrowError::InvalidArgumentError(
+                "Finite BigDecimal must have at least one magnitude byte".to_owned(),
+            ));
+        }
+        if class.is_finite() && magnitude.len() > 1 && magnitude.last() == Some(&0) {
+            return Err(ArrowError::InvalidArgumentError(
+                "BigDecimal magnitude must use the minimal little-endian encoding".to_owned(),
+            ));
+        }
+        Ok(Self {
+            class,
+            scale,
+            magnitude: magnitude.to_vec(),
+        })
+    }
+
+    /// Constructs a finite value from a minimal unsigned little-endian
+    /// magnitude. Zero is represented by `[0]`.
+    pub fn finite(
+        magnitude: impl AsRef<[u8]>,
+        scale: i16,
+        negative: bool,
+    ) -> Result<Self, ArrowError> {
+        let class = if negative {
+            BigDecimalClass::NegativeFinite
+        } else {
+            BigDecimalClass::PositiveFinite
+        };
+        Self::try_new(class, scale, magnitude)
+    }
+
+    /// Constructs a non-finite value.
+    pub fn non_finite(class: BigDecimalClass) -> Result<Self, ArrowError> {
+        if class.is_finite() {
+            return Err(ArrowError::InvalidArgumentError(
+                "Expected a non-finite BigDecimal class".to_owned(),
+            ));
+        }
+        Self::try_new(class, 0, [])
+    }
+
+    /// Returns the numeric class.
+    pub fn class(&self) -> BigDecimalClass {
+        self.class
+    }
+
+    /// Returns the row-level scale.
+    pub fn scale(&self) -> i16 {
+        self.scale
+    }
+
+    /// Returns the minimal unsigned little-endian magnitude, or `None` for a
+    /// non-finite value. Finite zero returns `[0]`.
+    pub fn magnitude_le_bytes(&self) -> Option<&[u8]> {
+        self.class.is_finite().then_some(&self.magnitude)
+    }
+
+    /// Encodes this value using layout version 1.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut encoded = Vec::with_capacity(BIG_DECIMAL_PREFIX_LENGTH + 16);
+        encoded.push(self.class as u8);
+        encoded.extend_from_slice(&self.scale.to_le_bytes());
+        if self.class.is_finite() {
+            encoded.extend_from_slice(&self.magnitude);
+        }
+        encoded
+    }
+
+    /// Decodes and validates a layout version 1 value.
+    pub fn decode(encoded: &[u8]) -> Result<Self, ArrowError> {
+        if encoded.len() < BIG_DECIMAL_PREFIX_LENGTH {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "BigDecimal value is shorter than {BIG_DECIMAL_PREFIX_LENGTH} bytes"
+            )));
+        }
+
+        let class = BigDecimalClass::try_from(encoded[0])?;
+        let scale = i16::from_le_bytes([encoded[1], encoded[2]]);
+        let magnitude = &encoded[BIG_DECIMAL_PREFIX_LENGTH..];
+
+        Self::try_new(class, scale, magnitude)
+    }
+}
+
+impl Display for BigDecimalValue {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        let literal = match self.class {
+            BigDecimalClass::NegativeSignalingNaN => return formatter.write_str("-sNaN"),
+            BigDecimalClass::NegativeQuietNaN => return formatter.write_str("-NaN"),
+            BigDecimalClass::NegativeInfinity => return formatter.write_str("-Infinity"),
+            BigDecimalClass::PositiveInfinity => return formatter.write_str("Infinity"),
+            BigDecimalClass::PositiveQuietNaN => return formatter.write_str("NaN"),
+            BigDecimalClass::PositiveSignalingNaN => return formatter.write_str("sNaN"),
+            BigDecimalClass::NegativeFinite | BigDecimalClass::PositiveFinite => {
+                BigUint::from_bytes_le(&self.magnitude).to_str_radix(10)
+            }
+        };
+
+        if self.class.is_negative() {
+            formatter.write_str("-")?;
+        }
+        if self.scale == 0 {
+            return formatter.write_str(&literal);
+        }
+        if self.scale < 0 {
+            return write!(formatter, "{literal}E{}", -i32::from(self.scale));
+        }
+
+        let scale = self.scale as usize;
+        if literal.len() > scale {
+            let split = literal.len() - scale;
+            write!(formatter, "{}.{}", &literal[..split], &literal[split..])
+        } else {
+            write!(
+                formatter,
+                "0.{}{literal}",
+                "0".repeat(scale - literal.len())
+            )
+        }
+    }
+}
+
+impl FromStr for BigDecimalValue {
+    type Err = ArrowError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let original = value;
+        let class = match value {
+            "-sNaN" => Some(BigDecimalClass::NegativeSignalingNaN),
+            "-NaN" => Some(BigDecimalClass::NegativeQuietNaN),
+            "-Infinity" => Some(BigDecimalClass::NegativeInfinity),
+            "Infinity" => Some(BigDecimalClass::PositiveInfinity),
+            "NaN" => Some(BigDecimalClass::PositiveQuietNaN),
+            "sNaN" => Some(BigDecimalClass::PositiveSignalingNaN),
+            _ => None,
+        };
+        if let Some(class) = class {
+            return Self::non_finite(class);
+        }
+
+        let (negative, value) = match value.strip_prefix('-') {
+            Some(value) => (true, value),
+            None => (false, value),
+        };
+        if value.is_empty() {
+            return Err(parse_error("BigDecimal has no digits"));
+        }
+
+        let exponent_index = value.bytes().position(|byte| matches!(byte, b'e' | b'E'));
+        let (mantissa, exponent) = match exponent_index {
+            Some(index) => {
+                let exponent = &value[index + 1..];
+                if exponent.is_empty() || exponent.bytes().any(|byte| matches!(byte, b'e' | b'E')) {
+                    return Err(parse_error("Invalid BigDecimal exponent"));
+                }
+                let exponent = exponent
+                    .parse::<i32>()
+                    .map_err(|_| parse_error("Invalid BigDecimal exponent"))?;
+                (&value[..index], exponent)
+            }
+            None => (value, 0),
+        };
+
+        let mut pieces = mantissa.split('.');
+        let integer = pieces.next().unwrap_or_default();
+        let fraction = pieces.next().unwrap_or_default();
+        if pieces.next().is_some() || (integer.is_empty() && fraction.is_empty()) {
+            return Err(parse_error("Invalid BigDecimal decimal point"));
+        }
+        if !integer.bytes().all(|byte| byte.is_ascii_digit())
+            || !fraction.bytes().all(|byte| byte.is_ascii_digit())
+        {
+            return Err(parse_error("BigDecimal contains a non-digit"));
+        }
+
+        let scale = i64::try_from(fraction.len()).unwrap_or(i64::MAX) - i64::from(exponent);
+        let scale = i16::try_from(scale)
+            .map_err(|_| parse_error("BigDecimal scale is outside the int16 range"))?;
+        let digits = format!("{integer}{fraction}");
+        let magnitude = BigUint::parse_bytes(digits.as_bytes(), 10)
+            .ok_or_else(|| parse_error("BigDecimal has no digits"))?;
+        let mut magnitude = magnitude.to_bytes_le();
+        if magnitude.is_empty() {
+            magnitude.push(0);
+        }
+        let value = Self::finite(magnitude, scale, negative)?;
+        if value.to_string() != original {
+            return Err(parse_error("BigDecimal string is not canonical"));
+        }
+        Ok(value)
+    }
+}
+
+fn parse_error(message: &str) -> ArrowError {
+    ArrowError::ParseError(message.to_owned())
+}
+
+/// A validated logical view over a physical [`BinaryViewArray`].
+///
+/// This type does not implement [`Array`]. In arrow-rs, an extension type is
+/// represented by [`Field`] metadata and the corresponding record-batch column
+/// remains its physical storage array. Use [`Self::storage`] or
+/// [`Self::into_storage`] when constructing a batch, and
+/// [`Self::try_from_array`] to recover this view from a batch column and field.
+#[derive(Debug, Clone)]
+pub struct BigDecimalArray {
+    storage: BinaryViewArray,
+    extension: BigDecimal,
+}
+
+impl BigDecimalArray {
+    /// Creates an array and validates every non-null encoded value.
+    pub fn try_new(storage: BinaryViewArray, extension: BigDecimal) -> Result<Self, ArrowError> {
+        let array = Self { storage, extension };
+        array.validate_full()?;
+        Ok(array)
+    }
+
+    /// Recovers a BigDecimal view from an arbitrary physical array and its
+    /// schema field.
+    ///
+    /// This validates the field's extension metadata, downcasts the physical
+    /// array to [`BinaryViewArray`], and validates every non-null value. The
+    /// cloned storage shares its underlying buffers with `array`.
+    pub fn try_from_array(array: &dyn Array, field: &Field) -> Result<Self, ArrowError> {
+        let extension = field.try_extension_type::<BigDecimal>()?;
+        let storage = array
+            .as_any()
+            .downcast_ref::<BinaryViewArray>()
+            .ok_or_else(|| {
+                ArrowError::InvalidArgumentError(format!(
+                    "BigDecimal storage array mismatch, expected BinaryViewArray, found {}",
+                    array.data_type()
+                ))
+            })?;
+        Self::try_new(storage.clone(), extension)
+    }
+
+    /// Returns the physical storage array.
+    pub fn storage(&self) -> &BinaryViewArray {
+        &self.storage
+    }
+
+    /// Consumes this wrapper and returns its physical storage.
+    pub fn into_storage(self) -> BinaryViewArray {
+        self.storage
+    }
+
+    /// Returns the extension type, including its metadata identity.
+    pub fn extension_type(&self) -> &BigDecimal {
+        &self.extension
+    }
+
+    /// Returns the number of rows.
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    /// Returns true if the array has no rows.
+    pub fn is_empty(&self) -> bool {
+        self.storage.is_empty()
+    }
+
+    /// Returns true if the row at `index` is null.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is outside this array.
+    pub fn is_null(&self, index: usize) -> bool {
+        self.storage.is_null(index)
+    }
+
+    /// Returns the encoded bytes at `index`, or `None` for a null row.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is outside this array.
+    pub fn encoded_value(&self, index: usize) -> Option<&[u8]> {
+        (!self.storage.is_null(index)).then(|| self.storage.value(index))
+    }
+
+    /// Decodes the value at `index`, or returns `None` for a null row.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is outside this array.
+    pub fn value(&self, index: usize) -> Result<Option<BigDecimalValue>, ArrowError> {
+        self.encoded_value(index)
+            .map(BigDecimalValue::decode)
+            .transpose()
+    }
+
+    /// Validates all encoded values.
+    ///
+    /// Informational extension metadata is not used to reject row values.
+    pub fn validate_full(&self) -> Result<(), ArrowError> {
+        for index in 0..self.storage.len() {
+            if let Some(encoded) = self.encoded_value(index) {
+                BigDecimalValue::decode(encoded).map_err(|error| {
+                    ArrowError::InvalidArgumentError(format!(
+                        "Invalid BigDecimal at row {index}: {error}"
+                    ))
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Converts every finite row exactly to a [`Decimal128Array`].
+    ///
+    /// This returns an error for a non-finite row, a rescaling operation that
+    /// would discard non-zero digits, or a value outside the requested
+    /// precision or Decimal128 integer range.
+    pub fn to_decimal128(&self, precision: u8, scale: i8) -> Result<Decimal128Array, ArrowError> {
+        validate_decimal_precision_and_scale::<Decimal128Type>(precision, scale)?;
+        let mut output = Vec::with_capacity(self.len());
+        for index in 0..self.len() {
+            let Some(value) = self.value(index)? else {
+                output.push(None);
+                continue;
+            };
+            let coefficient = rescale_exact(&value, scale, precision)
+                .map_err(|error| conversion_error(index, "Decimal128", error))?;
+            let coefficient = coefficient.to_i128().ok_or_else(|| {
+                conversion_error(
+                    index,
+                    "Decimal128",
+                    "coefficient is outside the signed 128-bit range",
+                )
+            })?;
+            output.push(Some(coefficient));
+        }
+        Decimal128Array::from(output).with_precision_and_scale(precision, scale)
+    }
+
+    /// Converts every finite row exactly to a [`Decimal256Array`].
+    ///
+    /// This returns an error for a non-finite row, a rescaling operation that
+    /// would discard non-zero digits, or a value outside the requested
+    /// precision or Decimal256 integer range.
+    pub fn to_decimal256(&self, precision: u8, scale: i8) -> Result<Decimal256Array, ArrowError> {
+        validate_decimal_precision_and_scale::<Decimal256Type>(precision, scale)?;
+        let mut output = Vec::with_capacity(self.len());
+        for index in 0..self.len() {
+            let Some(value) = self.value(index)? else {
+                output.push(None);
+                continue;
+            };
+            let coefficient = rescale_exact(&value, scale, precision)
+                .map_err(|error| conversion_error(index, "Decimal256", error))?;
+            let coefficient = coefficient.to_string().parse::<i256>().map_err(|_| {
+                conversion_error(
+                    index,
+                    "Decimal256",
+                    "coefficient is outside the signed 256-bit range",
+                )
+            })?;
+            output.push(Some(coefficient));
+        }
+        Decimal256Array::from(output).with_precision_and_scale(precision, scale)
+    }
+}
+
+fn rescale_exact(
+    value: &BigDecimalValue,
+    target_scale: i8,
+    precision: u8,
+) -> Result<BigInt, &'static str> {
+    if !value.class.is_finite() {
+        return Err("non-finite values cannot be represented by an Arrow decimal");
+    }
+
+    let mut coefficient = BigInt::from(BigUint::from_bytes_le(&value.magnitude));
+    if value.class.is_negative() {
+        coefficient = -coefficient;
+    }
+
+    let scale_delta = i32::from(target_scale) - i32::from(value.scale);
+    let factor = || BigInt::from(10_u8).pow(scale_delta.unsigned_abs());
+    if scale_delta > 0 {
+        coefficient *= factor();
+    } else if scale_delta < 0 {
+        let (quotient, remainder) = coefficient.div_rem(&factor());
+        if !remainder.is_zero() {
+            return Err("conversion would lose non-zero fractional digits");
+        }
+        coefficient = quotient;
+    }
+
+    let digits = coefficient.abs().to_str_radix(10).len();
+    if digits > usize::from(precision) {
+        return Err("coefficient exceeds the requested decimal precision");
+    }
+    Ok(coefficient)
+}
+
+fn conversion_error(index: usize, target: &str, message: &str) -> ArrowError {
+    ArrowError::InvalidArgumentError(format!(
+        "Cannot convert BigDecimal row {index} to {target}: {message}"
+    ))
+}
+
+/// Builder for a [`BigDecimalArray`].
+pub struct BigDecimalBuilder {
+    storage: BinaryViewBuilder,
+    extension: BigDecimal,
+}
+
+impl BigDecimalBuilder {
+    /// Creates an empty builder.
+    pub fn new(extension: BigDecimal) -> Self {
+        Self::with_capacity(extension, 1024)
+    }
+
+    /// Creates a builder with capacity for `capacity` rows.
+    pub fn with_capacity(extension: BigDecimal, capacity: usize) -> Self {
+        Self {
+            storage: BinaryViewBuilder::with_capacity(capacity),
+            extension,
+        }
+    }
+
+    /// Appends a decoded value after encoding it.
+    pub fn append_value(&mut self, value: &BigDecimalValue) -> Result<(), ArrowError> {
+        self.storage.try_append_value(value.encode())
+    }
+
+    /// Appends already encoded layout version 1 bytes after validation.
+    pub fn append_encoded(&mut self, encoded: &[u8]) -> Result<(), ArrowError> {
+        BigDecimalValue::decode(encoded)?;
+        self.storage.try_append_value(encoded)
+    }
+
+    /// Appends a null row.
+    pub fn append_null(&mut self) {
+        self.storage.append_null();
+    }
+
+    /// Returns the number of appended rows.
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
+
+    /// Returns true if no rows have been appended.
+    pub fn is_empty(&self) -> bool {
+        self.storage.is_empty()
+    }
+
+    /// Builds the array and resets this builder.
+    ///
+    /// Values are validated before they are appended, so this does not rescan
+    /// or decode the completed storage.
+    pub fn finish(&mut self) -> Result<BigDecimalArray, ArrowError> {
+        Ok(BigDecimalArray {
+            storage: self.storage.finish(),
+            extension: self.extension.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_schema::extension::BigDecimalMetadata;
+
+    use super::*;
+
+    fn finite(magnitude: u64, scale: i16, negative: bool) -> BigDecimalValue {
+        let mut magnitude = BigUint::from(magnitude).to_bytes_le();
+        if magnitude.is_empty() {
+            magnitude.push(0);
+        }
+        BigDecimalValue::finite(magnitude, scale, negative).unwrap()
+    }
+
+    #[test]
+    fn golden_encodings() {
+        let cases = [
+            (
+                BigDecimalValue::non_finite(BigDecimalClass::NegativeSignalingNaN).unwrap(),
+                vec![0x00, 0x00, 0x00],
+            ),
+            (
+                BigDecimalValue::non_finite(BigDecimalClass::NegativeQuietNaN).unwrap(),
+                vec![0x01, 0x00, 0x00],
+            ),
+            (
+                BigDecimalValue::non_finite(BigDecimalClass::NegativeInfinity).unwrap(),
+                vec![0x02, 0x00, 0x00],
+            ),
+            (finite(123, 0, true), vec![0x03, 0x00, 0x00, 0x7B]),
+            (finite(0, 0, false), vec![0x04, 0x00, 0x00, 0x00]),
+            (finite(123, 0, false), vec![0x04, 0x00, 0x00, 0x7B]),
+            (
+                finite(1_000_000, 0, false),
+                vec![0x04, 0x00, 0x00, 0x40, 0x42, 0x0F],
+            ),
+            (finite(1_234, 2, false), vec![0x04, 0x02, 0x00, 0xD2, 0x04]),
+            (finite(12, 4, false), vec![0x04, 0x04, 0x00, 0x0C]),
+            (finite(1_200, 0, false), vec![0x04, 0x00, 0x00, 0xB0, 0x04]),
+            (finite(12, -2, false), vec![0x04, 0xFE, 0xFF, 0x0C]),
+            (
+                BigDecimalValue::non_finite(BigDecimalClass::PositiveInfinity).unwrap(),
+                vec![0x05, 0x00, 0x00],
+            ),
+            (
+                BigDecimalValue::non_finite(BigDecimalClass::PositiveQuietNaN).unwrap(),
+                vec![0x06, 0x00, 0x00],
+            ),
+            (
+                BigDecimalValue::non_finite(BigDecimalClass::PositiveSignalingNaN).unwrap(),
+                vec![0x07, 0x00, 0x00],
+            ),
+        ];
+
+        for (value, encoded) in cases {
+            assert_eq!(value.encode(), encoded);
+            assert_eq!(BigDecimalValue::decode(&encoded).unwrap(), value);
+        }
+    }
+
+    #[test]
+    fn textual_round_trip_preserves_scale_and_sign() {
+        for literal in [
+            "-sNaN",
+            "-NaN",
+            "-Infinity",
+            "-123",
+            "-0",
+            "0",
+            "12.34",
+            "0.0012",
+            "12E2",
+            "Infinity",
+            "NaN",
+            "sNaN",
+        ] {
+            let value: BigDecimalValue = literal.parse().unwrap();
+            assert_eq!(value.to_string(), literal);
+        }
+    }
+
+    #[test]
+    fn rejects_non_canonical_text() {
+        for literal in [
+            "-qNaN",
+            "+qNaN",
+            "qNaN",
+            "-Inf",
+            "+Infinity",
+            "Inf",
+            "+Inf",
+            "+NaN",
+            "+sNaN",
+            "+1",
+            "01",
+            ".5",
+            "5.",
+            "1e2",
+            "1E+2",
+            "1E-2",
+        ] {
+            assert!(literal.parse::<BigDecimalValue>().is_err(), "{literal}");
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_encodings() {
+        for encoded in [
+            vec![],
+            vec![0x04, 0x00, 0x00],
+            vec![0x04, 0x00, 0x00, 0x01, 0x00],
+            vec![0x05, 0x01, 0x00],
+            vec![0x05, 0x00, 0x00, 0x00],
+            vec![0x08, 0x00, 0x00],
+        ] {
+            assert!(BigDecimalValue::decode(&encoded).is_err(), "{encoded:?}");
+        }
+    }
+
+    #[test]
+    fn builder_and_informational_metadata() {
+        let metadata =
+            BigDecimalMetadata::try_new(Some(4), Some(2), Some(false), Some(false)).unwrap();
+        let mut builder = BigDecimalBuilder::new(BigDecimal::new(metadata));
+
+        for value in [
+            finite(1_234, 2, false),
+            finite(12_345, 2, false),
+            finite(1, 3, false),
+            BigDecimalValue::non_finite(BigDecimalClass::PositiveInfinity).unwrap(),
+            BigDecimalValue::non_finite(BigDecimalClass::PositiveQuietNaN).unwrap(),
+        ] {
+            builder.append_value(&value).unwrap();
+        }
+        builder.append_null();
+
+        let array = builder.finish().unwrap();
+        assert_eq!(array.len(), 6);
+        assert_eq!(array.value(0).unwrap(), Some(finite(1_234, 2, false)));
+        assert!(array.value(5).unwrap().is_none());
+        array.validate_full().unwrap();
+    }
+
+    #[test]
+    fn metadata_does_not_override_equivalent_rows() {
+        let metadata = BigDecimalMetadata::try_new(Some(3), Some(1), None, None).unwrap();
+        let mut builder = BigDecimalBuilder::new(BigDecimal::new(metadata));
+
+        for literal in ["1200", "12E2", "5", "5.00"] {
+            builder
+                .append_value(&literal.parse::<BigDecimalValue>().unwrap())
+                .unwrap();
+        }
+        builder.finish().unwrap().validate_full().unwrap();
+    }
+
+    #[test]
+    fn array_rejects_invalid_storage() {
+        let storage = BinaryViewArray::from_iter_values([&[0x04, 0x00, 0x00][..]]);
+        assert!(BigDecimalArray::try_new(storage, BigDecimal::default()).is_err());
+    }
+
+    #[test]
+    fn exact_decimal128_conversion() {
+        let mut builder = BigDecimalBuilder::new(BigDecimal::default());
+        builder.append_value(&finite(1_234, 2, false)).unwrap();
+        builder.append_value(&finite(12, -2, false)).unwrap();
+        builder.append_value(&finite(7, 1, true)).unwrap();
+        builder.append_null();
+        let array = builder.finish().unwrap();
+
+        let converted = array.to_decimal128(8, 2).unwrap();
+        assert_eq!(converted.value(0), 1_234);
+        assert_eq!(converted.value(1), 120_000);
+        assert_eq!(converted.value(2), -70);
+        assert!(converted.is_null(3));
+    }
+
+    #[test]
+    fn exact_decimal256_conversion() {
+        let magnitude =
+            BigUint::parse_bytes(b"12345678901234567890123456789012345678901234567890", 10)
+                .unwrap()
+                .to_bytes_le();
+        let mut builder = BigDecimalBuilder::new(BigDecimal::default());
+        builder
+            .append_value(&BigDecimalValue::finite(magnitude, 0, false).unwrap())
+            .unwrap();
+        let array = builder.finish().unwrap();
+
+        let converted = array.to_decimal256(50, 0).unwrap();
+        assert_eq!(
+            converted.value(0).to_string(),
+            "12345678901234567890123456789012345678901234567890"
+        );
+    }
+
+    #[test]
+    fn decimal_conversion_rejects_loss_overflow_and_non_finite() {
+        let mut lossy = BigDecimalBuilder::new(BigDecimal::default());
+        lossy.append_value(&finite(12, 2, false)).unwrap();
+        assert!(lossy.finish().unwrap().to_decimal128(3, 1).is_err());
+
+        let mut overflow = BigDecimalBuilder::new(BigDecimal::default());
+        overflow.append_value(&finite(1_234, 0, false)).unwrap();
+        assert!(overflow.finish().unwrap().to_decimal128(3, 0).is_err());
+
+        let mut non_finite = BigDecimalBuilder::new(BigDecimal::default());
+        non_finite
+            .append_value(&BigDecimalValue::non_finite(BigDecimalClass::PositiveInfinity).unwrap())
+            .unwrap();
+        assert!(non_finite.finish().unwrap().to_decimal256(10, 0).is_err());
+    }
+}

--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -246,6 +246,8 @@ pub use numeric::*;
 mod scalar;
 pub use scalar::*;
 
+#[cfg(feature = "canonical_extension_types")]
+pub mod big_decimal;
 pub mod builder;
 pub mod cast;
 mod delta;

--- a/arrow-schema/src/extension/canonical/big_decimal.rs
+++ b/arrow-schema/src/extension/canonical/big_decimal.rs
@@ -1,0 +1,307 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Big decimal canonical extension type.
+
+use crate::{ArrowError, DataType, extension::ExtensionType};
+use serde_json::{Map, Number, Value};
+
+/// The only supported layout version for [`BigDecimal`].
+pub const BIG_DECIMAL_LAYOUT_VERSION: i8 = 1;
+
+/// Informational schema-level metadata for [`BigDecimal`].
+///
+/// Optional values are part of the extension type identity. They describe the
+/// source column and do not replace the precision and scale encoded per value.
+/// They are not used to accept or reject row values.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BigDecimalMetadata {
+    max_precision: Option<i32>,
+    max_scale: Option<i16>,
+    supports_infinity: Option<bool>,
+    supports_nan: Option<bool>,
+}
+
+impl BigDecimalMetadata {
+    /// Creates metadata after validating its constraints.
+    pub fn try_new(
+        max_precision: Option<i32>,
+        max_scale: Option<i16>,
+        supports_infinity: Option<bool>,
+        supports_nan: Option<bool>,
+    ) -> Result<Self, ArrowError> {
+        if max_precision.is_some_and(|v| v <= 0) {
+            return Err(ArrowError::InvalidArgumentError(
+                "BigDecimal max_precision must be greater than zero".to_owned(),
+            ));
+        }
+        Ok(Self {
+            max_precision,
+            max_scale,
+            supports_infinity,
+            supports_nan,
+        })
+    }
+
+    /// Returns the packed value layout version.
+    pub fn layout_version(&self) -> i8 {
+        BIG_DECIMAL_LAYOUT_VERSION
+    }
+
+    /// Returns the declared maximum significant decimal digits.
+    pub fn max_precision(&self) -> Option<i32> {
+        self.max_precision
+    }
+
+    /// Returns the declared maximum scale.
+    pub fn max_scale(&self) -> Option<i16> {
+        self.max_scale
+    }
+
+    /// Returns whether the source explicitly supports infinities.
+    pub fn supports_infinity(&self) -> Option<bool> {
+        self.supports_infinity
+    }
+
+    /// Returns whether the source explicitly supports NaNs.
+    pub fn supports_nan(&self) -> Option<bool> {
+        self.supports_nan
+    }
+}
+
+/// The canonical `arrow.big_decimal` extension type.
+///
+/// The storage type is [`DataType::BinaryView`]. Each non-null value contains
+/// a class byte, a little-endian signed 16-bit scale, and, for finite values,
+/// a minimal unsigned little-endian magnitude.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BigDecimal(BigDecimalMetadata);
+
+impl BigDecimal {
+    /// Creates an extension type with the provided metadata.
+    pub fn new(metadata: BigDecimalMetadata) -> Self {
+        Self(metadata)
+    }
+}
+
+impl ExtensionType for BigDecimal {
+    const NAME: &'static str = "arrow.big_decimal";
+
+    type Metadata = BigDecimalMetadata;
+
+    fn metadata(&self) -> &Self::Metadata {
+        &self.0
+    }
+
+    fn serialize_metadata(&self) -> Option<String> {
+        let metadata = self.metadata();
+        if metadata == &BigDecimalMetadata::default() {
+            return Some(String::new());
+        }
+
+        let mut object = Map::new();
+        if let Some(value) = metadata.max_precision {
+            object.insert(
+                "max_precision".to_owned(),
+                Value::Number(Number::from(value)),
+            );
+        }
+        if let Some(value) = metadata.max_scale {
+            object.insert("max_scale".to_owned(), Value::Number(Number::from(value)));
+        }
+        if let Some(value) = metadata.supports_infinity {
+            object.insert("supports_infinity".to_owned(), Value::Bool(value));
+        }
+        if let Some(value) = metadata.supports_nan {
+            object.insert("supports_nan".to_owned(), Value::Bool(value));
+        }
+        Some(Value::Object(object).to_string())
+    }
+
+    fn deserialize_metadata(metadata: Option<&str>) -> Result<Self::Metadata, ArrowError> {
+        let Some(metadata) = metadata else {
+            return Ok(BigDecimalMetadata::default());
+        };
+        let metadata = metadata.trim();
+        if metadata.is_empty() {
+            return Ok(BigDecimalMetadata::default());
+        }
+
+        let value: Value = serde_json::from_str(metadata).map_err(|error| {
+            ArrowError::InvalidArgumentError(format!(
+                "Invalid BigDecimal extension metadata: {error}"
+            ))
+        })?;
+        let object = value.as_object().ok_or_else(|| {
+            ArrowError::InvalidArgumentError(
+                "BigDecimal extension metadata must be a JSON object".to_owned(),
+            )
+        })?;
+
+        for key in object.keys() {
+            match key.as_str() {
+                "layout_version" | "max_precision" | "max_scale" | "supports_infinity"
+                | "supports_nan" => {}
+                _ => {
+                    return Err(ArrowError::InvalidArgumentError(format!(
+                        "Unknown BigDecimal extension metadata field: {key}"
+                    )));
+                }
+            }
+        }
+
+        if let Some(version) = optional_i64(object, "layout_version")?
+            && version != i64::from(BIG_DECIMAL_LAYOUT_VERSION)
+        {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "Unsupported BigDecimal layout_version: {version}"
+            )));
+        }
+
+        let max_precision = optional_i64(object, "max_precision")?
+            .map(|value| {
+                i32::try_from(value).map_err(|_| {
+                    ArrowError::InvalidArgumentError(
+                        "BigDecimal max_precision is outside the int32 range".to_owned(),
+                    )
+                })
+            })
+            .transpose()?;
+        let max_scale = optional_i64(object, "max_scale")?
+            .map(|value| {
+                i16::try_from(value).map_err(|_| {
+                    ArrowError::InvalidArgumentError(
+                        "BigDecimal max_scale is outside the int16 range".to_owned(),
+                    )
+                })
+            })
+            .transpose()?;
+        let supports_infinity = optional_bool(object, "supports_infinity")?;
+        let supports_nan = optional_bool(object, "supports_nan")?;
+
+        BigDecimalMetadata::try_new(max_precision, max_scale, supports_infinity, supports_nan)
+    }
+
+    fn supports_data_type(&self, data_type: &DataType) -> Result<(), ArrowError> {
+        match data_type {
+            DataType::BinaryView => Ok(()),
+            data_type => Err(ArrowError::InvalidArgumentError(format!(
+                "BigDecimal data type mismatch, expected BinaryView, found {data_type}"
+            ))),
+        }
+    }
+
+    fn try_new(data_type: &DataType, metadata: Self::Metadata) -> Result<Self, ArrowError> {
+        let value = Self(metadata);
+        value.supports_data_type(data_type)?;
+        Ok(value)
+    }
+
+    fn validate(data_type: &DataType, metadata: Self::Metadata) -> Result<(), ArrowError> {
+        Self(metadata).supports_data_type(data_type)
+    }
+}
+
+fn optional_i64(object: &Map<String, Value>, name: &str) -> Result<Option<i64>, ArrowError> {
+    object
+        .get(name)
+        .map(|value| {
+            value.as_i64().ok_or_else(|| {
+                ArrowError::InvalidArgumentError(format!("BigDecimal {name} must be an integer"))
+            })
+        })
+        .transpose()
+}
+
+fn optional_bool(object: &Map<String, Value>, name: &str) -> Result<Option<bool>, ArrowError> {
+    object
+        .get(name)
+        .map(|value| {
+            value.as_bool().ok_or_else(|| {
+                ArrowError::InvalidArgumentError(format!("BigDecimal {name} must be a boolean"))
+            })
+        })
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Field, extension::CanonicalExtensionType};
+
+    #[test]
+    fn metadata_round_trip_and_identity() {
+        let metadata =
+            BigDecimalMetadata::try_new(Some(38), Some(10), Some(true), Some(false)).unwrap();
+        let extension = BigDecimal::new(metadata.clone());
+        let serialized = extension.serialize_metadata().unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"max_precision":38,"max_scale":10,"supports_infinity":true,"supports_nan":false}"#
+        );
+        assert_eq!(
+            BigDecimal::deserialize_metadata(Some(&serialized)).unwrap(),
+            metadata
+        );
+
+        let mut field = Field::new("value", DataType::BinaryView, true);
+        field.try_with_extension_type(extension.clone()).unwrap();
+        assert_eq!(field.try_extension_type::<BigDecimal>().unwrap(), extension);
+        assert_eq!(
+            CanonicalExtensionType::try_from(&field).unwrap(),
+            CanonicalExtensionType::BigDecimal(extension)
+        );
+    }
+
+    #[test]
+    fn default_metadata_forms_are_equivalent() {
+        assert_eq!(
+            BigDecimal::deserialize_metadata(None).unwrap(),
+            BigDecimalMetadata::default()
+        );
+        assert_eq!(
+            BigDecimal::deserialize_metadata(Some("")).unwrap(),
+            BigDecimalMetadata::default()
+        );
+        assert_eq!(
+            BigDecimal::deserialize_metadata(Some("{}")).unwrap(),
+            BigDecimalMetadata::default()
+        );
+        assert_eq!(
+            BigDecimal::deserialize_metadata(Some(r#"{"layout_version":1}"#)).unwrap(),
+            BigDecimalMetadata::default()
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_metadata_or_storage() {
+        for metadata in [
+            r#"{"layout_version":2}"#,
+            r#"{"max_precision":0}"#,
+            r#"{"max_scale":32768}"#,
+            r#"{"supports_nan":1}"#,
+            r#"{"unknown":true}"#,
+        ] {
+            assert!(BigDecimal::deserialize_metadata(Some(metadata)).is_err());
+        }
+        assert!(
+            BigDecimal::default()
+                .supports_data_type(&DataType::Binary)
+                .is_err()
+        );
+    }
+}

--- a/arrow-schema/src/extension/canonical/mod.rs
+++ b/arrow-schema/src/extension/canonical/mod.rs
@@ -27,6 +27,8 @@
 
 mod bool8;
 pub use bool8::Bool8;
+mod big_decimal;
+pub use big_decimal::{BIG_DECIMAL_LAYOUT_VERSION, BigDecimal, BigDecimalMetadata};
 mod fixed_shape_tensor;
 pub use fixed_shape_tensor::{FixedShapeTensor, FixedShapeTensorMetadata};
 mod json;
@@ -50,6 +52,9 @@ use super::ExtensionType;
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum CanonicalExtensionType {
+    /// The extension type for `BigDecimal`.
+    BigDecimal(BigDecimal),
+
     /// The extension type for `FixedShapeTensor`.
     ///
     /// <https://arrow.apache.org/docs/format/CanonicalExtensions.html#fixed-shape-tensor>
@@ -104,6 +109,7 @@ impl TryFrom<&Field> for CanonicalExtensionType {
                 Uuid::NAME => value.try_extension_type::<Uuid>().map(Into::into),
                 Opaque::NAME => value.try_extension_type::<Opaque>().map(Into::into),
                 Bool8::NAME => value.try_extension_type::<Bool8>().map(Into::into),
+                BigDecimal::NAME => value.try_extension_type::<BigDecimal>().map(Into::into),
                 TimestampWithOffset::NAME => value
                     .try_extension_type::<TimestampWithOffset>()
                     .map(Into::into),
@@ -126,6 +132,12 @@ impl TryFrom<&Field> for CanonicalExtensionType {
 impl From<FixedShapeTensor> for CanonicalExtensionType {
     fn from(value: FixedShapeTensor) -> Self {
         CanonicalExtensionType::FixedShapeTensor(value)
+    }
+}
+
+impl From<BigDecimal> for CanonicalExtensionType {
+    fn from(value: BigDecimal) -> Self {
+        CanonicalExtensionType::BigDecimal(value)
     }
 }
 

--- a/arrow/Cargo.toml
+++ b/arrow/Cargo.toml
@@ -84,7 +84,10 @@ force_validate = ["arrow-array/force_validate", "arrow-data/force_validate"]
 # Enable ffi support
 ffi = ["arrow-schema/ffi", "arrow-data/ffi", "arrow-array/ffi"]
 chrono-tz = ["arrow-array/chrono-tz"]
-canonical_extension_types = ["arrow-schema/canonical_extension_types"]
+canonical_extension_types = [
+    "arrow-array/canonical_extension_types",
+    "arrow-schema/canonical_extension_types",
+]
 # Enable memory tracking support
 pool = ["arrow-array/pool"]
 

--- a/arrow/tests/big_decimal.rs
+++ b/arrow/tests/big_decimal.rs
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![cfg(all(feature = "canonical_extension_types", feature = "ipc"))]
+
+use std::io::Cursor;
+use std::sync::Arc;
+
+use arrow::array::big_decimal::{BigDecimalArray, BigDecimalBuilder, BigDecimalValue};
+use arrow::array::{ArrayRef, RecordBatch};
+use arrow::ipc::reader::StreamReader;
+use arrow::ipc::writer::StreamWriter;
+use arrow_schema::extension::{BigDecimal, BigDecimalMetadata};
+use arrow_schema::{DataType, Field, Schema};
+
+#[test]
+fn public_value_api_uses_magnitude_bytes() {
+    let value = BigDecimalValue::finite([0xD2, 0x04], 2, false).unwrap();
+    assert_eq!(value.magnitude_le_bytes(), Some(&[0xD2, 0x04][..]));
+    assert_eq!(value.to_string(), "12.34");
+
+    let non_finite = "NaN".parse::<BigDecimalValue>().unwrap();
+    assert_eq!(non_finite.magnitude_le_bytes(), None);
+}
+
+#[test]
+fn ipc_round_trip_preserves_extension_and_storage() {
+    let metadata =
+        BigDecimalMetadata::try_new(Some(100), Some(20), Some(true), Some(true)).unwrap();
+    let extension = BigDecimal::new(metadata);
+
+    let mut builder = BigDecimalBuilder::new(extension.clone());
+    builder
+        .append_value(&"12.34".parse::<BigDecimalValue>().unwrap())
+        .unwrap();
+    builder.append_null();
+    builder
+        .append_value(
+            &"1234567890123456789012345678901234567890"
+                .parse::<BigDecimalValue>()
+                .unwrap(),
+        )
+        .unwrap();
+    let array = builder.finish().unwrap();
+    let expected_storage = array.storage().clone();
+
+    let mut field = Field::new("amount", DataType::BinaryView, true);
+    field.try_with_extension_type(extension.clone()).unwrap();
+    let schema = Arc::new(Schema::new(vec![field]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(array.into_storage()) as ArrayRef],
+    )
+    .unwrap();
+
+    let mut buffer = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut buffer, &schema).unwrap();
+        writer.write(&batch).unwrap();
+        writer.finish().unwrap();
+    }
+
+    let mut reader = StreamReader::try_new(Cursor::new(buffer), None).unwrap();
+    let read_schema = reader.schema();
+    let read_batch = reader.next().unwrap().unwrap();
+    let decoded =
+        BigDecimalArray::try_from_array(read_batch.column(0).as_ref(), read_schema.field(0))
+            .unwrap();
+    assert_eq!(decoded.extension_type(), &extension);
+    assert_eq!(decoded.storage(), &expected_storage);
+    assert_eq!(decoded.value(0).unwrap().unwrap().to_string(), "12.34");
+    assert!(decoded.value(1).unwrap().is_none());
+    assert_eq!(
+        decoded.value(2).unwrap().unwrap().to_string(),
+        "1234567890123456789012345678901234567890"
+    );
+}


### PR DESCRIPTION
# Which issue does this PR close?

Implement `arrow.big_decimal` extension type.

# Rationale for this change

Be compatible with the [arrow.big_decimal canonical extension type specs](https://docs.google.com/document/d/10YNDPW9068RMsvAV_pjmC-uuerwWEwdhGqJARyVvnWI/edit?tab=t.0).

# What changes are included in this PR?

A new arrow.big_decimal extension type and test.

# Are these changes tested?

Yes.

# Are there any user-facing changes?

Yes, this is a new canonical extension type.
