### PR TITLE
introduce take_n_true benchmark

### DIFF
--- a/arrow-array/benches/boolean_array.rs
+++ b/arrow-array/benches/boolean_array.rs
@@ -70,6 +70,19 @@ fn criterion_benchmark(c: &mut Criterion) {
         c.bench_function(&format!("has_false(nulls_all_true, {len})"), |b| {
             b.iter(|| hint::black_box(&with_nulls).has_false());
         });
+        // take_n_true: mixed true/false
+        let bool_vec: Vec<bool> = (0..len)
+            .map(|idx| if idx % 3 == 0 { false } else { true })
+            .collect();
+        let mixed_boolean_array_unique = BooleanArray::from(bool_vec.clone());
+        c.bench_function(&format!("take_n_true({})", len / 2), |b| {
+            b.iter(|| hint::black_box(&mixed_boolean_array_unique));
+        });
+        let mixed_boolean_array_shared = BooleanArray::from(bool_vec);
+        let shared_array = mixed_boolean_array_shared.clone();
+        c.bench_function(&format!("take_n_true({})", len / 2), |b| {
+            b.iter(|| hint::black_box(&shared_array));
+        });
     }
 }
 

--- a/arrow-array/benches/boolean_array.rs
+++ b/arrow-array/benches/boolean_array.rs
@@ -70,18 +70,27 @@ fn criterion_benchmark(c: &mut Criterion) {
         c.bench_function(&format!("has_false(nulls_all_true, {len})"), |b| {
             b.iter(|| hint::black_box(&with_nulls).has_false());
         });
+
         // take_n_true: mixed true/false
         let bool_vec: Vec<bool> = (0..len)
             .map(|idx| if idx % 3 == 0 { false } else { true })
             .collect();
-        let mixed_boolean_array_unique = BooleanArray::from(bool_vec.clone());
         c.bench_function(&format!("take_n_true({})", len / 2), |b| {
-            b.iter(|| hint::black_box(&mixed_boolean_array_unique));
+            b.iter_batched(
+                || BooleanArray::from(bool_vec.clone()), // fresh buffer, strong_count == 1
+                |arr| hint::black_box(arr).take_n_true(len / 2),
+                BatchSize::SmallInput,
+            );
         });
+        // underlying buffer is shared
         let mixed_boolean_array_shared = BooleanArray::from(bool_vec);
         let shared_array = mixed_boolean_array_shared.clone();
         c.bench_function(&format!("take_n_true({})", len / 2), |b| {
-            b.iter(|| hint::black_box(&shared_array));
+            b.iter_batched(
+                || shared_array.clone(), // strong_count >= 2, forces copy path
+                |arr| hint::black_box(arr).take_n_true(len / 2),
+                BatchSize::SmallInput,
+            );
         });
     }
 }

--- a/arrow-array/benches/boolean_array.rs
+++ b/arrow-array/benches/boolean_array.rs
@@ -72,9 +72,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         });
 
         // take_n_true: mixed true/false
-        let bool_vec: Vec<bool> = (0..len)
-            .map(|idx| if idx % 3 == 0 { false } else { true })
-            .collect();
+        let bool_vec: Vec<bool> = (0..len).map(|idx| idx % 3 != 0).collect();
         c.bench_function(&format!("take_n_true({})", len / 2), |b| {
             b.iter_batched(
                 || BooleanArray::from(bool_vec.clone()), // fresh buffer, strong_count == 1


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- works towards closing https://github.com/apache/arrow-rs/issues/10251.
- related to #10438

# Rationale for this change
see https://github.com/apache/arrow-rs/pull/10438#issuecomment-5305222033

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
adds benchmarks for `BooleanArray::take_first`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
n/a
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
