### PR TITLE
Json decoder factory

### DIFF
--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -91,7 +91,9 @@
 pub mod reader;
 pub mod writer;
 
-pub use self::reader::{Reader, ReaderBuilder, Tape, TapeElement};
+pub use self::reader::{
+    ArrayDecoder, DecoderContext, DecoderFactory, Reader, ReaderBuilder, Tape, TapeElement,
+};
 pub use self::writer::{
     ArrayWriter, Encoder, EncoderFactory, EncoderOptions, LineDelimitedWriter, Writer,
     WriterBuilder,

--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -91,7 +91,7 @@
 pub mod reader;
 pub mod writer;
 
-pub use self::reader::{Reader, ReaderBuilder};
+pub use self::reader::{Reader, ReaderBuilder, Tape, TapeElement};
 pub use self::writer::{
     ArrayWriter, Encoder, EncoderFactory, EncoderOptions, LineDelimitedWriter, Writer,
     WriterBuilder,

--- a/arrow-json/src/reader/list_array.rs
+++ b/arrow-json/src/reader/list_array.rs
@@ -51,7 +51,7 @@ impl<O: OffsetSizeTrait, const IS_VIEW: bool> ListLikeArrayDecoder<O, IS_VIEW> {
             (true, DataType::LargeListView(f)) if O::IS_LARGE => f,
             _ => unreachable!(),
         };
-        let decoder = ctx.make_decoder(field.data_type(), field.is_nullable())?;
+        let decoder = ctx.make_decoder(field, field.is_nullable())?;
 
         Ok(Self {
             field: field.clone(),
@@ -148,7 +148,7 @@ impl FixedSizeListArrayDecoder {
             DataType::FixedSizeList(f, s) => (f, *s),
             _ => unreachable!(),
         };
-        let decoder = ctx.make_decoder(field.data_type(), field.is_nullable())?;
+        let decoder = ctx.make_decoder(field, field.is_nullable())?;
 
         Ok(Self {
             field: field.clone(),

--- a/arrow-json/src/reader/map_array.rs
+++ b/arrow-json/src/reader/map_array.rs
@@ -59,14 +59,8 @@ impl MapArrayDecoder {
             }
         };
 
-        let keys = ctx.make_decoder(
-            key_value_fields[0].data_type(),
-            key_value_fields[0].is_nullable(),
-        )?;
-        let values = ctx.make_decoder(
-            key_value_fields[1].data_type(),
-            key_value_fields[1].is_nullable(),
-        )?;
+        let keys = ctx.make_decoder(&key_value_fields[0], key_value_fields[0].is_nullable())?;
+        let values = ctx.make_decoder(&key_value_fields[1], key_value_fields[1].is_nullable())?;
 
         Ok(Self {
             entries_field,

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -773,10 +773,11 @@ pub trait ArrayDecoder: Send {
 /// ```
 /// use std::sync::Arc;
 /// use arrow_array::{Array, ArrayRef, BinaryArray};
+/// use arrow_array::types::Float64Type;
 /// use arrow_array::cast::AsArray;
 /// use arrow_json::reader::{ArrayDecoder, DecoderContext, DecoderFactory, Tape, TapeElement};
 /// use arrow_json::ReaderBuilder;
-/// use arrow_schema::{ArrowError, DataType, Field, FieldRef, Schema};
+/// use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields, Schema};
 ///
 /// /// Decodes `[104, 105]` into the bytes `b"hi"`
 /// struct IntArrayBinaryDecoder;
@@ -832,14 +833,16 @@ pub trait ArrayDecoder: Send {
 ///     }
 /// }
 ///
+/// let nested = Fields::from(vec![Field::new("inner", DataType::Binary, true)]);
 /// let schema = Arc::new(Schema::new(vec![
 ///     Field::new("bytes", DataType::Binary, true),
 ///     Field::new("float", DataType::Float64, true),
+///     Field::new("nested", DataType::Struct(nested), true),
 /// ]));
 ///
-/// let json = r#"{"bytes": [104, 105], "float": 1.0}
+/// let json = r#"{"bytes": [104, 105], "float": 1.0, "nested": {"inner": [104, 105]}}
 /// {"float": 2.3}
-/// {"bytes": [98]}
+/// {"bytes": [98], "nested": {"inner": [98]}}
 /// "#;
 ///
 /// let batch = ReaderBuilder::new(schema)
@@ -854,6 +857,12 @@ pub trait ArrayDecoder: Send {
 /// assert_eq!(bytes.value(0), b"hi");
 /// assert!(bytes.is_null(1));
 /// assert_eq!(bytes.value(2), b"b");
+///
+/// // The override applies wherever `Binary` appears, including nested, while types
+/// // the factory declines are decoded as usual
+/// let inner = batch.column(2).as_struct().column(0).as_binary::<i32>();
+/// assert_eq!(inner.value(0), b"hi");
+/// assert_eq!(batch.column(1).as_primitive::<Float64Type>().value(0), 1.0);
 /// ```
 ///
 /// [`EncoderFactory`]: crate::EncoderFactory
@@ -1112,7 +1121,6 @@ mod tests {
     use std::fs::File;
     use std::io::{BufReader, Cursor, Seek};
     use std::sync::Mutex;
-    use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
 
@@ -4069,7 +4077,7 @@ mod tests {
             assert_eq!(col.value(i), (i as i32) + 1);
         }
     }
-    /// Decodes a string as its byte length, an unmistakable signature
+    /// Decodes a string as its byte length
     struct StringLenDecoder;
 
     impl ArrayDecoder for StringLenDecoder {
@@ -4086,64 +4094,6 @@ mod tests {
             }
             Ok(Arc::new(builder.finish()))
         }
-    }
-
-    /// Overrides `Int32`, which would otherwise reject strings outright
-    #[derive(Debug)]
-    struct StringLenDecoderFactory;
-
-    impl DecoderFactory for StringLenDecoderFactory {
-        fn make_default_decoder(
-            &self,
-            _ctx: &DecoderContext,
-            field: &FieldRef,
-            _is_nullable: bool,
-        ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
-            match field.data_type() {
-                DataType::Int32 => Ok(Some(Box::new(StringLenDecoder))),
-                _ => Ok(None),
-            }
-        }
-    }
-
-    /// Consulted at every depth; declined types still use the default decoders.
-    #[test]
-    fn test_decoder_factory_overrides_at_every_depth() {
-        let inner = Fields::from(vec![
-            Field::new("overridden", DataType::Int32, true),
-            Field::new("untouched", DataType::Utf8, true),
-        ]);
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::Int32, true),
-            Field::new("s", DataType::Struct(inner), true),
-            Field::new_list("l", Field::new("item", DataType::Int32, true), true),
-        ]));
-
-        let buf = r#"{"a": "hello", "s": {"overridden": "abcd", "untouched": "kept"}, "l": ["xyz", "z"]}
-        {"a": null, "s": null, "l": []}
-        "#;
-
-        let batch = ReaderBuilder::new(schema)
-            .with_decoder_factory(Arc::new(StringLenDecoderFactory))
-            .build(Cursor::new(buf.as_bytes()))
-            .unwrap()
-            .next()
-            .unwrap()
-            .unwrap();
-
-        // Top level, including a null row
-        let a = batch.column(0).as_primitive::<Int32Type>();
-        assert_eq!(a.value(0), 5);
-        assert!(a.is_null(1));
-
-        // Inside a struct; its sibling decoded normally
-        let s = batch.column(1).as_struct();
-        assert_eq!(s.column(0).as_primitive::<Int32Type>().value(0), 4);
-        assert_eq!(s.column(1).as_string::<i32>().value(0), "kept");
-
-        // Inside a list, reached via the default list decoder
-        let values = batch.column(2).as_list::<i32>().values();
-        assert_eq!(values.as_primitive::<Int32Type>().values(), &[3, 1]);
     }
 
     /// Declining everything must be indistinguishable from no factory at all.
@@ -4220,25 +4170,23 @@ mod tests {
     /// *same* field, which would otherwise loop.
     #[test]
     fn test_decoder_factory_can_delegate_to_builtin_for_same_field() {
-        /// Delegates to the built-in decoder, recording that it did so
-        struct Delegating {
-            inner: Box<dyn ArrayDecoder>,
-            called: Arc<AtomicBool>,
-        }
+        /// Upper-cases whatever the built-in decoder produced
+        struct Upper(Box<dyn ArrayDecoder>);
 
-        impl ArrayDecoder for Delegating {
+        impl ArrayDecoder for Upper {
             fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError> {
-                self.called.store(true, Ordering::SeqCst);
-                self.inner.decode(tape, pos)
+                let inner = self.0.decode(tape, pos)?;
+                let values = inner.as_string::<i32>();
+                Ok(Arc::new(StringArray::from_iter(
+                    values.iter().map(|v| v.map(str::to_uppercase)),
+                )))
             }
         }
 
         #[derive(Debug)]
-        struct BuiltinDelegatingFactory {
-            called: Arc<AtomicBool>,
-        }
+        struct UpperFactory;
 
-        impl DecoderFactory for BuiltinDelegatingFactory {
+        impl DecoderFactory for UpperFactory {
             fn make_default_decoder(
                 &self,
                 ctx: &DecoderContext,
@@ -4247,30 +4195,25 @@ mod tests {
             ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
                 match field.data_type() {
                     // The SAME field -- via `make_decoder` this would loop forever
-                    DataType::Utf8 => Ok(Some(Box::new(Delegating {
-                        inner: ctx.make_builtin_decoder(field, is_nullable)?,
-                        called: Arc::clone(&self.called),
-                    }))),
+                    DataType::Utf8 => Ok(Some(Box::new(Upper(
+                        ctx.make_builtin_decoder(field, is_nullable)?,
+                    )))),
                     _ => Ok(None),
                 }
             }
         }
 
-        let called = Arc::new(AtomicBool::new(false));
         let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, true)]));
         let batch = ReaderBuilder::new(schema)
-            .with_decoder_factory(Arc::new(BuiltinDelegatingFactory {
-                called: Arc::clone(&called),
-            }))
+            .with_decoder_factory(Arc::new(UpperFactory))
             .build(Cursor::new(br#"{"s": "hello"}"#.as_slice()))
             .unwrap()
             .next()
             .unwrap()
             .unwrap();
 
-        // The wrapper ran, and the built-in did the work
-        assert!(called.load(Ordering::SeqCst), "custom decoder was not used");
-        assert_eq!(batch.column(0).as_string::<i32>().value(0), "hello");
+        // Upper-cased, so this decoder ran; "hello" at all, so the built-in did the work
+        assert_eq!(batch.column(0).as_string::<i32>().value(0), "HELLO");
     }
 
     /// Why the factory receives a `FieldRef`: selection can key off field metadata.

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -198,7 +198,6 @@ pub struct ReaderBuilder {
     struct_mode: StructMode,
     flatten_top_level_arrays: bool,
     decoder_factory: Option<Arc<dyn DecoderFactory>>,
-
     schema: SchemaRef,
 }
 

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -161,10 +161,14 @@ use crate::reader::run_end_array::RunEndEncodedArrayDecoder;
 use crate::reader::string_array::StringArrayDecoder;
 use crate::reader::string_view_array::StringViewArrayDecoder;
 use crate::reader::struct_array::StructArrayDecoder;
-use crate::reader::tape::{Tape, TapeDecoder, TapeDecoderOptions};
+use crate::reader::tape::{TapeDecoder, TapeDecoderOptions};
 use crate::reader::timestamp_array::TimestampArrayDecoder;
 
 pub use schema::*;
+// Note: `mod tape` is deliberately kept private. Exposing only these two types means
+// downstream code can read a `Tape` handed to it, but cannot construct one, keeping
+// `TapeDecoder` an implementation detail.
+pub use tape::{Tape, TapeElement};
 pub use value_iter::ValueIter;
 
 mod binary_array;

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -755,7 +755,8 @@ pub trait ArrayDecoder: Send {
     /// Decode elements from `tape` starting at the indexes contained in `pos`
     ///
     /// `pos` contains one tape index per output row, so the returned array must have
-    /// exactly `pos.len()` elements. A row's value may be [`TapeElement::Null`].
+    /// exactly `pos.len()` elements and the field's data type. A row's value may be
+    /// [`TapeElement::Null`].
     fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError>;
 }
 
@@ -869,8 +870,9 @@ pub trait DecoderFactory: std::fmt::Debug + Send + Sync {
     /// for this field. Calling `make_decoder` with the field this was invoked with
     /// recurses back here and loops.
     ///
-    /// `is_nullable` folds in ancestor nullability, so it may be `true` even when
-    /// `field.is_nullable()` is not.
+    /// `is_nullable` folds in ancestor nullability, so it may differ from
+    /// `field.is_nullable()` in either direction: a nullable struct widens its
+    /// children, while a run-end encoded array narrows its values.
     ///
     /// [extension types]: https://arrow.apache.org/docs/format/Columnar.html#extension-types
     fn make_default_decoder(
@@ -880,6 +882,34 @@ pub trait DecoderFactory: std::fmt::Debug + Send + Sync {
         _is_nullable: bool,
     ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
         Ok(None)
+    }
+}
+
+/// Validates the output of a [`DecoderFactory`] decoder before it reaches the arrays
+/// built from it, some of which are constructed without further checks.
+struct CheckedDecoder {
+    inner: Box<dyn ArrayDecoder>,
+    data_type: DataType,
+}
+
+impl ArrayDecoder for CheckedDecoder {
+    fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError> {
+        let array = self.inner.decode(tape, pos)?;
+        if array.data_type() != &self.data_type {
+            return Err(ArrowError::JsonError(format!(
+                "custom decoder returned {} for a field of type {}",
+                array.data_type(),
+                self.data_type
+            )));
+        }
+        if array.len() != pos.len() {
+            return Err(ArrowError::JsonError(format!(
+                "custom decoder returned {} values for {} rows",
+                array.len(),
+                pos.len()
+            )));
+        }
+        Ok(array)
     }
 }
 
@@ -960,7 +990,10 @@ fn make_decoder(
     if let Some(factory) = ctx.decoder_factory()
         && let Some(decoder) = factory.make_default_decoder(ctx, field, is_nullable)?
     {
-        return Ok(decoder);
+        return Ok(Box::new(CheckedDecoder {
+            inner: decoder,
+            data_type: field.data_type().clone(),
+        }));
     }
 
     make_builtin_decoder(ctx, field, is_nullable)
@@ -4073,42 +4106,21 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_decoder_factory_overrides_primitive() {
-        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
-        let buf = r#"{"a": "hello"}
-        {"a": null}
-        {"a": "hi"}
-        "#;
-
-        let batch = ReaderBuilder::new(schema)
-            .with_decoder_factory(Arc::new(StringLenDecoderFactory))
-            .build(Cursor::new(buf.as_bytes()))
-            .unwrap()
-            .next()
-            .unwrap()
-            .unwrap();
-
-        let col = batch.column(0).as_primitive::<Int32Type>();
-        assert_eq!(col.len(), 3);
-        assert_eq!(col.value(0), 5);
-        assert!(col.is_null(1));
-        assert_eq!(col.value(2), 2);
-    }
-
     /// Consulted at every depth; declined types still use the default decoders.
     #[test]
-    fn test_decoder_factory_overrides_nested_and_delegates_siblings() {
+    fn test_decoder_factory_overrides_at_every_depth() {
         let inner = Fields::from(vec![
             Field::new("overridden", DataType::Int32, true),
             Field::new("untouched", DataType::Utf8, true),
         ]);
         let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
             Field::new("s", DataType::Struct(inner), true),
             Field::new_list("l", Field::new("item", DataType::Int32, true), true),
         ]));
 
-        let buf = r#"{"s": {"overridden": "abcd", "untouched": "kept"}, "l": ["xyz", "z"]}
+        let buf = r#"{"a": "hello", "s": {"overridden": "abcd", "untouched": "kept"}, "l": ["xyz", "z"]}
+        {"a": null, "s": null, "l": []}
         "#;
 
         let batch = ReaderBuilder::new(schema)
@@ -4119,15 +4131,19 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        // Overridden inside a struct; its sibling decoded normally
-        let s = batch.column(0).as_struct();
+        // Top level, including a null row
+        let a = batch.column(0).as_primitive::<Int32Type>();
+        assert_eq!(a.value(0), 5);
+        assert!(a.is_null(1));
+
+        // Inside a struct; its sibling decoded normally
+        let s = batch.column(1).as_struct();
         assert_eq!(s.column(0).as_primitive::<Int32Type>().value(0), 4);
         assert_eq!(s.column(1).as_string::<i32>().value(0), "kept");
 
-        // Reached via the default list decoder's `make_decoder` call
-        let l = batch.column(1).as_list::<i32>();
-        let values = l.values().as_primitive::<Int32Type>();
-        assert_eq!(values.values(), &[3, 1]);
+        // Inside a list, reached via the default list decoder
+        let values = batch.column(2).as_list::<i32>().values();
+        assert_eq!(values.as_primitive::<Int32Type>().values(), &[3, 1]);
     }
 
     /// Declining everything must be indistinguishable from no factory at all.
@@ -4303,45 +4319,64 @@ mod tests {
         assert_eq!(batch.column(1).as_primitive::<Int32Type>().value(0), 7);
     }
 
-    /// A factory may delegate via `make_decoder` for a *different* field.
+    /// A custom decoder's output is not trusted: the arrays built from it are
+    /// constructed without further validation, so a mismatch must be caught here.
     #[test]
-    fn test_decoder_factory_can_delegate_to_default() {
-        /// Overrides `Utf8`, handing the work to the `Utf8View` decoder
-        #[derive(Debug)]
-        struct DelegatingFactory;
+    fn test_decoder_factory_output_is_validated() {
+        /// Returns either the wrong data type or the wrong number of rows
+        struct Bad {
+            wrong_type: bool,
+        }
 
-        impl DecoderFactory for DelegatingFactory {
+        impl ArrayDecoder for Bad {
+            fn decode(&mut self, _tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError> {
+                Ok(match self.wrong_type {
+                    true => Arc::new(StringViewArray::from(vec!["x"; pos.len()])) as ArrayRef,
+                    false => Arc::new(StringArray::from(Vec::<&str>::new())),
+                })
+            }
+        }
+
+        #[derive(Debug)]
+        struct BadFactory {
+            wrong_type: bool,
+        }
+
+        impl DecoderFactory for BadFactory {
             fn make_default_decoder(
                 &self,
-                ctx: &DecoderContext,
+                _ctx: &DecoderContext,
                 field: &FieldRef,
-                is_nullable: bool,
+                _is_nullable: bool,
             ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
                 match field.data_type() {
-                    // A *different* type, so this doesn't recurse back here
-                    DataType::Utf8 => {
-                        let view =
-                            Arc::new(field.as_ref().clone().with_data_type(DataType::Utf8View));
-                        Ok(Some(ctx.make_decoder(&view, is_nullable)?))
-                    }
+                    DataType::Utf8 => Ok(Some(Box::new(Bad {
+                        wrong_type: self.wrong_type,
+                    }))),
                     _ => Ok(None),
                 }
             }
         }
 
-        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
-        let buf = r#"{"a": "hello"}
-        "#;
+        let read = |wrong_type: bool| {
+            let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, true)]));
+            ReaderBuilder::new(schema)
+                .with_decoder_factory(Arc::new(BadFactory { wrong_type }))
+                .build(Cursor::new(br#"{"s": "hello"}"#.as_slice()))
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap_err()
+                .to_string()
+        };
 
-        let batch = ReaderBuilder::new(schema)
-            .with_decoder_factory(Arc::new(DelegatingFactory))
-            .build(Cursor::new(buf.as_bytes()))
-            .unwrap()
-            .next()
-            .unwrap()
-            .unwrap();
+        let err = read(true);
+        assert!(
+            err.contains("returned Utf8View for a field of type Utf8"),
+            "{err}"
+        );
 
-        // The `Utf8View` decoder ran in place of the `Utf8` one
-        assert_eq!(batch.column(0).as_string_view().value(0), "hello");
+        let err = read(false);
+        assert!(err.contains("returned 0 values for 1 rows"), "{err}");
     }
 }

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -165,9 +165,8 @@ use crate::reader::tape::{TapeDecoder, TapeDecoderOptions};
 use crate::reader::timestamp_array::TimestampArrayDecoder;
 
 pub use schema::*;
-// Note: `mod tape` is deliberately kept private. Exposing only these two types means
-// downstream code can read a `Tape` handed to it, but cannot construct one, keeping
-// `TapeDecoder` an implementation detail.
+// `mod tape` stays private: exposing only these two types means downstream can read a
+// `Tape` but not construct one, keeping `TapeDecoder` an implementation detail.
 pub use tape::{Tape, TapeElement};
 pub use value_iter::ValueIter;
 
@@ -198,6 +197,7 @@ pub struct ReaderBuilder {
     is_field: bool,
     struct_mode: StructMode,
     flatten_top_level_arrays: bool,
+    decoder_factory: Option<Arc<dyn DecoderFactory>>,
 
     schema: SchemaRef,
 }
@@ -220,6 +220,7 @@ impl ReaderBuilder {
             is_field: false,
             struct_mode: Default::default(),
             flatten_top_level_arrays: false,
+            decoder_factory: None,
             schema,
         }
     }
@@ -263,6 +264,7 @@ impl ReaderBuilder {
             is_field: true,
             struct_mode: Default::default(),
             flatten_top_level_arrays: false,
+            decoder_factory: None,
             schema: Arc::new(Schema::new([field.into()])),
         }
     }
@@ -345,6 +347,16 @@ impl ReaderBuilder {
         }
     }
 
+    /// Set an optional hook for customizing decoding behavior.
+    ///
+    /// See [`DecoderFactory`] for details and an example.
+    pub fn with_decoder_factory(self, decoder_factory: Arc<dyn DecoderFactory>) -> Self {
+        Self {
+            decoder_factory: Some(decoder_factory),
+            ..self
+        }
+    }
+
     /// Create a [`Reader`] with the provided [`BufRead`]
     pub fn build<R: BufRead>(self, reader: R) -> Result<Reader<R>, ArrowError> {
         Ok(Reader {
@@ -369,6 +381,7 @@ impl ReaderBuilder {
             strict_mode: self.strict_mode,
             struct_mode: self.struct_mode,
             ignore_type_conflicts: self.ignore_type_conflicts,
+            decoder_factory: self.decoder_factory,
         };
         let decoder = ctx.make_decoder(data_type.as_ref(), nullable)?;
 
@@ -739,9 +752,131 @@ impl Decoder {
     }
 }
 
-trait ArrayDecoder: Send {
+/// Decodes a column of JSON values from a [`Tape`] into an [`ArrayRef`]
+///
+/// Implement this together with [`DecoderFactory`] to override how a type is
+/// decoded, or to add support for a type the reader does not handle.
+pub trait ArrayDecoder: Send {
     /// Decode elements from `tape` starting at the indexes contained in `pos`
+    ///
+    /// `pos` contains one tape index per output row, so the returned array must have
+    /// exactly `pos.len()` elements. A row's value may be [`TapeElement::Null`].
     fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError>;
+}
+
+/// A trait to create custom decoders for specific data types.
+///
+/// Overrides the default decoder for a data type, or adds support for one the reader
+/// does not handle. The reader-side counterpart of [`EncoderFactory`]; register an
+/// implementation with [`ReaderBuilder::with_decoder_factory`].
+///
+/// # Examples
+///
+/// Decodes `Binary` from a JSON array of integers rather than the default hex string,
+/// the inverse of the [`EncoderFactory`] example.
+///
+/// ```
+/// use std::sync::Arc;
+/// use arrow_array::{Array, ArrayRef, BinaryArray};
+/// use arrow_array::cast::AsArray;
+/// use arrow_json::reader::{ArrayDecoder, DecoderContext, DecoderFactory, Tape, TapeElement};
+/// use arrow_json::ReaderBuilder;
+/// use arrow_schema::{ArrowError, DataType, Field, Schema};
+///
+/// /// Decodes `[104, 105]` into the bytes `b"hi"`
+/// struct IntArrayBinaryDecoder;
+///
+/// impl ArrayDecoder for IntArrayBinaryDecoder {
+///     fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError> {
+///         let mut values: Vec<Option<Vec<u8>>> = Vec::with_capacity(pos.len());
+///         for p in pos {
+///             match tape.get(*p) {
+///                 TapeElement::Null => values.push(None),
+///                 TapeElement::StartList(end) => {
+///                     let mut bytes = Vec::new();
+///                     let mut cur = p + 1;
+///                     while cur < end {
+///                         match tape.get(cur) {
+///                             // JSON text yields `Number`; serde yields `I32`
+///                             TapeElement::Number(idx) => {
+///                                 let s = tape.get_string(idx);
+///                                 bytes.push(s.parse::<u8>().map_err(|e| {
+///                                     ArrowError::JsonError(format!("invalid byte {s}: {e}"))
+///                                 })?);
+///                             }
+///                             TapeElement::I32(v) => bytes.push(v as u8),
+///                             _ => return Err(tape.error(cur, "byte")),
+///                         }
+///                         cur = tape.next(cur, "byte")?;
+///                     }
+///                     values.push(Some(bytes));
+///                 }
+///                 _ => return Err(tape.error(*p, "list of bytes")),
+///             }
+///         }
+///         Ok(Arc::new(BinaryArray::from_iter(values.iter().map(|v| v.as_deref()))))
+///     }
+/// }
+///
+/// #[derive(Debug)]
+/// struct IntArrayBinaryDecoderFactory;
+///
+/// impl DecoderFactory for IntArrayBinaryDecoderFactory {
+///     fn make_custom_decoder(
+///         &self,
+///         _ctx: &DecoderContext,
+///         data_type: &DataType,
+///         _is_nullable: bool,
+///     ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
+///         match data_type {
+///             DataType::Binary => Ok(Some(Box::new(IntArrayBinaryDecoder))),
+///             // Returning `None` uses the reader's default decoder
+///             _ => Ok(None),
+///         }
+///     }
+/// }
+///
+/// let schema = Arc::new(Schema::new(vec![
+///     Field::new("bytes", DataType::Binary, true),
+///     Field::new("float", DataType::Float64, true),
+/// ]));
+///
+/// let json = r#"{"bytes": [104, 105], "float": 1.0}
+/// {"float": 2.3}
+/// {"bytes": [98]}
+/// "#;
+///
+/// let batch = ReaderBuilder::new(schema)
+///     .with_decoder_factory(Arc::new(IntArrayBinaryDecoderFactory))
+///     .build(json.as_bytes())
+///     .unwrap()
+///     .next()
+///     .unwrap()
+///     .unwrap();
+///
+/// let bytes = batch.column(0).as_binary::<i32>();
+/// assert_eq!(bytes.value(0), b"hi");
+/// assert!(bytes.is_null(1));
+/// assert_eq!(bytes.value(2), b"b");
+/// ```
+///
+/// [`EncoderFactory`]: crate::EncoderFactory
+pub trait DecoderFactory: std::fmt::Debug + Send + Sync {
+    /// Make a decoder for `data_type`, or `Ok(None)` to use the reader's default.
+    ///
+    /// Use [`DecoderContext::make_decoder`] on `ctx` to build child decoders. Calling
+    /// it for the `data_type` this was invoked with recurses back here and loops.
+    ///
+    /// `is_nullable` folds in ancestor nullability, so it may be `true` even where the
+    /// corresponding field is not.
+    fn make_custom_decoder(
+        &self,
+        _ctx: &DecoderContext,
+        _data_type: &DataType,
+        _is_nullable: bool,
+    ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
+        Ok(None)
+    }
 }
 
 /// Context for decoder creation, containing configuration.
@@ -757,6 +892,8 @@ pub struct DecoderContext {
     struct_mode: StructMode,
     /// Whether to treat columns with incompatible types as missing (i.e. NULL)
     ignore_type_conflicts: bool,
+    /// An optional hook for customizing decoding behavior
+    decoder_factory: Option<Arc<dyn DecoderFactory>>,
 }
 
 impl DecoderContext {
@@ -780,11 +917,18 @@ impl DecoderContext {
         self.ignore_type_conflicts
     }
 
+    /// Returns the optional hook for customizing decoding behavior
+    pub fn decoder_factory(&self) -> Option<&Arc<dyn DecoderFactory>> {
+        self.decoder_factory.as_ref()
+    }
+
     /// Create a decoder for a type.
     ///
-    /// This is the standard way to create child decoders from within a decoder
-    /// implementation.
-    fn make_decoder(
+    /// The standard way to create child decoders from within a decoder, and how a
+    /// [`DecoderFactory`] delegates to the decoder the reader would otherwise use.
+    /// The factory is consulted first, so calling this for the same data type the
+    /// factory was asked about will loop.
+    pub fn make_decoder(
         &self,
         data_type: &DataType,
         is_nullable: bool,
@@ -814,6 +958,12 @@ fn make_decoder(
         ($t:ty, $p:expr, $s:expr) => {
             Ok(Box::new(DecimalArrayDecoder::<$t>::new(ctx, $p, $s)))
         };
+    }
+
+    if let Some(factory) = ctx.decoder_factory()
+        && let Some(decoder) = factory.make_custom_decoder(ctx, data_type, is_nullable)?
+    {
+        return Ok(decoder);
     }
 
     downcast_integer! {
@@ -902,6 +1052,7 @@ mod tests {
     use serde_json::json;
     use std::fs::File;
     use std::io::{BufReader, Cursor, Seek};
+    use std::sync::Mutex;
 
     use super::*;
 
@@ -3857,5 +4008,189 @@ mod tests {
         for i in 0..6 {
             assert_eq!(col.value(i), (i as i32) + 1);
         }
+    }
+    /// Decodes any string as its byte length, giving an unmistakable signature
+    struct StringLenDecoder;
+
+    impl ArrayDecoder for StringLenDecoder {
+        fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError> {
+            let mut builder = Int32Array::builder(pos.len());
+            for p in pos {
+                match tape.get(*p) {
+                    TapeElement::String(idx) => {
+                        builder.append_value(tape.get_string(idx).len() as i32)
+                    }
+                    TapeElement::Null => builder.append_null(),
+                    _ => return Err(tape.error(*p, "string")),
+                }
+            }
+            Ok(Arc::new(builder.finish()))
+        }
+    }
+
+    /// Overrides `Int32`, which would otherwise reject strings outright
+    #[derive(Debug)]
+    struct StringLenDecoderFactory;
+
+    impl DecoderFactory for StringLenDecoderFactory {
+        fn make_custom_decoder(
+            &self,
+            _ctx: &DecoderContext,
+            data_type: &DataType,
+            _is_nullable: bool,
+        ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
+            match data_type {
+                DataType::Int32 => Ok(Some(Box::new(StringLenDecoder))),
+                _ => Ok(None),
+            }
+        }
+    }
+
+    #[test]
+    fn test_decoder_factory_overrides_primitive() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let buf = r#"{"a": "hello"}
+        {"a": null}
+        {"a": "hi"}
+        "#;
+
+        let batch = ReaderBuilder::new(schema)
+            .with_decoder_factory(Arc::new(StringLenDecoderFactory))
+            .build(Cursor::new(buf.as_bytes()))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap();
+
+        let col = batch.column(0).as_primitive::<Int32Type>();
+        assert_eq!(col.len(), 3);
+        assert_eq!(col.value(0), 5);
+        assert!(col.is_null(1));
+        assert_eq!(col.value(2), 2);
+    }
+
+    /// Consulted at every depth; declined types still use the default decoders.
+    #[test]
+    fn test_decoder_factory_overrides_nested_and_delegates_siblings() {
+        let inner = Fields::from(vec![
+            Field::new("overridden", DataType::Int32, true),
+            Field::new("untouched", DataType::Utf8, true),
+        ]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("s", DataType::Struct(inner), true),
+            Field::new_list("l", Field::new("item", DataType::Int32, true), true),
+        ]));
+
+        let buf = r#"{"s": {"overridden": "abcd", "untouched": "kept"}, "l": ["xyz", "z"]}
+        "#;
+
+        let batch = ReaderBuilder::new(schema)
+            .with_decoder_factory(Arc::new(StringLenDecoderFactory))
+            .build(Cursor::new(buf.as_bytes()))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap();
+
+        // Overridden inside a struct; its sibling decoded normally
+        let s = batch.column(0).as_struct();
+        assert_eq!(s.column(0).as_primitive::<Int32Type>().value(0), 4);
+        assert_eq!(s.column(1).as_string::<i32>().value(0), "kept");
+
+        // The default list decoder built its values decoder via `make_decoder`
+        let l = batch.column(1).as_list::<i32>();
+        let values = l.values().as_primitive::<Int32Type>();
+        assert_eq!(values.values(), &[3, 1]);
+    }
+
+    /// Declining everything must be indistinguishable from no factory at all.
+    #[test]
+    fn test_decoder_factory_declining_everything_is_transparent() {
+        #[derive(Debug, Default)]
+        struct DeclineAll {
+            seen: Mutex<Vec<DataType>>,
+        }
+
+        impl DecoderFactory for DeclineAll {
+            fn make_custom_decoder(
+                &self,
+                _ctx: &DecoderContext,
+                data_type: &DataType,
+                _is_nullable: bool,
+            ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
+                self.seen.lock().unwrap().push(data_type.clone());
+                Ok(None)
+            }
+        }
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Utf8, true),
+            Field::new_list("c", Field::new("item", DataType::Float64, true), true),
+        ]));
+        let buf = r#"{"a": 1, "b": "x", "c": [1.5, 2.5]}
+        {"a": null, "c": []}
+        "#;
+
+        let read = |factory: Option<Arc<dyn DecoderFactory>>| {
+            let mut builder = ReaderBuilder::new(schema.clone());
+            if let Some(factory) = factory {
+                builder = builder.with_decoder_factory(factory);
+            }
+            builder
+                .build(Cursor::new(buf.as_bytes()))
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap()
+        };
+
+        let factory = Arc::new(DeclineAll::default());
+        assert_eq!(read(None), read(Some(factory.clone())));
+
+        // Still consulted for the root struct and every leaf
+        let seen = factory.seen.lock().unwrap();
+        assert!(matches!(seen[0], DataType::Struct(_)), "{seen:?}");
+        for expected in [DataType::Int32, DataType::Utf8, DataType::Float64] {
+            assert!(seen.contains(&expected), "{expected} missing from {seen:?}");
+        }
+    }
+
+    /// A factory may delegate to the decoder the reader would otherwise use.
+    #[test]
+    fn test_decoder_factory_can_delegate_to_default() {
+        /// Overrides `Utf8` but hands the work straight back to the default decoder
+        #[derive(Debug)]
+        struct DelegatingFactory;
+
+        impl DecoderFactory for DelegatingFactory {
+            fn make_custom_decoder(
+                &self,
+                ctx: &DecoderContext,
+                data_type: &DataType,
+                is_nullable: bool,
+            ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
+                match data_type {
+                    // A *different* type, so this doesn't recurse back here
+                    DataType::Utf8 => Ok(Some(ctx.make_decoder(&DataType::Utf8View, is_nullable)?)),
+                    _ => Ok(None),
+                }
+            }
+        }
+
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Utf8, true)]));
+        let buf = r#"{"a": "hello"}
+        "#;
+
+        let batch = ReaderBuilder::new(schema)
+            .with_decoder_factory(Arc::new(DelegatingFactory))
+            .build(Cursor::new(buf.as_bytes()))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap();
+
+        // The default `Utf8View` decoder ran in place of the `Utf8` one
+        assert_eq!(batch.column(0).as_string_view().value(0), "hello");
     }
 }

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -778,6 +778,8 @@ pub trait ArrayDecoder: Send {
 /// use arrow_json::reader::{ArrayDecoder, DecoderContext, DecoderFactory, Tape, TapeElement};
 /// use arrow_json::ReaderBuilder;
 /// use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields, Schema};
+/// use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
+/// use arrow_array::StringArray;
 ///
 /// /// Decodes `[104, 105]` into the bytes `b"hi"`
 /// struct IntArrayBinaryDecoder;
@@ -814,17 +816,38 @@ pub trait ArrayDecoder: Send {
 ///     }
 /// }
 ///
+/// /// Upper-cases whatever the reader's own decoder produced
+/// struct ShoutDecoder(Box<dyn ArrayDecoder>);
+///
+/// impl ArrayDecoder for ShoutDecoder {
+///     fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError> {
+///         let inner = self.0.decode(tape, pos)?;
+///         let values = inner.as_string::<i32>();
+///         Ok(Arc::new(StringArray::from_iter(
+///             values.iter().map(|v| v.map(str::to_uppercase)),
+///         )))
+///     }
+/// }
+///
 /// #[derive(Debug)]
 /// struct IntArrayBinaryDecoderFactory;
 ///
 /// impl DecoderFactory for IntArrayBinaryDecoderFactory {
 ///     fn make_default_decoder(
 ///         &self,
-///         _ctx: &DecoderContext,
+///         ctx: &DecoderContext,
 ///         field: &FieldRef,
-///         _is_nullable: bool,
+///         is_nullable: bool,
 ///     ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
-///         // `field.metadata()` is also available, e.g. for extension types
+///         // Selection can key off metadata, e.g. to recognise an extension type, and
+///         // build on the reader's own decoder for the very same field
+///         if field.metadata().get(EXTENSION_TYPE_NAME_KEY).map(String::as_str)
+///             == Some("apache.shout")
+///         {
+///             let inner = ctx.make_builtin_decoder(field, is_nullable)?;
+///             return Ok(Some(Box::new(ShoutDecoder(inner))));
+///         }
+///
 ///         match field.data_type() {
 ///             DataType::Binary => Ok(Some(Box::new(IntArrayBinaryDecoder))),
 ///             // Returning `None` uses the reader's default decoder
@@ -838,9 +861,11 @@ pub trait ArrayDecoder: Send {
 ///     Field::new("bytes", DataType::Binary, true),
 ///     Field::new("float", DataType::Float64, true),
 ///     Field::new("nested", DataType::Struct(nested), true),
+///     Field::new("shout", DataType::Utf8, true)
+///         .with_metadata([(EXTENSION_TYPE_NAME_KEY, "apache.shout")]),
 /// ]));
 ///
-/// let json = r#"{"bytes": [104, 105], "float": 1.0, "nested": {"inner": [104, 105]}}
+/// let json = r#"{"bytes": [104, 105], "float": 1.0, "nested": {"inner": [104, 105]}, "shout": "hi"}
 /// {"float": 2.3}
 /// {"bytes": [98], "nested": {"inner": [98]}}
 /// "#;
@@ -863,6 +888,9 @@ pub trait ArrayDecoder: Send {
 /// let inner = batch.column(2).as_struct().column(0).as_binary::<i32>();
 /// assert_eq!(inner.value(0), b"hi");
 /// assert_eq!(batch.column(1).as_primitive::<Float64Type>().value(0), 1.0);
+///
+/// // Dispatched on metadata, and decoded by the reader's own `Utf8` decoder
+/// assert_eq!(batch.column(3).as_string::<i32>().value(0), "HI");
 /// ```
 ///
 /// [`EncoderFactory`]: crate::EncoderFactory
@@ -1115,7 +1143,6 @@ mod tests {
     };
     use arrow_buffer::{ArrowNativeType, NullBuffer, OffsetBuffer, ScalarBuffer};
     use arrow_cast::display::{ArrayFormatter, FormatOptions};
-    use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
     use arrow_schema::{Field, Fields};
     use serde_json::json;
     use std::fs::File;
@@ -4077,24 +4104,6 @@ mod tests {
             assert_eq!(col.value(i), (i as i32) + 1);
         }
     }
-    /// Decodes a string as its byte length
-    struct StringLenDecoder;
-
-    impl ArrayDecoder for StringLenDecoder {
-        fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError> {
-            let mut builder = Int32Array::builder(pos.len());
-            for p in pos {
-                match tape.get(*p) {
-                    TapeElement::String(idx) => {
-                        builder.append_value(tape.get_string(idx).len() as i32)
-                    }
-                    TapeElement::Null => builder.append_null(),
-                    _ => return Err(tape.error(*p, "string")),
-                }
-            }
-            Ok(Arc::new(builder.finish()))
-        }
-    }
 
     /// Declining everything must be indistinguishable from no factory at all.
     #[test]
@@ -4164,102 +4173,6 @@ mod tests {
                 "{expected:?} missing from {by_name:?}"
             );
         }
-    }
-
-    /// `make_builtin_decoder` serves the case `make_decoder` cannot: delegating for the
-    /// *same* field, which would otherwise loop.
-    #[test]
-    fn test_decoder_factory_can_delegate_to_builtin_for_same_field() {
-        /// Upper-cases whatever the built-in decoder produced
-        struct Upper(Box<dyn ArrayDecoder>);
-
-        impl ArrayDecoder for Upper {
-            fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError> {
-                let inner = self.0.decode(tape, pos)?;
-                let values = inner.as_string::<i32>();
-                Ok(Arc::new(StringArray::from_iter(
-                    values.iter().map(|v| v.map(str::to_uppercase)),
-                )))
-            }
-        }
-
-        #[derive(Debug)]
-        struct UpperFactory;
-
-        impl DecoderFactory for UpperFactory {
-            fn make_default_decoder(
-                &self,
-                ctx: &DecoderContext,
-                field: &FieldRef,
-                is_nullable: bool,
-            ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
-                match field.data_type() {
-                    // The SAME field -- via `make_decoder` this would loop forever
-                    DataType::Utf8 => Ok(Some(Box::new(Upper(
-                        ctx.make_builtin_decoder(field, is_nullable)?,
-                    )))),
-                    _ => Ok(None),
-                }
-            }
-        }
-
-        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, true)]));
-        let batch = ReaderBuilder::new(schema)
-            .with_decoder_factory(Arc::new(UpperFactory))
-            .build(Cursor::new(br#"{"s": "hello"}"#.as_slice()))
-            .unwrap()
-            .next()
-            .unwrap()
-            .unwrap();
-
-        // Upper-cased, so this decoder ran; "hello" at all, so the built-in did the work
-        assert_eq!(batch.column(0).as_string::<i32>().value(0), "HELLO");
-    }
-
-    /// Why the factory receives a `FieldRef`: selection can key off field metadata.
-    #[test]
-    fn test_decoder_factory_can_dispatch_on_field_metadata() {
-        #[derive(Debug)]
-        struct ExtensionFactory;
-
-        impl DecoderFactory for ExtensionFactory {
-            fn make_default_decoder(
-                &self,
-                _ctx: &DecoderContext,
-                field: &FieldRef,
-                _is_nullable: bool,
-            ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
-                // Two fields share a data type; only the annotated one is overridden
-                match field.metadata().get(EXTENSION_TYPE_NAME_KEY) {
-                    Some(name) if name == "mycompany.strlen" => {
-                        Ok(Some(Box::new(StringLenDecoder)))
-                    }
-                    _ => Ok(None),
-                }
-            }
-        }
-
-        let tagged = Field::new("tagged", DataType::Int32, true)
-            .with_metadata([(EXTENSION_TYPE_NAME_KEY, "mycompany.strlen")]);
-        let schema = Arc::new(Schema::new(vec![
-            tagged,
-            Field::new("plain", DataType::Int32, true),
-        ]));
-
-        let batch = ReaderBuilder::new(schema)
-            .with_decoder_factory(Arc::new(ExtensionFactory))
-            .build(Cursor::new(
-                br#"{"tagged": "hello", "plain": 7}"#.as_slice(),
-            ))
-            .unwrap()
-            .next()
-            .unwrap()
-            .unwrap();
-
-        // Overridden
-        assert_eq!(batch.column(0).as_primitive::<Int32Type>().value(0), 5);
-        // Same type, no metadata
-        assert_eq!(batch.column(1).as_primitive::<Int32Type>().value(0), 7);
     }
 
     /// A custom decoder's output is not trusted: the arrays built from it are

--- a/arrow-json/src/reader/mod.rs
+++ b/arrow-json/src/reader/mod.rs
@@ -133,7 +133,6 @@
 //! ```
 //!
 
-use std::borrow::Cow;
 use std::io::BufRead;
 use std::sync::Arc;
 
@@ -141,7 +140,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::timezone::Tz;
 use arrow_array::types::*;
 use arrow_array::{ArrayRef, RecordBatch, RecordBatchReader, downcast_integer};
-use arrow_schema::{ArrowError, DataType, FieldRef, Schema, SchemaRef, TimeUnit};
+use arrow_schema::{ArrowError, DataType, Field, FieldRef, Schema, SchemaRef, TimeUnit};
 use chrono::Utc;
 use serde_core::Serialize;
 
@@ -165,8 +164,7 @@ use crate::reader::tape::{TapeDecoder, TapeDecoderOptions};
 use crate::reader::timestamp_array::TimestampArrayDecoder;
 
 pub use schema::*;
-// `mod tape` stays private: exposing only these two types means downstream can read a
-// `Tape` but not construct one, keeping `TapeDecoder` an implementation detail.
+// `mod tape` stays private so `TapeDecoder` does not become public API
 pub use tape::{Tape, TapeElement};
 pub use value_iter::ValueIter;
 
@@ -346,9 +344,7 @@ impl ReaderBuilder {
         }
     }
 
-    /// Set an optional hook for customizing decoding behavior.
-    ///
-    /// See [`DecoderFactory`] for details and an example.
+    /// Set a hook for customizing decoding behavior. See [`DecoderFactory`].
     pub fn with_decoder_factory(self, decoder_factory: Arc<dyn DecoderFactory>) -> Self {
         Self {
             decoder_factory: Some(decoder_factory),
@@ -366,13 +362,14 @@ impl ReaderBuilder {
 
     /// Create a [`Decoder`]
     pub fn build_decoder(self) -> Result<Decoder, ArrowError> {
-        let (data_type, nullable) = if self.is_field {
-            let field = &self.schema.fields[0];
-            let data_type = Cow::Borrowed(field.data_type());
-            (data_type, field.is_nullable())
+        let (field, nullable) = if self.is_field {
+            let field = self.schema.fields[0].clone();
+            let nullable = field.is_nullable();
+            (field, nullable)
         } else {
-            let data_type = Cow::Owned(DataType::Struct(self.schema.fields.clone()));
-            (data_type, false)
+            // The root has no field of its own; synthesize a nameless one
+            let data_type = DataType::Struct(self.schema.fields.clone());
+            (Arc::new(Field::new("", data_type, false)), false)
         };
 
         let ctx = DecoderContext {
@@ -382,7 +379,7 @@ impl ReaderBuilder {
             ignore_type_conflicts: self.ignore_type_conflicts,
             decoder_factory: self.decoder_factory,
         };
-        let decoder = ctx.make_decoder(data_type.as_ref(), nullable)?;
+        let decoder = ctx.make_decoder(&field, nullable)?;
 
         let num_fields = self.schema.flattened_fields().len();
 
@@ -753,8 +750,7 @@ impl Decoder {
 
 /// Decodes a column of JSON values from a [`Tape`] into an [`ArrayRef`]
 ///
-/// Implement this together with [`DecoderFactory`] to override how a type is
-/// decoded, or to add support for a type the reader does not handle.
+/// Implement alongside [`DecoderFactory`] to override or add support for a type.
 pub trait ArrayDecoder: Send {
     /// Decode elements from `tape` starting at the indexes contained in `pos`
     ///
@@ -765,14 +761,13 @@ pub trait ArrayDecoder: Send {
 
 /// A trait to create custom decoders for specific data types.
 ///
-/// Overrides the default decoder for a data type, or adds support for one the reader
-/// does not handle. The reader-side counterpart of [`EncoderFactory`]; register an
+/// Overrides the reader's decoder for a data type, or adds support for one it does not
+/// handle. The reader-side counterpart of [`EncoderFactory`]; register an
 /// implementation with [`ReaderBuilder::with_decoder_factory`].
 ///
 /// # Examples
 ///
-/// Decodes `Binary` from a JSON array of integers rather than the default hex string,
-/// the inverse of the [`EncoderFactory`] example.
+/// Decodes `Binary` from a JSON array of integers rather than the default hex string.
 ///
 /// ```
 /// use std::sync::Arc;
@@ -780,7 +775,7 @@ pub trait ArrayDecoder: Send {
 /// use arrow_array::cast::AsArray;
 /// use arrow_json::reader::{ArrayDecoder, DecoderContext, DecoderFactory, Tape, TapeElement};
 /// use arrow_json::ReaderBuilder;
-/// use arrow_schema::{ArrowError, DataType, Field, Schema};
+/// use arrow_schema::{ArrowError, DataType, Field, FieldRef, Schema};
 ///
 /// /// Decodes `[104, 105]` into the bytes `b"hi"`
 /// struct IntArrayBinaryDecoder;
@@ -821,13 +816,14 @@ pub trait ArrayDecoder: Send {
 /// struct IntArrayBinaryDecoderFactory;
 ///
 /// impl DecoderFactory for IntArrayBinaryDecoderFactory {
-///     fn make_custom_decoder(
+///     fn make_default_decoder(
 ///         &self,
 ///         _ctx: &DecoderContext,
-///         data_type: &DataType,
+///         field: &FieldRef,
 ///         _is_nullable: bool,
 ///     ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
-///         match data_type {
+///         // `field.metadata()` is also available, e.g. for extension types
+///         match field.data_type() {
 ///             DataType::Binary => Ok(Some(Box::new(IntArrayBinaryDecoder))),
 ///             // Returning `None` uses the reader's default decoder
 ///             _ => Ok(None),
@@ -861,17 +857,26 @@ pub trait ArrayDecoder: Send {
 ///
 /// [`EncoderFactory`]: crate::EncoderFactory
 pub trait DecoderFactory: std::fmt::Debug + Send + Sync {
-    /// Make a decoder for `data_type`, or `Ok(None)` to use the reader's default.
+    /// Make a decoder for `field`, or `Ok(None)` to use the reader's default.
     ///
-    /// Use [`DecoderContext::make_decoder`] on `ctx` to build child decoders. Calling
-    /// it for the `data_type` this was invoked with recurses back here and loops.
+    /// Receives the [`FieldRef`] rather than just its [`DataType`] so decoder
+    /// selection can consider the field's metadata, e.g. to identify [extension
+    /// types]. The root of a [`ReaderBuilder::new`] schema is presented as a
+    /// synthesized nameless `Struct` field.
     ///
-    /// `is_nullable` folds in ancestor nullability, so it may be `true` even where the
-    /// corresponding field is not.
-    fn make_custom_decoder(
+    /// Use [`DecoderContext::make_decoder`] on `ctx` to build child decoders, and
+    /// [`DecoderContext::make_builtin_decoder`] to build on the reader's own decoder
+    /// for this field. Calling `make_decoder` with the field this was invoked with
+    /// recurses back here and loops.
+    ///
+    /// `is_nullable` folds in ancestor nullability, so it may be `true` even when
+    /// `field.is_nullable()` is not.
+    ///
+    /// [extension types]: https://arrow.apache.org/docs/format/Columnar.html#extension-types
+    fn make_default_decoder(
         &self,
         _ctx: &DecoderContext,
-        _data_type: &DataType,
+        _field: &FieldRef,
         _is_nullable: bool,
     ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
         Ok(None)
@@ -923,24 +928,51 @@ impl DecoderContext {
 
     /// Create a decoder for a type.
     ///
-    /// The standard way to create child decoders from within a decoder, and how a
-    /// [`DecoderFactory`] delegates to the decoder the reader would otherwise use.
-    /// The factory is consulted first, so calling this for the same data type the
-    /// factory was asked about will loop.
+    /// This is the standard way to create child decoders from within a decoder
+    /// implementation.
     pub fn make_decoder(
         &self,
-        data_type: &DataType,
+        field: &FieldRef,
         is_nullable: bool,
     ) -> Result<Box<dyn ArrayDecoder>, ArrowError> {
-        make_decoder(self, data_type, is_nullable)
+        make_decoder(self, field, is_nullable)
+    }
+
+    /// Create the decoder the reader would use for `field`, ignoring any
+    /// [`DecoderFactory`].
+    ///
+    /// Lets a factory build on the reader's own decoder, including for the field it was
+    /// asked about — which [`Self::make_decoder`] cannot do without looping.
+    pub fn make_builtin_decoder(
+        &self,
+        field: &FieldRef,
+        is_nullable: bool,
+    ) -> Result<Box<dyn ArrayDecoder>, ArrowError> {
+        make_builtin_decoder(self, field, is_nullable)
     }
 }
 
 fn make_decoder(
     ctx: &DecoderContext,
-    data_type: &DataType,
+    field: &FieldRef,
     is_nullable: bool,
 ) -> Result<Box<dyn ArrayDecoder>, ArrowError> {
+    if let Some(factory) = ctx.decoder_factory()
+        && let Some(decoder) = factory.make_default_decoder(ctx, field, is_nullable)?
+    {
+        return Ok(decoder);
+    }
+
+    make_builtin_decoder(ctx, field, is_nullable)
+}
+
+fn make_builtin_decoder(
+    ctx: &DecoderContext,
+    field: &FieldRef,
+    is_nullable: bool,
+) -> Result<Box<dyn ArrayDecoder>, ArrowError> {
+    let data_type = field.data_type();
+
     macro_rules! primitive_decoder {
         ($t:ty, $data_type:expr) => {
             Ok(Box::new(PrimitiveArrayDecoder::<$t>::new(ctx, $data_type)))
@@ -957,12 +989,6 @@ fn make_decoder(
         ($t:ty, $p:expr, $s:expr) => {
             Ok(Box::new(DecimalArrayDecoder::<$t>::new(ctx, $p, $s)))
         };
-    }
-
-    if let Some(factory) = ctx.decoder_factory()
-        && let Some(decoder) = factory.make_custom_decoder(ctx, data_type, is_nullable)?
-    {
-        return Ok(decoder);
     }
 
     downcast_integer! {
@@ -1047,11 +1073,13 @@ mod tests {
     };
     use arrow_buffer::{ArrowNativeType, NullBuffer, OffsetBuffer, ScalarBuffer};
     use arrow_cast::display::{ArrayFormatter, FormatOptions};
+    use arrow_schema::extension::EXTENSION_TYPE_NAME_KEY;
     use arrow_schema::{Field, Fields};
     use serde_json::json;
     use std::fs::File;
     use std::io::{BufReader, Cursor, Seek};
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
 
@@ -4008,7 +4036,7 @@ mod tests {
             assert_eq!(col.value(i), (i as i32) + 1);
         }
     }
-    /// Decodes any string as its byte length, giving an unmistakable signature
+    /// Decodes a string as its byte length, an unmistakable signature
     struct StringLenDecoder;
 
     impl ArrayDecoder for StringLenDecoder {
@@ -4032,13 +4060,13 @@ mod tests {
     struct StringLenDecoderFactory;
 
     impl DecoderFactory for StringLenDecoderFactory {
-        fn make_custom_decoder(
+        fn make_default_decoder(
             &self,
             _ctx: &DecoderContext,
-            data_type: &DataType,
+            field: &FieldRef,
             _is_nullable: bool,
         ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
-            match data_type {
+            match field.data_type() {
                 DataType::Int32 => Ok(Some(Box::new(StringLenDecoder))),
                 _ => Ok(None),
             }
@@ -4096,7 +4124,7 @@ mod tests {
         assert_eq!(s.column(0).as_primitive::<Int32Type>().value(0), 4);
         assert_eq!(s.column(1).as_string::<i32>().value(0), "kept");
 
-        // The default list decoder built its values decoder via `make_decoder`
+        // Reached via the default list decoder's `make_decoder` call
         let l = batch.column(1).as_list::<i32>();
         let values = l.values().as_primitive::<Int32Type>();
         assert_eq!(values.values(), &[3, 1]);
@@ -4107,17 +4135,17 @@ mod tests {
     fn test_decoder_factory_declining_everything_is_transparent() {
         #[derive(Debug, Default)]
         struct DeclineAll {
-            seen: Mutex<Vec<DataType>>,
+            seen: Mutex<Vec<FieldRef>>,
         }
 
         impl DecoderFactory for DeclineAll {
-            fn make_custom_decoder(
+            fn make_default_decoder(
                 &self,
                 _ctx: &DecoderContext,
-                data_type: &DataType,
+                field: &FieldRef,
                 _is_nullable: bool,
             ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
-                self.seen.lock().unwrap().push(data_type.clone());
+                self.seen.lock().unwrap().push(field.clone());
                 Ok(None)
             }
         }
@@ -4147,31 +4175,155 @@ mod tests {
         let factory = Arc::new(DeclineAll::default());
         assert_eq!(read(None), read(Some(factory.clone())));
 
-        // Still consulted for the root struct and every leaf
+        // Consulted for the root struct and every leaf, with names attached; the
+        // root is the documented synthesized nameless struct
         let seen = factory.seen.lock().unwrap();
-        assert!(matches!(seen[0], DataType::Struct(_)), "{seen:?}");
-        for expected in [DataType::Int32, DataType::Utf8, DataType::Float64] {
-            assert!(seen.contains(&expected), "{expected} missing from {seen:?}");
+        assert!(
+            matches!(seen[0].data_type(), DataType::Struct(_)),
+            "{seen:?}"
+        );
+        assert_eq!(seen[0].name(), "", "root field should be nameless");
+
+        let by_name: Vec<(&str, &DataType)> = seen
+            .iter()
+            .map(|f| (f.name().as_str(), f.data_type()))
+            .collect();
+        for expected in [
+            ("a", &DataType::Int32),
+            ("b", &DataType::Utf8),
+            ("item", &DataType::Float64),
+        ] {
+            assert!(
+                by_name.contains(&expected),
+                "{expected:?} missing from {by_name:?}"
+            );
         }
     }
 
-    /// A factory may delegate to the decoder the reader would otherwise use.
+    /// `make_builtin_decoder` serves the case `make_decoder` cannot: delegating for the
+    /// *same* field, which would otherwise loop.
+    #[test]
+    fn test_decoder_factory_can_delegate_to_builtin_for_same_field() {
+        /// Delegates to the built-in decoder, recording that it did so
+        struct Delegating {
+            inner: Box<dyn ArrayDecoder>,
+            called: Arc<AtomicBool>,
+        }
+
+        impl ArrayDecoder for Delegating {
+            fn decode(&mut self, tape: &Tape<'_>, pos: &[u32]) -> Result<ArrayRef, ArrowError> {
+                self.called.store(true, Ordering::SeqCst);
+                self.inner.decode(tape, pos)
+            }
+        }
+
+        #[derive(Debug)]
+        struct BuiltinDelegatingFactory {
+            called: Arc<AtomicBool>,
+        }
+
+        impl DecoderFactory for BuiltinDelegatingFactory {
+            fn make_default_decoder(
+                &self,
+                ctx: &DecoderContext,
+                field: &FieldRef,
+                is_nullable: bool,
+            ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
+                match field.data_type() {
+                    // The SAME field -- via `make_decoder` this would loop forever
+                    DataType::Utf8 => Ok(Some(Box::new(Delegating {
+                        inner: ctx.make_builtin_decoder(field, is_nullable)?,
+                        called: Arc::clone(&self.called),
+                    }))),
+                    _ => Ok(None),
+                }
+            }
+        }
+
+        let called = Arc::new(AtomicBool::new(false));
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, true)]));
+        let batch = ReaderBuilder::new(schema)
+            .with_decoder_factory(Arc::new(BuiltinDelegatingFactory {
+                called: Arc::clone(&called),
+            }))
+            .build(Cursor::new(br#"{"s": "hello"}"#.as_slice()))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap();
+
+        // The wrapper ran, and the built-in did the work
+        assert!(called.load(Ordering::SeqCst), "custom decoder was not used");
+        assert_eq!(batch.column(0).as_string::<i32>().value(0), "hello");
+    }
+
+    /// Why the factory receives a `FieldRef`: selection can key off field metadata.
+    #[test]
+    fn test_decoder_factory_can_dispatch_on_field_metadata() {
+        #[derive(Debug)]
+        struct ExtensionFactory;
+
+        impl DecoderFactory for ExtensionFactory {
+            fn make_default_decoder(
+                &self,
+                _ctx: &DecoderContext,
+                field: &FieldRef,
+                _is_nullable: bool,
+            ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
+                // Two fields share a data type; only the annotated one is overridden
+                match field.metadata().get(EXTENSION_TYPE_NAME_KEY) {
+                    Some(name) if name == "mycompany.strlen" => {
+                        Ok(Some(Box::new(StringLenDecoder)))
+                    }
+                    _ => Ok(None),
+                }
+            }
+        }
+
+        let tagged = Field::new("tagged", DataType::Int32, true)
+            .with_metadata([(EXTENSION_TYPE_NAME_KEY, "mycompany.strlen")]);
+        let schema = Arc::new(Schema::new(vec![
+            tagged,
+            Field::new("plain", DataType::Int32, true),
+        ]));
+
+        let batch = ReaderBuilder::new(schema)
+            .with_decoder_factory(Arc::new(ExtensionFactory))
+            .build(Cursor::new(
+                br#"{"tagged": "hello", "plain": 7}"#.as_slice(),
+            ))
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap();
+
+        // Overridden
+        assert_eq!(batch.column(0).as_primitive::<Int32Type>().value(0), 5);
+        // Same type, no metadata
+        assert_eq!(batch.column(1).as_primitive::<Int32Type>().value(0), 7);
+    }
+
+    /// A factory may delegate via `make_decoder` for a *different* field.
     #[test]
     fn test_decoder_factory_can_delegate_to_default() {
-        /// Overrides `Utf8` but hands the work straight back to the default decoder
+        /// Overrides `Utf8`, handing the work to the `Utf8View` decoder
         #[derive(Debug)]
         struct DelegatingFactory;
 
         impl DecoderFactory for DelegatingFactory {
-            fn make_custom_decoder(
+            fn make_default_decoder(
                 &self,
                 ctx: &DecoderContext,
-                data_type: &DataType,
+                field: &FieldRef,
                 is_nullable: bool,
             ) -> Result<Option<Box<dyn ArrayDecoder>>, ArrowError> {
-                match data_type {
+                match field.data_type() {
                     // A *different* type, so this doesn't recurse back here
-                    DataType::Utf8 => Ok(Some(ctx.make_decoder(&DataType::Utf8View, is_nullable)?)),
+                    DataType::Utf8 => {
+                        let view =
+                            Arc::new(field.as_ref().clone().with_data_type(DataType::Utf8View));
+                        Ok(Some(ctx.make_decoder(&view, is_nullable)?))
+                    }
                     _ => Ok(None),
                 }
             }
@@ -4189,7 +4341,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        // The default `Utf8View` decoder ran in place of the `Utf8` one
+        // The `Utf8View` decoder ran in place of the `Utf8` one
         assert_eq!(batch.column(0).as_string_view().value(0), "hello");
     }
 }

--- a/arrow-json/src/reader/run_end_array.rs
+++ b/arrow-json/src/reader/run_end_array.rs
@@ -47,7 +47,7 @@ impl<R: RunEndIndexType> RunEndEncodedArrayDecoder<R> {
             unreachable!()
         };
         let values_nullable = values_field.is_nullable() && is_nullable;
-        let decoder = ctx.make_decoder(values_field.data_type(), values_nullable)?;
+        let decoder = ctx.make_decoder(values_field, values_nullable)?;
 
         Ok(Self {
             data_type: data_type.clone(),

--- a/arrow-json/src/reader/struct_array.rs
+++ b/arrow-json/src/reader/struct_array.rs
@@ -95,7 +95,7 @@ impl StructArrayDecoder {
                 // StructArrayDecoder::decode verifies that if the child is not nullable
                 // it doesn't contain any nulls not masked by its parent
                 let nullable = f.is_nullable() || is_nullable;
-                ctx.make_decoder(f.data_type(), nullable)
+                ctx.make_decoder(f, nullable)
             })
             .collect::<Result<Vec<_>, ArrowError>>()?;
 

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -29,24 +29,16 @@ use std::fmt::Write;
 /// Uses `u32` for offsets to ensure `TapeElement` is 64-bits. A future
 /// iteration may increase this to a custom `u56` type.
 ///
-/// # Numeric representation
+/// Numbers arrive in more than one form and matches must handle all of them.
+/// [`Self::Number`] holds the value textually (read via [`Tape::get_string`]) and is
+/// what parsing JSON text always yields. Serializing Rust values (see
+/// [`Decoder::serialize`](super::Decoder::serialize)) yields [`Self::I32`],
+/// [`Self::I64`], [`Self::F32`] or [`Self::F64`] — 64-bit values occupying two
+/// consecutive elements, high bits first — falling back to [`Self::Number`] for
+/// integers too large for `i64`.
 ///
-/// Numbers reach the tape in one of two forms, depending on how the [`Tape`] was
-/// produced, and code matching on [`TapeElement`] must handle both:
+/// `#[non_exhaustive]` as the encoding is an implementation detail.
 ///
-/// * Parsing JSON text yields [`Self::Number`], which references the textual
-///   representation in the tape's string data. Read it with [`Tape::get_string`]
-///   and parse it yourself.
-/// * Serializing Rust values (see [`Decoder::serialize`]) yields the native
-///   variants [`Self::I32`], [`Self::I64`], [`Self::F32`] and [`Self::F64`].
-///   64-bit values occupy *two* consecutive elements, high bits first.
-///
-/// The built-in primitive decoder handles every case and is a useful reference.
-///
-/// This enum is `#[non_exhaustive]`: the tape's encoding is an implementation
-/// detail and new variants may be added in a minor release.
-///
-/// [`Decoder::serialize`]: super::Decoder::serialize
 /// [simdjson]: https://github.com/simdjson/simdjson/blob/master/doc/tape.md
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -110,17 +102,9 @@ pub enum TapeElement {
 ///
 /// This approach to decoding JSON is inspired by [simdjson]
 ///
-/// # Reading a tape
-///
-/// A `Tape` is borrowed, never constructed, by code that decodes it: use
-/// [`Tape::get`] to inspect the element at an index, [`Tape::get_string`] to
-/// resolve string data, [`Tape::next`] to skip over a value (including nested
-/// objects and lists), and [`Tape::error`] to produce errors consistent with the
-/// built-in decoders.
-///
-/// Note that string data is *copied* into the tape with escape sequences already
-/// resolved, so [`Tape::get_string`] borrows from the tape rather than from the
-/// input buffer. See [`TapeElement`] for how numbers are represented.
+/// A `Tape` is borrowed, never constructed, by code that decodes it. String data is
+/// copied into the tape with escapes resolved, so [`Tape::get_string`] borrows from
+/// the tape, not the input. See [`TapeElement`] for how numbers are represented.
 ///
 /// [simdjson]: https://github.com/simdjson/simdjson/blob/master/doc/tape.md
 #[derive(Debug)]

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -29,8 +29,27 @@ use std::fmt::Write;
 /// Uses `u32` for offsets to ensure `TapeElement` is 64-bits. A future
 /// iteration may increase this to a custom `u56` type.
 ///
+/// # Numeric representation
+///
+/// Numbers reach the tape in one of two forms, depending on how the [`Tape`] was
+/// produced, and code matching on [`TapeElement`] must handle both:
+///
+/// * Parsing JSON text yields [`Self::Number`], which references the textual
+///   representation in the tape's string data. Read it with [`Tape::get_string`]
+///   and parse it yourself.
+/// * Serializing Rust values (see [`Decoder::serialize`]) yields the native
+///   variants [`Self::I32`], [`Self::I64`], [`Self::F32`] and [`Self::F64`].
+///   64-bit values occupy *two* consecutive elements, high bits first.
+///
+/// The built-in primitive decoder handles every case and is a useful reference.
+///
+/// This enum is `#[non_exhaustive]`: the tape's encoding is an implementation
+/// detail and new variants may be added in a minor release.
+///
+/// [`Decoder::serialize`]: super::Decoder::serialize
 /// [simdjson]: https://github.com/simdjson/simdjson/blob/master/doc/tape.md
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum TapeElement {
     /// The start of an object, i.e. `{`
     ///
@@ -90,6 +109,18 @@ pub enum TapeElement {
 /// The first element is always [`TapeElement::Null`]
 ///
 /// This approach to decoding JSON is inspired by [simdjson]
+///
+/// # Reading a tape
+///
+/// A `Tape` is borrowed, never constructed, by code that decodes it: use
+/// [`Tape::get`] to inspect the element at an index, [`Tape::get_string`] to
+/// resolve string data, [`Tape::next`] to skip over a value (including nested
+/// objects and lists), and [`Tape::error`] to produce errors consistent with the
+/// built-in decoders.
+///
+/// Note that string data is *copied* into the tape with escape sequences already
+/// resolved, so [`Tape::get_string`] borrows from the tape rather than from the
+/// input buffer. See [`TapeElement`] for how numbers are represented.
 ///
 /// [simdjson]: https://github.com/simdjson/simdjson/blob/master/doc/tape.md
 #[derive(Debug)]

--- a/arrow-json/src/reader/tape.rs
+++ b/arrow-json/src/reader/tape.rs
@@ -29,15 +29,12 @@ use std::fmt::Write;
 /// Uses `u32` for offsets to ensure `TapeElement` is 64-bits. A future
 /// iteration may increase this to a custom `u56` type.
 ///
-/// Numbers arrive in more than one form and matches must handle all of them.
-/// [`Self::Number`] holds the value textually (read via [`Tape::get_string`]) and is
-/// what parsing JSON text always yields. Serializing Rust values (see
+/// Numbers take more than one form, and matches must handle all of them. Parsing JSON
+/// text always yields [`Self::Number`], holding the value textually (read via
+/// [`Tape::get_string`]). Serializing Rust values (see
 /// [`Decoder::serialize`](super::Decoder::serialize)) yields [`Self::I32`],
-/// [`Self::I64`], [`Self::F32`] or [`Self::F64`] — 64-bit values occupying two
-/// consecutive elements, high bits first — falling back to [`Self::Number`] for
-/// integers too large for `i64`.
-///
-/// `#[non_exhaustive]` as the encoding is an implementation detail.
+/// [`Self::I64`], [`Self::F32`] or [`Self::F64`] — 64-bit values spanning two
+/// elements, high bits first — or [`Self::Number`] for integers exceeding `i64`.
 ///
 /// [simdjson]: https://github.com/simdjson/simdjson/blob/master/doc/tape.md
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -102,9 +99,8 @@ pub enum TapeElement {
 ///
 /// This approach to decoding JSON is inspired by [simdjson]
 ///
-/// A `Tape` is borrowed, never constructed, by code that decodes it. String data is
-/// copied into the tape with escapes resolved, so [`Tape::get_string`] borrows from
-/// the tape, not the input. See [`TapeElement`] for how numbers are represented.
+/// String data is copied into the tape with escapes resolved, so [`Tape::get_string`]
+/// borrows from the tape, not the input. A `Tape` is read, never constructed.
 ///
 /// [simdjson]: https://github.com/simdjson/simdjson/blob/master/doc/tape.md
 #[derive(Debug)]


### PR DESCRIPTION
# Which issue does this PR close?

- Related: #9021, #9272 (prior art, both went stale); a step toward #8987 but does not close it.
- Closes https://github.com/apache/arrow-rs/issues/10739

# Rationale for this change

- The JSON writer has been extensible since #7015 (`EncoderFactory`, plus a public `make_encoder` to delegate to defaults). The reader has no equivalent.
- Small now because #9272's prefactors already merged (#9266, #9270, #9271): `DecoderContext` already sits on `main`.

# What changes are included in this PR?

- `TapeElement` `#[non_exhaustive]`, documenting numbers as `Number` (JSON text) or native `i32`/`i64`/`f32`/`f64` (serde path), 64-bit spanning two elements.
- `ArrayDecoder` public; `pos` holds one tape index per output row.
- New `DecoderFactory`, consulted before the reader's dispatch; `Ok(None)` accepts the default.
- `DecoderContext::make_decoder` public, so a factory can delegate to the decoder the reader would otherwise use - without it, overriding a nested type means reimplementing its children (@scovich's point on #9021).
- `ReaderBuilder::with_decoder_factory`.

# Are these changes tested?

Yes. Unit tests and a doctest decoding `Binary` from a JSON int array - the inverse of the existing `EncoderFactory` doctest, so the two round-trip, no new dependency.

# Are there any user-facing changes?

New: `arrow_json::{Tape, TapeElement, ArrayDecoder, DecoderFactory}`, `DecoderContext::{make_decoder, decoder_factory}`, `ReaderBuilder::with_decoder_factory`.