### PR TITLE
chore: fix `.gitattributes` to not mark `arrow-ipc/src/gen/mod.rs` as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 arrow-flight/src/arrow.flight.protocol.rs linguist-generated
 arrow-flight/src/sql/arrow.flight.protocol.sql.rs linguist-generated
 arrow-ipc/src/gen/*.rs linguist-generated
+arrow-ipc/src/gen/mod.rs -linguist-generated


### PR DESCRIPTION
the other files are auto generated, mod.rs isnt