### PR TITLE
Expose `&Arc[Buffer]` in `GenericByteViewArray::data_buffers` for cheaper cloning

### DIFF
--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -238,14 +238,11 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
     /// # Safety
     ///
     /// Safe if [`Self::try_new`] would not error
-    pub unsafe fn new_unchecked<U>(
+    pub unsafe fn new_unchecked(
         views: ScalarBuffer<u128>,
-        buffers: U,
+        buffers: Arc<[Buffer]>,
         nulls: Option<NullBuffer>,
-    ) -> Self
-    where
-        U: Into<Arc<[Buffer]>>,
-    {
+    ) -> Self {
         if cfg!(feature = "force_validate") {
             return Self::new(views, buffers, nulls);
         }
@@ -254,7 +251,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
             data_type: T::DATA_TYPE,
             phantom: Default::default(),
             views,
-            buffers: buffers.into(),
+            buffers,
             nulls,
         }
     }
@@ -300,27 +297,14 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         &self.views
     }
 
-    /// Returns the buffers storing string data
+    /// Returns the shared collection of buffers storing non-inline string or binary data.
+    ///
+    /// The returned `Arc` can be cloned to share the buffers with another array without
+    /// allocating a new collection or cloning the individual buffers. To consume this
+    /// array and take ownership of its buffers, use [`Self::into_parts`].
     #[inline]
-    pub fn data_buffers(&self) -> &[Buffer] {
+    pub fn data_buffers(&self) -> &Arc<[Buffer]> {
         &self.buffers
-    }
-
-    /// Returns a cloned `Arc` of the buffers storing non-inline string or binary data.
-    ///
-    /// This is useful when needing to construct a new byte view array from this existing
-    /// array, but [`into_parts`] is not feasible (e.g. need to keep both arrays around),
-    /// and trying to reconstruct the buffers from [`data_buffers`] would require a
-    /// `Vec` allocation and cloning of each buffer element, which can be expensive
-    /// if there is a large number of buffers.
-    ///
-    /// This operation is `O(1)` and clones only the collection's `Arc`.
-    ///
-    /// [`into_parts`]: Self::into_parts
-    /// [`data_buffers`]: Self::data_buffers
-    #[inline]
-    pub fn data_buffers_cloned(&self) -> Arc<[Buffer]> {
-        Arc::clone(&self.buffers)
     }
 
     /// Returns the element at index `i`
@@ -555,7 +539,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
             return unsafe {
                 GenericByteViewArray::new_unchecked(
                     self.views().clone(),
-                    vec![], // empty data blocks
+                    Arc::from([]), // empty data blocks
                     nulls,
                 )
             };
@@ -570,7 +554,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
             return unsafe {
                 GenericByteViewArray::new_unchecked(
                     self.views().clone(),
-                    vec![], // empty data blocks
+                    Arc::from([]), // empty data blocks
                     nulls,
                 )
             };
@@ -669,7 +653,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         let views_scalar = ScalarBuffer::from(views_buf);
 
         // SAFETY: views_scalar, data_blocks, and nulls are correctly aligned and sized
-        unsafe { GenericByteViewArray::new_unchecked(views_scalar, data_blocks, nulls) }
+        unsafe { GenericByteViewArray::new_unchecked(views_scalar, data_blocks.into(), nulls) }
     }
 
     /// Copy the i‑th view into `data_buf` if it refers to an out‑of‑line buffer.
@@ -1648,7 +1632,7 @@ mod tests {
             gced.data_buffers().len()
         );
         // No output buffer may exceed the cap.
-        for buf in gced.data_buffers() {
+        for buf in gced.data_buffers().iter() {
             assert!(buf.len() <= max_buffer_size, "buffer exceeded max size");
         }
         // Every value (inline, large, and null) is unchanged and in order.

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -306,6 +306,16 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         &self.buffers
     }
 
+    /// Returns shared ownership of the buffers storing non-inline values
+    ///
+    /// This operation is `O(1)` and does not clone the individual buffers or
+    /// their contents. See [`Self::data_buffers`] to inspect the buffers
+    /// without taking shared ownership.
+    #[inline]
+    pub fn data_buffers_shared(&self) -> Arc<[Buffer]> {
+        Arc::clone(&self.buffers)
+    }
+
     /// Returns the element at index `i`
     ///
     /// Note: This method does not check for nulls and the value is arbitrary

--- a/arrow-array/src/array/byte_view_array.rs
+++ b/arrow-array/src/array/byte_view_array.rs
@@ -306,13 +306,20 @@ impl<T: ByteViewType + ?Sized> GenericByteViewArray<T> {
         &self.buffers
     }
 
-    /// Returns shared ownership of the buffers storing non-inline values
+    /// Returns a cloned `Arc` of the buffers storing non-inline string or binary data.
     ///
-    /// This operation is `O(1)` and does not clone the individual buffers or
-    /// their contents. See [`Self::data_buffers`] to inspect the buffers
-    /// without taking shared ownership.
+    /// This is useful when needing to construct a new byte view array from this existing
+    /// array, but [`into_parts`] is not feasible (e.g. need to keep both arrays around),
+    /// and trying to reconstruct the buffers from [`data_buffers`] would require a
+    /// `Vec` allocation and cloning of each buffer element, which can be expensive
+    /// if there is a large number of buffers.
+    ///
+    /// This operation is `O(1)` and clones only the collection's `Arc`.
+    ///
+    /// [`into_parts`]: Self::into_parts
+    /// [`data_buffers`]: Self::data_buffers
     #[inline]
-    pub fn data_buffers_shared(&self) -> Arc<[Buffer]> {
+    pub fn data_buffers_cloned(&self) -> Arc<[Buffer]> {
         Arc::clone(&self.buffers)
     }
 

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -500,7 +500,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
         }
         let views = std::mem::take(&mut self.views_buffer);
         // SAFETY: valid by construction
-        unsafe { GenericByteViewArray::new_unchecked(views.into(), completed, nulls) }
+        unsafe { GenericByteViewArray::new_unchecked(views.into(), completed.into(), nulls) }
     }
 
     /// Builds the [`GenericByteViewArray`] without resetting the builder
@@ -514,7 +514,7 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
         let views = ScalarBuffer::new(views, 0, len);
         let nulls = self.null_buffer_builder.finish_cloned();
         // SAFETY: valid by construction
-        unsafe { GenericByteViewArray::new_unchecked(views, completed, nulls) }
+        unsafe { GenericByteViewArray::new_unchecked(views, completed.into(), nulls) }
     }
 
     /// Returns the current null buffer as a slice

--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -1815,7 +1815,7 @@ mod tests_from_ffi {
     #[cfg(not(feature = "force_validate"))]
     fn test_utf8_view_ffi_from_dangling_pointer() {
         let empty = GenericByteViewBuilder::<StringViewType>::new().finish();
-        let buffers = empty.data_buffers().to_vec();
+        let buffers = Arc::clone(empty.data_buffers());
         let nulls = empty.nulls().cloned();
 
         // Create a dangling pointer to a view buffer with zero length.

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -3567,7 +3567,7 @@ mod tests {
         let array = unsafe {
             StringViewArray::new_unchecked(
                 binary_view_array.views().clone(),
-                binary_view_array.data_buffers().to_vec(),
+                Arc::clone(binary_view_array.data_buffers()),
                 binary_view_array.nulls().cloned(),
             )
         };

--- a/arrow-row/src/variable.rs
+++ b/arrow-row/src/variable.rs
@@ -375,7 +375,7 @@ fn decode_binary_view_inner<const VALIDATE_UTF8: bool>(
 
     // SAFETY:
     // Valid by construction above
-    unsafe { BinaryViewArray::new_unchecked(views.into(), [values.into()], nulls) }
+    unsafe { BinaryViewArray::new_unchecked(views.into(), [values.into()].into(), nulls) }
 }
 
 /// Decodes a binary view array from `rows` with the provided `options`

--- a/arrow-select/src/coalesce/byte_view.rs
+++ b/arrow-select/src/coalesce/byte_view.rs
@@ -501,8 +501,9 @@ impl<B: ByteViewType> InProgressArray for InProgressByteViewArray<B> {
 
         // Safety: we created valid views and buffers above and the
         // input arrays had value data and nulls
-        let new_array =
-            unsafe { GenericByteViewArray::<B>::new_unchecked(views.into(), buffers, nulls) };
+        let new_array = unsafe {
+            GenericByteViewArray::<B>::new_unchecked(views.into(), buffers.into(), nulls)
+        };
         Ok(Arc::new(new_array))
     }
 

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -934,7 +934,7 @@ fn filter_byte_view<T: ByteViewType>(
 ) -> GenericByteViewArray<T> {
     let new_view_buffer = filter_native(array.views(), predicate);
     let views = ScalarBuffer::new(new_view_buffer, 0, predicate.count);
-    let buffers = array.data_buffers().to_vec();
+    let buffers = array.data_buffers_shared();
     let nulls = predicate.filter_nulls(array.nulls());
 
     // SAFETY: each view is copied unchanged from `array.views()` and `buffers`
@@ -1297,6 +1297,9 @@ mod tests {
             let actual = filter(&array, &predicate).unwrap();
 
             assert_eq!(actual.len(), 3);
+            let actual_buffers = actual.as_byte_view::<T>().data_buffers_shared();
+            let input_buffers = array.data_buffers_shared();
+            assert!(Arc::ptr_eq(&actual_buffers, &input_buffers));
 
             let expected = {
                 // ["hello", null, "large payload over 12 bytes"]

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -934,7 +934,7 @@ fn filter_byte_view<T: ByteViewType>(
 ) -> GenericByteViewArray<T> {
     let new_view_buffer = filter_native(array.views(), predicate);
     let views = ScalarBuffer::new(new_view_buffer, 0, predicate.count);
-    let buffers = array.data_buffers_cloned();
+    let buffers = Arc::clone(array.data_buffers());
     let nulls = predicate.filter_nulls(array.nulls());
 
     // SAFETY: each view is copied unchanged from `array.views()` and `buffers`
@@ -1297,9 +1297,9 @@ mod tests {
             let actual = filter(&array, &predicate).unwrap();
 
             assert_eq!(actual.len(), 3);
-            let actual_buffers = actual.as_byte_view::<T>().data_buffers_cloned();
-            let input_buffers = array.data_buffers_cloned();
-            assert!(Arc::ptr_eq(&actual_buffers, &input_buffers));
+            let actual_buffers = actual.as_byte_view::<T>().data_buffers();
+            let input_buffers = array.data_buffers();
+            assert!(Arc::ptr_eq(actual_buffers, input_buffers));
 
             let expected = {
                 // ["hello", null, "large payload over 12 bytes"]

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -934,7 +934,7 @@ fn filter_byte_view<T: ByteViewType>(
 ) -> GenericByteViewArray<T> {
     let new_view_buffer = filter_native(array.views(), predicate);
     let views = ScalarBuffer::new(new_view_buffer, 0, predicate.count);
-    let buffers = array.data_buffers_shared();
+    let buffers = array.data_buffers_cloned();
     let nulls = predicate.filter_nulls(array.nulls());
 
     // SAFETY: each view is copied unchanged from `array.views()` and `buffers`
@@ -1297,8 +1297,8 @@ mod tests {
             let actual = filter(&array, &predicate).unwrap();
 
             assert_eq!(actual.len(), 3);
-            let actual_buffers = actual.as_byte_view::<T>().data_buffers_shared();
-            let input_buffers = array.data_buffers_shared();
+            let actual_buffers = actual.as_byte_view::<T>().data_buffers_cloned();
+            let input_buffers = array.data_buffers_cloned();
             assert!(Arc::ptr_eq(&actual_buffers, &input_buffers));
 
             let expected = {

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -340,7 +340,7 @@ fn interleave_views<T: ByteViewType>(
         .collect();
 
     let array = unsafe {
-        GenericByteViewArray::<T>::new_unchecked(views.into(), buffers, interleaved.nulls)
+        GenericByteViewArray::<T>::new_unchecked(views.into(), buffers.into(), interleaved.nulls)
     };
     Ok(Arc::new(array))
 }

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -636,7 +636,7 @@ fn take_byte_view<T: ByteViewType, IndexType: ArrowPrimitiveType>(
 ) -> Result<GenericByteViewArray<T>, ArrowError> {
     let new_views = take_native(array.views(), indices);
     let new_nulls = take_nulls(array.nulls(), indices);
-    let buffers = array.data_buffers_cloned();
+    let buffers = Arc::clone(array.data_buffers());
     // Safety:  array.views was valid, and take_native copies only valid values, and verifies bounds
     Ok(unsafe { GenericByteViewArray::new_unchecked(new_views, buffers, new_nulls) })
 }
@@ -1805,9 +1805,9 @@ mod tests {
         let actual = take(&array, &index, None).unwrap();
 
         assert_eq!(actual.len(), index.len());
-        let actual_buffers = actual.as_byte_view::<T>().data_buffers_cloned();
-        let input_buffers = array.data_buffers_cloned();
-        assert!(Arc::ptr_eq(&actual_buffers, &input_buffers));
+        let actual_buffers = actual.as_byte_view::<T>().data_buffers();
+        let input_buffers = array.data_buffers();
+        assert!(Arc::ptr_eq(actual_buffers, input_buffers));
 
         let expected = {
             // ["large payload over 12 bytes", null, "world", "large payload over 12 bytes", "lulu", null]

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -636,7 +636,7 @@ fn take_byte_view<T: ByteViewType, IndexType: ArrowPrimitiveType>(
 ) -> Result<GenericByteViewArray<T>, ArrowError> {
     let new_views = take_native(array.views(), indices);
     let new_nulls = take_nulls(array.nulls(), indices);
-    let buffers = array.data_buffers_shared();
+    let buffers = array.data_buffers_cloned();
     // Safety:  array.views was valid, and take_native copies only valid values, and verifies bounds
     Ok(unsafe { GenericByteViewArray::new_unchecked(new_views, buffers, new_nulls) })
 }
@@ -1805,8 +1805,8 @@ mod tests {
         let actual = take(&array, &index, None).unwrap();
 
         assert_eq!(actual.len(), index.len());
-        let actual_buffers = actual.as_byte_view::<T>().data_buffers_shared();
-        let input_buffers = array.data_buffers_shared();
+        let actual_buffers = actual.as_byte_view::<T>().data_buffers_cloned();
+        let input_buffers = array.data_buffers_cloned();
         assert!(Arc::ptr_eq(&actual_buffers, &input_buffers));
 
         let expected = {

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -636,10 +636,9 @@ fn take_byte_view<T: ByteViewType, IndexType: ArrowPrimitiveType>(
 ) -> Result<GenericByteViewArray<T>, ArrowError> {
     let new_views = take_native(array.views(), indices);
     let new_nulls = take_nulls(array.nulls(), indices);
+    let buffers = array.data_buffers_shared();
     // Safety:  array.views was valid, and take_native copies only valid values, and verifies bounds
-    Ok(unsafe {
-        GenericByteViewArray::new_unchecked(new_views, array.data_buffers().to_vec(), new_nulls)
-    })
+    Ok(unsafe { GenericByteViewArray::new_unchecked(new_views, buffers, new_nulls) })
 }
 
 /// `take` implementation for list arrays
@@ -1806,6 +1805,9 @@ mod tests {
         let actual = take(&array, &index, None).unwrap();
 
         assert_eq!(actual.len(), index.len());
+        let actual_buffers = actual.as_byte_view::<T>().data_buffers_shared();
+        let input_buffers = array.data_buffers_shared();
+        assert!(Arc::ptr_eq(&actual_buffers, &input_buffers));
 
         let expected = {
             // ["large payload over 12 bytes", null, "world", "large payload over 12 bytes", "lulu", null]

--- a/arrow/benches/take_kernels.rs
+++ b/arrow/benches/take_kernels.rs
@@ -17,11 +17,10 @@
 
 #[macro_use]
 extern crate criterion;
-use criterion::{BenchmarkId, Criterion};
+use criterion::Criterion;
 
 use rand::RngExt;
 
-use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::compute::{TakeOptions, take, take_record_batch};
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
@@ -70,26 +69,6 @@ fn bench_take_record_batch(batch: &RecordBatch, indices: &UInt32Array) {
 
 fn bench_take_bounds_check(values: &dyn Array, indices: &UInt32Array) {
     hint::black_box(take(values, indices, Some(TakeOptions { check_bounds: true })).unwrap());
-}
-
-/// Creates an array whose buffer entries all share the same payload allocation.
-///
-/// Views reference every entry in turn, isolating the cost of cloning the buffer
-/// collection from the size of the underlying string payload.
-fn create_string_view_array_with_buffers(size: usize, buffer_count: usize) -> StringViewArray {
-    const VALUE: &[u8] = b"a string longer than twelve bytes";
-
-    let buffer = Buffer::from(VALUE);
-    let buffers = vec![buffer; buffer_count];
-    let views = (0..size)
-        .map(|i| {
-            ByteView::new(VALUE.len() as u32, &VALUE[..4])
-                .with_buffer_index((i % buffer_count) as u32)
-                .as_u128()
-        })
-        .collect::<ScalarBuffer<_>>();
-
-    StringViewArray::new(views, buffers, None)
 }
 
 fn add_benchmark(c: &mut Criterion) {
@@ -226,18 +205,6 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("take stringview null values null indices 1024", |b| {
         b.iter(|| bench_take(&values, &indices))
     });
-
-    let indices = create_random_index(8192, 0.0);
-    let mut group = c.benchmark_group("take stringview by buffer count");
-    for buffer_count in [1, 16, 256, 4096] {
-        let values = create_string_view_array_with_buffers(8192, buffer_count);
-        group.bench_with_input(
-            BenchmarkId::from_parameter(buffer_count),
-            &buffer_count,
-            |b, _| b.iter(|| bench_take(&values, &indices)),
-        );
-    }
-    group.finish();
 
     let values = create_primitive_list_array::<i32, Int32Type>(512, 0.0, 0.0, 20);
     let indices = create_random_index(512, 0.0);

--- a/arrow/benches/take_kernels.rs
+++ b/arrow/benches/take_kernels.rs
@@ -17,10 +17,11 @@
 
 #[macro_use]
 extern crate criterion;
-use criterion::Criterion;
+use criterion::{BenchmarkId, Criterion};
 
 use rand::RngExt;
 
+use arrow::buffer::{Buffer, ScalarBuffer};
 use arrow::compute::{TakeOptions, take, take_record_batch};
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
@@ -69,6 +70,26 @@ fn bench_take_record_batch(batch: &RecordBatch, indices: &UInt32Array) {
 
 fn bench_take_bounds_check(values: &dyn Array, indices: &UInt32Array) {
     hint::black_box(take(values, indices, Some(TakeOptions { check_bounds: true })).unwrap());
+}
+
+/// Creates an array whose buffer entries all share the same payload allocation.
+///
+/// Views reference every entry in turn, isolating the cost of cloning the buffer
+/// collection from the size of the underlying string payload.
+fn create_string_view_array_with_buffers(size: usize, buffer_count: usize) -> StringViewArray {
+    const VALUE: &[u8] = b"a string longer than twelve bytes";
+
+    let buffer = Buffer::from(VALUE);
+    let buffers = vec![buffer; buffer_count];
+    let views = (0..size)
+        .map(|i| {
+            ByteView::new(VALUE.len() as u32, &VALUE[..4])
+                .with_buffer_index((i % buffer_count) as u32)
+                .as_u128()
+        })
+        .collect::<ScalarBuffer<_>>();
+
+    StringViewArray::new(views, buffers, None)
 }
 
 fn add_benchmark(c: &mut Criterion) {
@@ -205,6 +226,18 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("take stringview null values null indices 1024", |b| {
         b.iter(|| bench_take(&values, &indices))
     });
+
+    let indices = create_random_index(8192, 0.0);
+    let mut group = c.benchmark_group("take stringview by buffer count");
+    for buffer_count in [1, 16, 256, 4096] {
+        let values = create_string_view_array_with_buffers(8192, buffer_count);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(buffer_count),
+            &buffer_count,
+            |b, _| b.iter(|| bench_take(&values, &indices)),
+        );
+    }
+    group.finish();
 
     let values = create_primitive_list_array::<i32, Int32Type>(512, 0.0, 0.0, 20);
     let indices = create_random_index(512, 0.0);

--- a/parquet/src/arrow/buffer/view_buffer.rs
+++ b/parquet/src/arrow/buffer/view_buffer.rs
@@ -57,14 +57,15 @@ impl ViewBuffer {
         let len = self.views.len();
         let views = ScalarBuffer::from(self.views);
         let nulls = null_buffer.and_then(|b| NullBuffer::from_unsliced_buffer(b, len));
+        let buffers = self.buffers.into();
         match data_type {
             ArrowType::Utf8View => {
                 // Safety: views were created correctly, and checked that the data is utf8 when building the buffer
-                unsafe { Arc::new(StringViewArray::new_unchecked(views, self.buffers, nulls)) }
+                unsafe { Arc::new(StringViewArray::new_unchecked(views, buffers, nulls)) }
             }
             ArrowType::BinaryView => {
                 // Safety: views were created correctly
-                unsafe { Arc::new(BinaryViewArray::new_unchecked(views, self.buffers, nulls)) }
+                unsafe { Arc::new(BinaryViewArray::new_unchecked(views, buffers, nulls)) }
             }
             _ => panic!("Unsupported data type: {data_type}"),
         }

--- a/parquet/tests/arrow_reader/invalid_utf8.rs
+++ b/parquet/tests/arrow_reader/invalid_utf8.rs
@@ -125,7 +125,7 @@ fn test_invalid_utf8_string_view_array() {
             let array = unsafe {
                 StringViewArray::new_unchecked(
                     array.views().clone(),
-                    array.data_buffers().to_vec(),
+                    Arc::clone(array.data_buffers()),
                     array.nulls().cloned(),
                 )
             };


### PR DESCRIPTION
# Which issue does this PR close?

- Related to #10692.

# Rationale for this change

This change follows directly from the existing ByteView design history:

- #6408 traced slow ByteView slicing to allocating and cloning the backing-buffer list. The discussion specifically identified `take` as another operation that would benefit from sharing this list.
- #6427 distinguished two related but separate concerns: very large buffer lists may indicate missing GC or deduplication, but avoiding allocation when an operation retains the complete list is independently worthwhile.
- #6808 demonstrated why eager deduplication in a general-purpose path is a different tradeoff: it added substantial overhead to common operations, and review favored treating ByteView compaction more holistically.
- #9016 subsequently changed `GenericByteViewArray` to store the collection as `Arc<[Buffer]>`, making it possible to share the complete list without allocation.

The downstream impact is concrete. [apache/datafusion#16206](https://github.com/apache/datafusion/issues/16206) describes hash joins where concatenating build-side batches produces ByteView payload columns with many backing buffers, and constructing join output repeatedly calls `take`. In that pattern, cloning and later dropping every buffer handle can become a significant part of execution time. Arrow issue #10692 provides a compact multi-stage `take` and `BatchCoalescer` reproduction of the same ownership-metadata amplification.

`take_byte_view` and `filter_byte_view` do not yet use this shared representation. They rebuild the collection with `data_buffers().to_vec()`, allocating a new collection and cloning every `Buffer`. This makes the ownership bookkeeping for selection O(number of backing buffers), despite retaining exactly the same complete buffer list.

Selection already copies the chosen views while leaving their payloads zero-copy. The cost of retaining the unchanged backing-buffer collection should therefore not grow with the number of entries in that collection. This PR completes that narrow part of the earlier design while leaving buffer canonicalization as a separate problem.

# What changes are included in this PR?

- Change `GenericByteViewArray::data_buffers()` to return `&Arc<[Buffer]>`, allowing callers to inspect the buffers as before or clone the collection's `Arc` in O(1).
- Change `GenericByteViewArray::new_unchecked` to accept `Arc<[Buffer]>` directly, making shared versus newly constructed buffer-list ownership explicit at each call site.
- Use `Arc::clone` in the ByteView `take` and `filter` kernels instead of rebuilding the collection.
- Replace three additional `data_buffers().to_vec()` call sites found by the stricter constructor signature with shared `Arc` clones.
- Verify for both StringView and BinaryView that selection results share the input buffer collection.

This PR only removes repeated ownership-metadata cloning. It retains the same complete collection of backing buffers as before. It does not prune or deduplicate buffer entries, remap views, run GC, or copy string/binary payloads. The broader buffer-fragmentation problem described in #10692 remains separate.

# Are these changes tested?

```shell
cargo fmt --all -- --check
cargo check --workspace --all-targets
cargo test -p arrow-array -p arrow-select -p arrow-row -p arrow-ipc
cargo test -p parquet --test arrow_reader invalid_utf8
cargo clippy -p arrow-array -p arrow-select -p arrow-row -p arrow-ipc -p parquet --all-targets --all-features -- -D warnings
cargo doc -p arrow-array --no-deps
```

A temporary local Criterion benchmark was used to validate the asymptotic behavior. It takes 8,192 views distributed across a varying number of buffer entries. The entries share one immutable payload allocation, isolating collection-ownership cost from payload size. `main` and this PR were built in separate Cargo target directories on an Intel Xeon Platinum 8474C:

| Buffer entries | `main` | This PR | Speedup |
|---:|---:|---:|---:|
| 1 | 5.4900 us | 5.4619 us | 1.01x |
| 16 | 5.7342 us | 5.4577 us | 1.05x |
| 256 | 9.2806 us | 5.4518 us | 1.70x |
| 4,096 | 65.774 us | 5.4584 us | 12.05x |

Existing normal-size benchmarks did not regress:

| Benchmark | `main` | This PR |
|---|---:|---:|
| `take stringview 512` | 504.73 ns | 439.40 ns |
| `take stringview 1024` | 872.36 ns | 773.48 ns |
| `filter context mixed string view (kept 1/2)` | 73.406 us | 72.083 us |

# Are there any user-facing changes?

There are two public signature changes. `data_buffers()` now returns `&Arc<[Buffer]>` instead of `&[Buffer]`; slice methods remain available through deref, while direct `for` iteration can use `.iter()`. `new_unchecked` now requires `Arc<[Buffer]>`; callers constructing a `Vec<Buffer>` can convert it with `.into()`. ByteView selection results now share the immutable backing-buffer collection instead of allocating an equivalent collection. Logical values, null handling, buffer indexes, payload lifetimes, and GC behavior are unchanged.

# AI assistance

I used OpenAI Codex to help inspect the relevant implementation history, draft the patch and tests, and prepare the benchmark harness and PR text. I reviewed the implementation and benchmark methodology and ran the checks above locally.
