### PR TITLE
implement `Metadata::retain`

### DIFF
--- a/arrow-schema/src/metadata.rs
+++ b/arrow-schema/src/metadata.rs
@@ -153,11 +153,15 @@ impl Metadata {
     /// remain in their original (sorted) order.
     ///
     /// Clones the underlying map if (and only if) it is shared.
-    pub fn retain<F>(&mut self, eq: F)
+    pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&String, &mut String) -> bool,
     {
-        Arc::make_mut(self.0.get_or_insert_default()).retain(eq);
+        let Some(map) = self.0.as_mut() else { return };
+        Arc::make_mut(map).retain(&mut f);
+        if map.is_empty() {
+            self.0 = None;
+        }
     }
 }
 
@@ -458,6 +462,7 @@ mod tests {
         assert_eq!(format!("{metadata:?}"), r#"{"a": "1", "b": "2"}"#);
         assert_eq!(format!("{:?}", Metadata::new()), "{}");
     }
+
     #[test]
     fn test_retain() {
         let mut metadata =
@@ -467,6 +472,21 @@ mod tests {
 
         let result_map = Metadata::from([("c", "3"), ("d", "4"), ("e", "5")]);
         assert_eq!(metadata, result_map)
+    }
+
+    #[test]
+    fn test_retain_empty() {
+        let mut metadata = Metadata::new();
+        metadata.retain(|_, _| -> bool { true });
+        assert!(metadata.is_empty())
+    }
+
+    #[test]
+    fn test_retain_all_removed() {
+        let mut metadata = Metadata::from([("a", "1"), ("b", "2"), ("c", "3")]);
+        metadata.retain(|_, _| false);
+        assert!(metadata.is_empty());
+        assert!(metadata.0.is_none());
     }
 
     #[test]

--- a/arrow-schema/src/metadata.rs
+++ b/arrow-schema/src/metadata.rs
@@ -146,6 +146,19 @@ impl Metadata {
     pub fn values(&self) -> impl Iterator<Item = &String> {
         self.iter().map(|(_, value)| value)
     }
+
+    /// Retains only the entries for which `f(&key, &mut value)` returns `true`.
+    ///
+    /// Entries for which `f` returns `false` are removed. Retained entries
+    /// remain in their original (sorted) order.
+    ///
+    /// Clones the underlying map if (and only if) it is shared.
+    pub fn retain<F>(&mut self, eq: F)
+    where
+        F: FnMut(&String, &mut String) -> bool,
+    {
+        Arc::make_mut(self.0.get_or_insert_default()).retain(eq);
+    }
 }
 
 /// Iterator over the entries of a [`Metadata`], sorted by key.
@@ -444,6 +457,35 @@ mod tests {
         let metadata = Metadata::from([("b", "2"), ("a", "1")]);
         assert_eq!(format!("{metadata:?}"), r#"{"a": "1", "b": "2"}"#);
         assert_eq!(format!("{:?}", Metadata::new()), "{}");
+    }
+    #[test]
+    fn test_retain() {
+        let mut metadata =
+            Metadata::from([("a", "1"), ("b", "2"), ("c", "3"), ("d", "4"), ("e", "5")]);
+
+        metadata.retain(|k, _| -> bool { k >= &String::from("c") });
+
+        let result_map = Metadata::from([("c", "3"), ("d", "4"), ("e", "5")]);
+        assert_eq!(metadata, result_map)
+    }
+
+    #[test]
+    fn test_retain_copy_on_write() {
+        let mut metadata = Metadata::from([("a", "1"), ("b", "2"), ("c", "3")]);
+        let clone = metadata.clone();
+
+        // both share the same Arc before any mutation:
+        assert!(Arc::ptr_eq(
+            metadata.0.as_ref().expect("non-empty"),
+            clone.0.as_ref().expect("non-empty"),
+        ));
+
+        // retain clones the shared map, leaving the clone untouched:
+        metadata.retain(|k, _| k != "a");
+        assert_eq!(metadata.len(), 2);
+        assert_eq!(clone.len(), 3);
+        assert!(!metadata.contains_key("a"));
+        assert!(clone.contains_key("a"));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10683.

# Rationale for this change

see #10683

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
implements `retain` on metadata. The underlying BTreeMap is allocation free unless the `Arc` pointer is shared
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
yes, new `retain` method on the metadata struct
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
