### PR TITLE
Re-export `rand` crate in `arrow::util`

### DIFF
--- a/arrow/src/util/mod.rs
+++ b/arrow/src/util/mod.rs
@@ -25,6 +25,12 @@ pub use arrow_data::bit_mask;
 pub mod bench_util;
 #[cfg(feature = "test_utils")]
 pub mod data_gen;
+/// Re-export of the `rand` crate version used by this crate.
+///
+/// Use `arrow::util::rand` to import `StandardUniform`, `StdRng`, etc. when
+/// calling APIs in `bench_util` or `test_util` to avoid `rand` version mismatches.
+#[cfg(feature = "test_utils")]
+pub use rand;
 #[cfg(feature = "prettyprint")]
 pub use arrow_cast::pretty;
 pub mod string_writer;

--- a/arrow/src/util/mod.rs
+++ b/arrow/src/util/mod.rs
@@ -25,14 +25,14 @@ pub use arrow_data::bit_mask;
 pub mod bench_util;
 #[cfg(feature = "test_utils")]
 pub mod data_gen;
+#[cfg(feature = "prettyprint")]
+pub use arrow_cast::pretty;
 /// Re-export of the `rand` crate version used by this crate.
 ///
 /// Use `arrow::util::rand` to import `StandardUniform`, `StdRng`, etc. when
 /// calling APIs in `bench_util` or `test_util` to avoid `rand` version mismatches.
 #[cfg(feature = "test_utils")]
 pub use rand;
-#[cfg(feature = "prettyprint")]
-pub use arrow_cast::pretty;
 pub mod string_writer;
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_util;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10685.

# Rationale for this change
`bench_util` and `test_util` expose rand types in their public API (e.g. StandardUniform bounds, StdRng return types). Downstream crates on a different rand major version can't satisfy those bounds, causing compile errors.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

`pub use rand`; re-export added to` arrow::util` behind the `test_utils` feature flag, so callers can import `arrow::util::rand::..`. to get the exact rand version arrow uses. 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

n/a

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
yes, users can avoid import conflicts
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
