### PR TITLE
fix(arrow-arith): handle sliced boolean arrays in and_not

### DIFF
--- a/arrow-arith/src/boolean.rs
+++ b/arrow-arith/src/boolean.rs
@@ -290,8 +290,8 @@ pub fn or(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray, Arr
 /// assert_eq!(andn_ab, and(&a, &not(&b).unwrap()).unwrap());
 pub fn and_not(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray, ArrowError> {
     binary_boolean_kernel(left, right, |a, b| {
-        let buffer = buffer_bin_and_not(a.inner(), b.offset(), b.inner(), a.offset(), a.len());
-        BooleanBuffer::new(buffer, left.offset(), left.len())
+        let buffer = buffer_bin_and_not(a.inner(), a.offset(), b.inner(), b.offset(), a.len());
+        BooleanBuffer::new(buffer, 0, left.len())
     })
 }
 
@@ -392,6 +392,30 @@ mod tests {
 
         assert_eq!(c, expected);
         assert_eq!(c, and(&a, &not(&b).unwrap()).unwrap());
+    }
+
+    #[test]
+    fn test_bool_array_and_not_sliced() {
+        let a = BooleanArray::from(vec![true, false, true, false, true, false, true]);
+        let b = BooleanArray::from(vec![false, true, false, true, false, true, false]);
+        let a = a.slice(2, 3);
+        let b = b.slice(2, 3);
+        let a = a.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
+
+        assert_eq!(and_not(a, b).unwrap(), and(a, &not(b).unwrap()).unwrap());
+    }
+
+    #[test]
+    fn test_bool_array_and_not_sliced_different_offsets() {
+        let a = BooleanArray::from(vec![false, true, true, false, true, false, true]);
+        let b = BooleanArray::from(vec![true, false, false, true, false, true, false]);
+        let a = a.slice(1, 4);
+        let b = b.slice(2, 4);
+        let a = a.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
+
+        assert_eq!(and_not(a, b).unwrap(), and(a, &not(b).unwrap()).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10698

# Rationale for this change

`and_not` produced incorrect values for sliced `BooleanArray`s.

The implementation passed the left and right bitmap offsets to
`buffer_bin_and_not` in reverse order. It also reapplied `left.offset()` when
wrapping a buffer that had already been normalized to offset zero.

As a result, `and_not(left, right)` could differ from its documented
equivalent, `and(left, not(right))`, when the input arrays were slices.

# What changes are included in this PR?

- Pass the bitmap offsets to `buffer_bin_and_not` in the correct order.
- Wrap its normalized result with offset `0`.
- Add regression tests for sliced inputs with matching and different offsets.

# Are there any user-facing changes?

No API changes. This fixes incorrect results returned by the existing public
`and_not` API when called with sliced `BooleanArray`s.

# Tests

```text
cargo test -p arrow-arith and_not
cargo fmt --check