### PR TITLE
Add `Metadata` `Arc` helper methods

### DIFF
--- a/arrow-schema/src/metadata.rs
+++ b/arrow-schema/src/metadata.rs
@@ -128,6 +128,22 @@ impl Metadata {
         self.0 = None;
     }
 
+    /// Returns a reference to the underlying [`Arc`], or `None` if the map is empty.
+    ///
+    /// Useful for pointer-based deduplication (e.g. memory accounting) where
+    /// callers need to detect clones that share the same allocation.
+    pub fn as_arc(&self) -> Option<&Arc<BTreeMap<String, String>>> {
+        self.0.as_ref()
+    }
+
+    /// Consumes `self` and returns the underlying [`Arc`], or `None` if the map is empty.
+    ///
+    /// Useful for zero-copy conversion into wrapper types that also store an
+    /// `Arc<BTreeMap<String, String>>` internally.
+    pub fn into_arc(self) -> Option<Arc<BTreeMap<String, String>>> {
+        self.0
+    }
+
     /// Returns an iterator over the entries, sorted by key.
     pub fn iter(&self) -> MetadataIter<'_> {
         self.0
@@ -437,6 +453,30 @@ mod tests {
         metadata.extend([("a", "1"), ("b", "2")]);
         assert_eq!(metadata.len(), 2);
         assert!(clone.is_empty());
+    }
+
+    #[test]
+    fn test_as_arc_into_arc() {
+        let empty = Metadata::new();
+        assert!(empty.as_arc().is_none());
+        assert!(empty.into_arc().is_none());
+
+        // Non-empty metadata exposes the same Arc via as_arc / into_arc
+        let metadata = Metadata::from([("a", "1")]);
+        let arc_ref = metadata.as_arc().expect("non-empty");
+        assert_eq!(arc_ref.get("a").map(String::as_str), Some("1"));
+
+        let clone = metadata.clone();
+        // Clones share the same allocation
+        assert!(Arc::ptr_eq(
+            metadata.as_arc().unwrap(),
+            clone.as_arc().unwrap()
+        ));
+
+        let arc = metadata.into_arc().expect("non-empty");
+        assert_eq!(arc.get("a").map(String::as_str), Some("1"));
+        // into_arc gives back the same Arc (no copy)
+        assert!(Arc::ptr_eq(&arc, clone.as_arc().unwrap()));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10684.

# Rationale for this change

see #10684

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

two new method 
- `as_arc(&self) : Option<&Arc<BTreeMap<String, String>>>` returns a reference to the inner Arc (or None for empty).
- `into_arc(self) :Option<Arc<BTreeMap<String, String>>>` consumes self and hands back the Arc directly, enabling zero-copy conversions
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?

yes, new public methods `as_arc` & `into_arc` on Metadata.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
