### PR TITLE
Enable `allow_attributes` lint for `parquet`

### DIFF
--- a/parquet/benches/arrow_reader_clickbench.rs
+++ b/parquet/benches/arrow_reader_clickbench.rs
@@ -654,7 +654,7 @@ impl ClickBenchPredicate {
     }
 
     /// Create Predicate: col LIKE '%Google%'
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     fn like_Google(column_index: usize) -> Self {
         Self::new(column_index, move || {
             let google_url = StringViewArray::new_scalar("%Google%");

--- a/parquet/benches/arrow_reader_peak_memory.rs
+++ b/parquet/benches/arrow_reader_peak_memory.rs
@@ -84,7 +84,7 @@ fn add_allocated_bytes(size: usize) {
     });
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 unsafe impl std::alloc::GlobalAlloc for TrackingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let ptr = unsafe { self.inner.alloc(layout) };

--- a/parquet/src/arrow/array_reader/map_array.rs
+++ b/parquet/src/arrow/array_reader/map_array.rs
@@ -29,7 +29,6 @@ pub struct MapArrayReader {
 }
 
 impl MapArrayReader {
-    #[allow(rustdoc::private_intra_doc_links)]
     /// Creates a new [`MapArrayReader`] with a `def_level`, `rep_level` and `nullable`
     /// as defined on [`ParquetField`][crate::arrow::schema::ParquetField]
     pub fn new(

--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -56,9 +56,9 @@ use crate::file::metadata::RowGroupMetaData;
 pub use builder::{ArrayReaderBuilder, CacheOptions, CacheOptionsBuilder};
 pub use byte_array::make_byte_array_reader;
 pub use byte_array_dictionary::make_byte_array_dictionary_reader;
-#[allow(unused_imports)] // Only used for benchmarks
+#[cfg_attr(not(feature = "experimental"), expect(unused_imports))]
 pub use byte_view_array::make_byte_view_array_reader;
-#[allow(unused_imports)] // Only used for benchmarks
+#[cfg_attr(not(feature = "experimental"), expect(unused_imports))]
 pub use fixed_len_byte_array::make_fixed_len_byte_array_reader;
 pub use fixed_size_list_array::FixedSizeListArrayReader;
 pub use list_array::ListArrayReader;
@@ -88,7 +88,6 @@ pub use struct_array::StructArrayReader;
 pub trait ArrayReader: Send {
     // TODO: this function is never used, and the trait is not public. Perhaps this should be
     // removed.
-    #[allow(dead_code)]
     fn as_any(&self) -> &dyn Any;
 
     /// Returns the arrow type of this array reader.

--- a/parquet/src/arrow/array_reader/primitive_array.rs
+++ b/parquet/src/arrow/array_reader/primitive_array.rs
@@ -466,7 +466,7 @@ mod tests {
     use rand::distr::uniform::SampleUniform;
     use std::collections::VecDeque;
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn make_column_chunks<T: DataType>(
         column_desc: ColumnDescPtr,
         encoding: Encoding,

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -323,7 +323,6 @@ impl Storage for ByteArrayStorage {
         key as u64
     }
 
-    #[allow(dead_code)] // not used in parquet_derive, so is dead there
     fn estimated_memory_size(&self) -> usize {
         self.page.capacity() * std::mem::size_of::<u8>()
             + self.values.capacity() * std::mem::size_of::<std::ops::Range<usize>>()

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -4057,7 +4057,7 @@ mod tests {
     #[test]
     fn arrow_writer_string_dictionary() {
         // define schema
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let schema = Arc::new(Schema::new(vec![Field::new_dict(
             "dictionary",
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
@@ -4310,7 +4310,7 @@ mod tests {
     #[test]
     fn arrow_writer_primitive_dictionary() {
         // define schema
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let schema = Arc::new(Schema::new(vec![Field::new_dict(
             "dictionary",
             DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::UInt32)),
@@ -4421,7 +4421,7 @@ mod tests {
     #[test]
     fn arrow_writer_string_dictionary_unsigned_index() {
         // define schema
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let schema = Arc::new(Schema::new(vec![Field::new_dict(
             "dictionary",
             DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::Utf8)),

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -58,7 +58,6 @@ mod store;
 
 use crate::DecodeResult;
 use crate::arrow::push_decoder::{ParquetPushDecoder, ParquetPushDecoderBuilder, PushDecoderInput};
-#[allow(deprecated)]
 #[cfg(feature = "object_store")]
 pub use store::*;
 

--- a/parquet/src/arrow/async_reader/store.rs
+++ b/parquet/src/arrow/async_reader/store.rs
@@ -66,7 +66,7 @@ pub struct ParquetObjectReader {
     runtime: Option<Handle>,
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl ParquetObjectReader {
     /// Creates a new [`ParquetObjectReader`] for the provided [`ObjectStore`] and [`Path`].
     pub fn new(store: Arc<dyn ObjectStore>, path: Path) -> Self {
@@ -177,7 +177,7 @@ impl ParquetObjectReader {
     }
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl MetadataSuffixFetch for &mut ParquetObjectReader {
     fn fetch_suffix(&mut self, suffix: usize) -> BoxFuture<'_, Result<Bytes>> {
         let options = GetOptions {
@@ -194,7 +194,7 @@ impl MetadataSuffixFetch for &mut ParquetObjectReader {
     }
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl AsyncFileReader for ParquetObjectReader {
     fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes>> {
         self.spawn(|store, path| store.get_range(path, range).boxed())
@@ -257,7 +257,7 @@ impl AsyncFileReader for ParquetObjectReader {
 }
 
 #[cfg(test)]
-#[allow(deprecated)]
+#[expect(deprecated)]
 mod tests {
     use crate::arrow::async_reader::ArrowReaderOptions;
     use crate::file::metadata::PageIndexPolicy;

--- a/parquet/src/arrow/async_writer/mod.rs
+++ b/parquet/src/arrow/async_writer/mod.rs
@@ -60,7 +60,6 @@
 
 #[cfg(feature = "object_store")]
 mod store;
-#[allow(deprecated)]
 #[cfg(feature = "object_store")]
 pub use store::*;
 

--- a/parquet/src/arrow/async_writer/store.rs
+++ b/parquet/src/arrow/async_writer/store.rs
@@ -84,7 +84,7 @@ pub struct ParquetObjectWriter {
     w: BufWriter,
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl ParquetObjectWriter {
     /// Create a new [`ParquetObjectWriter`] that writes to the specified path in the given store.
     ///
@@ -104,7 +104,7 @@ impl ParquetObjectWriter {
     }
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl AsyncFileWriter for ParquetObjectWriter {
     fn write(&mut self, bs: Bytes) -> BoxFuture<'_, Result<()>> {
         Box::pin(async {
@@ -124,14 +124,14 @@ impl AsyncFileWriter for ParquetObjectWriter {
         })
     }
 }
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl From<BufWriter> for ParquetObjectWriter {
     fn from(w: BufWriter) -> Self {
         Self::from_buf_writer(w)
     }
 }
 #[cfg(test)]
-#[allow(deprecated)]
+#[expect(deprecated)]
 mod tests {
     use arrow_array::{ArrayRef, Int64Array, RecordBatch};
     use object_store::memory::InMemory;

--- a/parquet/src/arrow/buffer/dictionary_buffer.rs
+++ b/parquet/src/arrow/buffer/dictionary_buffer.rs
@@ -39,7 +39,7 @@ pub enum DictionaryBuffer<K: ArrowNativeType, V: OffsetSizeTrait> {
 }
 
 impl<K: ArrowNativeType + Ord, V: OffsetSizeTrait> DictionaryBuffer<K, V> {
-    #[allow(unused)]
+    #[cfg_attr(not(test), expect(unused))]
     pub fn len(&self) -> usize {
         match self {
             Self::Dict { keys, .. } => keys.len(),

--- a/parquet/src/arrow/record_reader/definition_levels.rs
+++ b/parquet/src/arrow/record_reader/definition_levels.rs
@@ -385,7 +385,7 @@ impl PackedDecoder {
         self.packed_offset = 0;
         self.packed_count = match encoding {
             Encoding::RLE => 0,
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             Encoding::BIT_PACKED => data.len() * 8,
             _ => unreachable!("invalid level encoding: {}", encoding),
         };

--- a/parquet/src/arrow/record_reader/mod.rs
+++ b/parquet/src/arrow/record_reader/mod.rs
@@ -174,7 +174,7 @@ where
     }
 
     /// Returns number of records stored in buffer.
-    #[allow(unused)]
+    #[cfg_attr(not(test), expect(unused))]
     pub fn num_records(&self) -> usize {
         self.num_records
     }

--- a/parquet/src/arrow/schema/complex.rs
+++ b/parquet/src/arrow/schema/complex.rs
@@ -749,11 +749,11 @@ fn convert_field(
     match arrow_hint {
         Some(hint) => {
             // If the inferred type is a dictionary, preserve dictionary metadata
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let field = match (&data_type, hint.dict_id(), hint.dict_is_ordered()) {
                 (DataType::Dictionary(_, _), Some(id), Some(ordered)) =>
                 {
-                    #[allow(deprecated)]
+                    #[expect(deprecated)]
                     Field::new_dict(name, data_type, nullable, id, ordered)
                 }
                 _ => Field::new(name, data_type, nullable),

--- a/parquet/src/arrow/schema/mod.rs
+++ b/parquet/src/arrow/schema/mod.rs
@@ -2103,7 +2103,7 @@ mod tests {
                 // Field::new("c28", DataType::Duration(TimeUnit::Millisecond), false),
                 // Field::new("c29", DataType::Duration(TimeUnit::Microsecond), false),
                 // Field::new("c30", DataType::Duration(TimeUnit::Nanosecond), false),
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 Field::new_dict(
                     "c31",
                     DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),

--- a/parquet/src/arrow/schema/primitive.rs
+++ b/parquet/src/arrow/schema/primitive.rs
@@ -170,7 +170,7 @@ fn decimal_256_type(scale: i32, precision: i32) -> Result<DataType> {
     Ok(DataType::Decimal256(precision, scale))
 }
 
-#[allow(clippy::manual_range_contains)]
+#[expect(clippy::manual_range_contains)]
 fn check_decimal_length(type_length: i32) -> Result<()> {
     if type_length < 1 || type_length > 32 {
         return Err(ParquetError::General(format!(

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -460,7 +460,7 @@ impl FromStr for Encoding {
             "PLAIN" | "plain" => Ok(Encoding::PLAIN),
             "PLAIN_DICTIONARY" | "plain_dictionary" => Ok(Encoding::PLAIN_DICTIONARY),
             "RLE" | "rle" => Ok(Encoding::RLE),
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             "BIT_PACKED" | "bit_packed" => Ok(Encoding::BIT_PACKED),
             "DELTA_BINARY_PACKED" | "delta_binary_packed" => Ok(Encoding::DELTA_BINARY_PACKED),
             "DELTA_LENGTH_BYTE_ARRAY" | "delta_length_byte_array" => {
@@ -596,7 +596,7 @@ impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for EncodingMask {
     }
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 fn i32_to_encoding(val: i32) -> Encoding {
     match val {
         0 => Encoding::PLAIN,
@@ -658,7 +658,7 @@ enum CompressionCodec {
 /// worse compression ratios. However, it is not as widely supported by the ecosystem, with the
 /// Hadoop ecosystem historically favoring the non-standard and now deprecated [`Compression::LZ4`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub enum Compression {
     /// No compression.
     UNCOMPRESSED,
@@ -976,7 +976,7 @@ union BloomFilterCompression {
 ///
 /// See [`ColumnOrder`] for more information.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub enum SortOrder {
     /// Signed (either value or legacy byte-wise) comparison.
     SIGNED,
@@ -1021,7 +1021,7 @@ impl SortOrder {
 ///
 /// [`ColumnOrder`]: https://github.com/apache/parquet-format/blob/2076361bb64e2de9ca6a8d06eda025a6fa4e9df6/src/main/thrift/parquet.thrift#L1103
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub enum ColumnOrder {
     /// Column uses the order defined by its logical or physical type
     /// (if there is no logical type), parquet-format 2.4.0+.
@@ -1451,7 +1451,7 @@ impl str::FromStr for LogicalType {
 }
 
 #[cfg(test)]
-#[allow(deprecated)] // allow BIT_PACKED encoding for the whole test module
+#[expect(deprecated)] // allow BIT_PACKED encoding for the whole test module
 mod tests {
     use super::*;
     use crate::parquet_thrift::{ThriftSliceInputProtocol, tests::test_roundtrip};

--- a/parquet/src/bin/parquet-rewrite.rs
+++ b/parquet/src/bin/parquet-rewrite.rs
@@ -132,7 +132,7 @@ enum EncodingArgs {
     ByteStreamSplit,
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl From<EncodingArgs> for Encoding {
     fn from(value: EncodingArgs) -> Self {
         match value {

--- a/parquet/src/column/chunker/cdc.rs
+++ b/parquet/src/column/chunker/cdc.rs
@@ -324,7 +324,6 @@ impl ContentDefinedChunker {
             //   def_levels:    [1, 0, 1, 0, 1]
             //   level:          0  1  2  3  4
             //   value_offset:   0     1     2  (only increments on def==1)
-            #[allow(clippy::needless_range_loop)]
             for offset in 0..num_levels {
                 let def_level = def_levels
                     .value_at(offset)

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -606,7 +606,7 @@ fn parse_v1_level(
             }
             Err(general_err!("not enough data to read levels"))
         }
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         Encoding::BIT_PACKED => {
             let bit_width = num_required_bits(max_level as u64);
             let num_bytes = ceil(num_buffered_values as usize * bit_width as usize, 8);
@@ -1290,7 +1290,7 @@ mod tests {
 
         // Helper function for the general case of `read_batch()` where `values`,
         // `def_levels` and `rep_levels` are always provided with enough space.
-        #[allow(clippy::too_many_arguments)]
+        #[expect(clippy::too_many_arguments)]
         fn test_read_batch_general(
             &mut self,
             desc: ColumnDescPtr,
@@ -1309,7 +1309,7 @@ mod tests {
 
         // Helper function to test `read_batch()` method with custom buffers for values,
         // definition and repetition levels.
-        #[allow(clippy::too_many_arguments)]
+        #[expect(clippy::too_many_arguments)]
         fn test_read_batch(
             &mut self,
             desc: ColumnDescPtr,

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -273,7 +273,7 @@ impl LevelDecoder {
                 decoder.set_data(data)?;
                 Ok(Self::Rle(decoder))
             }
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             Encoding::BIT_PACKED => Ok(Self::Packed(BitReader::new(data), bit_width)),
             _ => unreachable!("invalid level encoding: {}", encoding),
         }

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -539,7 +539,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn write_batch_internal(
         &mut self,
         values: &E::Values,
@@ -830,7 +830,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     /// `#[inline(never)]` keeps this slow path — only reached for
     /// variable-width columns whose values need page splitting — out of
     /// the hot `write_batch_internal` loop.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     #[inline(never)]
     fn write_granular_chunk(
         &mut self,
@@ -1725,7 +1725,7 @@ fn update_max<T: ParquetValueType>(descr: &ColumnDescriptor, val: &T, max: &mut 
 }
 
 #[inline]
-#[allow(clippy::eq_op)]
+#[expect(clippy::eq_op)]
 fn is_nan<T: ParquetValueType>(basic_type_info: &BasicTypeInfo, val: &T) -> bool {
     match T::PHYSICAL_TYPE {
         Type::FLOAT | Type::DOUBLE => val != val,

--- a/parquet/src/compression.rs
+++ b/parquet/src/compression.rs
@@ -147,7 +147,24 @@ pub(crate) trait CompressionLevel<T: std::fmt::Display + std::cmp::PartialOrd> {
 /// bytes for the compression type.
 /// This returns `None` if the codec type is `UNCOMPRESSED`.
 pub fn create_codec(codec: CodecType, _options: &CodecOptions) -> Result<Option<Box<dyn Codec>>> {
-    #[allow(unreachable_code, unused_variables)]
+    #[cfg_attr(
+        any(
+            test,
+            feature = "brotli",
+            feature = "flate2",
+            feature = "lz4",
+            feature = "snap",
+            feature = "zstd"
+        ),
+        expect(unreachable_code)
+    )]
+    #[cfg_attr(
+        all(
+            not(test),
+            not(all(feature = "brotli", feature = "flate2", feature = "zstd"))
+        ),
+        expect(unused_variables)
+    )]
     match codec {
         CodecType::BROTLI(level) => {
             #[cfg(any(feature = "brotli", test))]

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -564,7 +564,6 @@ impl AsBytes for [u8] {
 macro_rules! gen_as_bytes {
     ($source_ty:ident) => {
         impl AsBytes for $source_ty {
-            #[allow(clippy::size_of_in_element_count)]
             fn as_bytes(&self) -> &[u8] {
                 // SAFETY: macro is only used with primitive types that have no padding, so the
                 // resulting slice always refers to initialized memory.
@@ -579,7 +578,6 @@ macro_rules! gen_as_bytes {
 
         impl SliceAsBytes for $source_ty {
             #[inline]
-            #[allow(clippy::size_of_in_element_count)]
             fn slice_as_bytes(self_: &[Self]) -> &[u8] {
                 // SAFETY: macro is only used with primitive types that have no padding, so the
                 // resulting slice always refers to initialized memory.
@@ -592,7 +590,6 @@ macro_rules! gen_as_bytes {
             }
 
             #[inline]
-            #[allow(clippy::size_of_in_element_count)]
             unsafe fn slice_as_bytes_mut(self_: &mut [Self]) -> &mut [u8] {
                 // SAFETY: macro is only used with primitive types that have no padding, so the
                 // resulting slice always refers to initialized memory. Moreover, self has no

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -1327,7 +1327,7 @@ mod tests {
         );
 
         // unsupported
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         create_and_check_decoder::<Int32Type>(
             Encoding::BIT_PACKED,
             Some(nyi_err!("Encoding BIT_PACKED is not supported")),
@@ -2322,14 +2322,12 @@ mod tests {
 
     /// A util trait to convert slices of different types to byte arrays
     trait ToByteArray<T: DataType> {
-        #[allow(clippy::wrong_self_convention)]
         fn to_byte_array(data: &[T::T]) -> Vec<u8>;
     }
 
     macro_rules! to_byte_array_impl {
         ($ty: ty) => {
             impl ToByteArray<$ty> for $ty {
-                #[allow(clippy::wrong_self_convention)]
                 fn to_byte_array(data: &[<$ty as DataType>::T]) -> Vec<u8> {
                     <$ty as DataType>::T::slice_as_bytes(data).to_vec()
                 }
@@ -2343,7 +2341,6 @@ mod tests {
     to_byte_array_impl!(DoubleType);
 
     impl ToByteArray<BoolType> for BoolType {
-        #[allow(clippy::wrong_self_convention)]
         fn to_byte_array(data: &[bool]) -> Vec<u8> {
             let mut v = vec![];
             for (i, item) in data.iter().enumerate() {
@@ -2359,7 +2356,6 @@ mod tests {
     }
 
     impl ToByteArray<Int96Type> for Int96Type {
-        #[allow(clippy::wrong_self_convention)]
         fn to_byte_array(data: &[Int96]) -> Vec<u8> {
             let mut v = vec![];
             for d in data {
@@ -2370,7 +2366,6 @@ mod tests {
     }
 
     impl ToByteArray<ByteArrayType> for ByteArrayType {
-        #[allow(clippy::wrong_self_convention)]
         fn to_byte_array(data: &[ByteArray]) -> Vec<u8> {
             let mut v = vec![];
             for d in data {
@@ -2384,7 +2379,6 @@ mod tests {
     }
 
     impl ToByteArray<FixedLenByteArrayType> for FixedLenByteArrayType {
-        #[allow(clippy::wrong_self_convention)]
         fn to_byte_array(data: &[FixedLenByteArray]) -> Vec<u8> {
             let mut v = vec![];
             for d in data {
@@ -2397,7 +2391,7 @@ mod tests {
 
     #[test]
     // Allow initializing a vector and pushing to it for clarity in this test
-    #[allow(clippy::vec_init_then_push)]
+    #[expect(clippy::vec_init_then_push)]
     fn test_delta_bit_packed_invalid_bit_width() {
         // Manually craft a buffer with an invalid bit width
         let mut buffer = vec![];

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -796,7 +796,7 @@ mod tests {
         );
 
         // unsupported
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         create_and_check_encoder::<Int32Type>(
             0,
             Encoding::BIT_PACKED,

--- a/parquet/src/encodings/levels.rs
+++ b/parquet/src/encodings/levels.rs
@@ -126,7 +126,7 @@ impl LevelEncoder {
     /// Finalizes level encoder, flush all intermediate buffers and return resulting
     /// encoded buffer. Returned buffer is already truncated to encoded bytes only.
     #[inline]
-    #[allow(unused)]
+    #[cfg_attr(all(not(feature = "experimental"), not(test)), expect(unused))]
     pub fn consume(self) -> Vec<u8> {
         match self {
             LevelEncoder::Rle(encoder) => {

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -82,7 +82,7 @@ pub struct RleEncoder {
 }
 
 impl RleEncoder {
-    #[allow(unused)]
+    #[cfg_attr(all(not(feature = "experimental"), not(test)), expect(unused))]
     pub fn new(bit_width: u8, buffer_len: usize) -> Self {
         let buffer = Vec::with_capacity(buffer_len);
         RleEncoder::new_from_buf(bit_width, buffer)
@@ -185,7 +185,7 @@ impl RleEncoder {
     }
 
     #[inline]
-    #[allow(unused)]
+    #[cfg_attr(not(feature = "experimental"), expect(unused))]
     pub fn buffer(&self) -> &[u8] {
         self.bit_writer.buffer()
     }
@@ -195,7 +195,7 @@ impl RleEncoder {
         self.bit_writer.bytes_written()
     }
 
-    #[allow(unused)]
+    #[cfg_attr(not(feature = "experimental"), expect(unused))]
     pub fn is_empty(&self) -> bool {
         self.bit_writer.bytes_written() == 0
     }
@@ -389,7 +389,7 @@ impl RleDecoder {
     // These functions inline badly, they tend to inline and then create very large loop unrolls
     // that damage L1d-cache occupancy. This results in a ~18% performance drop
     #[inline(never)]
-    #[allow(unused)]
+    #[cfg_attr(all(not(feature = "experimental"), not(test)), expect(unused))]
     pub fn get<T: FromBitpacked>(&mut self) -> Result<Option<T>> {
         assert!(size_of::<T>() <= size_of::<u64>());
 

--- a/parquet/src/file/metadata/mod.rs
+++ b/parquet/src/file/metadata/mod.rs
@@ -1757,7 +1757,7 @@ mod tests {
     };
 
     #[test]
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn test_level_histogram_update_from_levels_compat() {
         let mut histogram = LevelHistogram::try_new(2).unwrap();
         histogram.update_from_levels(&[0, 2, 1, 2, 2]);

--- a/parquet/src/file/metadata/reader.rs
+++ b/parquet/src/file/metadata/reader.rs
@@ -804,7 +804,6 @@ impl ParquetMetaDataReader {
 
 /// The bounds needed to read page indexes
 // this is an internal enum, so it is ok to allow differences in enum size
-#[allow(clippy::large_enum_variant)]
 enum NeedsIndexData {
     /// no additional data is needed (e.g. the indexes weren't requested)
     No(ParquetMetaData),

--- a/parquet/src/file/metadata/thrift/mod.rs
+++ b/parquet/src/file/metadata/thrift/mod.rs
@@ -1422,7 +1422,7 @@ impl<'a> WriteThrift for FileMeta<'a> {
     const ELEMENT_TYPE: ElementType = ElementType::Struct;
 
     // needed for last_field_id w/o encryption
-    #[allow(unused_assignments)]
+    #[cfg_attr(not(feature = "encryption"), expect(unused_assignments))]
     fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
         writer.set_write_path_in_schema(self.write_path_in_schema);
         // only write ordinal if all values will fit in an i16
@@ -1613,7 +1613,7 @@ impl WriteThrift for RowGroupMetaData {
 impl WriteThrift for ColumnChunkMetaData {
     const ELEMENT_TYPE: ElementType = ElementType::Struct;
 
-    #[allow(unused_assignments)]
+    #[cfg_attr(not(feature = "encryption"), expect(unused_assignments))]
     fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
         let mut last_field_id = 0i16;
         if let Some(file_path) = self.file_path() {

--- a/parquet/src/file/page_index/column_index.rs
+++ b/parquet/src/file/page_index/column_index.rs
@@ -103,7 +103,7 @@ pub struct PrimitiveColumnIndex<T> {
 }
 
 impl<T: ParquetValueType> PrimitiveColumnIndex<T> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn try_new(
         null_pages: Vec<bool>,
         boundary_order: BoundaryOrder,
@@ -322,7 +322,7 @@ pub struct ByteArrayColumnIndex {
 }
 
 impl ByteArrayColumnIndex {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn try_new(
         null_pages: Vec<bool>,
         boundary_order: BoundaryOrder,
@@ -564,7 +564,7 @@ macro_rules! colidx_enum_func {
 /// [`ParquetColumnIndex`]: crate::file::metadata::ParquetColumnIndex
 /// [`ColumnIndex`]: https://github.com/apache/parquet-format/blob/master/PageIndex.md
 #[derive(Debug, Clone, PartialEq)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub enum ColumnIndexMetaData {
     /// Sometimes reading page index from parquet file
     /// will only return pageLocations without min_max index,

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -135,7 +135,7 @@ impl Default for CdcOptions {
 ///
 /// Basic constant, which is not part of the Thrift definition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub enum WriterVersion {
     /// Parquet format version 1.0
     PARQUET_1_0,
@@ -2180,7 +2180,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn test_writer_properties_deprecated_bloom_filter_ndv_setters_still_work() {
         let col = ColumnPath::from("col");
         let props = WriterProperties::builder()

--- a/parquet/src/file/reader.rs
+++ b/parquet/src/file/reader.rs
@@ -39,7 +39,7 @@ use crate::column::reader::ColumnReaderImpl;
 
 /// Length should return the total number of bytes in the input source.
 /// It's mainly used to read the metadata, which is at the end of the source.
-#[allow(clippy::len_without_is_empty)]
+#[expect(clippy::len_without_is_empty)]
 pub trait Length {
     /// Returns the amount of bytes of the inner source.
     fn len(&self) -> u64;

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -1439,7 +1439,7 @@ mod tests {
                     assert_eq!(num_values, 8);
                     assert_eq!(encoding, Encoding::PLAIN_DICTIONARY);
                     assert_eq!(def_level_encoding, Encoding::RLE);
-                    #[allow(deprecated)]
+                    #[expect(deprecated)]
                     let expected_rep_level_encoding = Encoding::BIT_PACKED;
                     assert_eq!(rep_level_encoding, expected_rep_level_encoding);
                     assert!(statistics.is_none());

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -143,6 +143,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 /// Defines a an item with an experimental public API
 ///

--- a/parquet/src/parquet_macros.rs
+++ b/parquet/src/parquet_macros.rs
@@ -31,8 +31,12 @@
 //! [Thrift compact]: https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#list-and-set
 //! [THRIFT.md]: https://github.com/apache/arrow-rs/blob/main/parquet/THRIFT.md
 
+// These macros generate `allow` attributes for lints that may not fire on every
+// invocation, so we keep `allow` instead of `expect`.
+
 #[doc(hidden)]
 #[macro_export]
+#[expect(clippy::allow_attributes)]
 #[allow(clippy::crate_in_macro_def)]
 /// Macro used to generate rust enums from a Thrift `enum` definition.
 ///
@@ -43,6 +47,7 @@ macro_rules! thrift_enum {
     ($(#[$($def_attrs:tt)*])* enum $identifier:ident { $($(#[$($field_attrs:tt)*])* $field_name:ident = $field_value:literal;)* }) => {
         $(#[$($def_attrs)*])*
         #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[allow(clippy::allow_attributes)]
         #[allow(non_camel_case_types)]
         #[allow(missing_docs)]
         pub enum $identifier {
@@ -50,6 +55,7 @@ macro_rules! thrift_enum {
         }
 
         impl<'a, R: ThriftCompactInputProtocol<'a>> ReadThrift<'a, R> for $identifier {
+            #[allow(clippy::allow_attributes)]
             #[allow(deprecated)]
             fn read_thrift(prot: &mut R) -> Result<Self> {
                 let val = prot.read_i32()?;
@@ -83,6 +89,7 @@ macro_rules! thrift_enum {
         }
 
         impl $identifier {
+            #[allow(clippy::allow_attributes)]
             #[allow(deprecated)]
             #[doc = "Returns a slice containing every variant of this enum."]
             #[allow(dead_code)]
@@ -90,6 +97,7 @@ macro_rules! thrift_enum {
                 $(Self::$field_name),*
             ];
 
+            #[allow(clippy::allow_attributes)]
             #[allow(deprecated)]
             const fn max_discriminant_impl() -> i32 {
                 let values: &[i32] = &[$($field_value),*];
@@ -105,6 +113,7 @@ macro_rules! thrift_enum {
                 max
             }
 
+            #[allow(clippy::allow_attributes)]
             #[allow(deprecated)]
             #[doc = "Returns the largest discriminant value defined for this enum."]
             #[allow(dead_code)]
@@ -127,11 +136,13 @@ macro_rules! thrift_enum {
 ///  - When utilizing this macro the Thrift serialization traits and structs need to be in scope.
 #[doc(hidden)]
 #[macro_export]
+#[expect(clippy::allow_attributes)]
 #[allow(clippy::crate_in_macro_def)]
 macro_rules! thrift_union_all_empty {
     ($(#[$($def_attrs:tt)*])* union $identifier:ident { $($(#[$($field_attrs:tt)*])* $field_id:literal : $field_type:ident $(< $element_type:ident >)? $field_name:ident $(;)?)* }) => {
         $(#[cfg_attr(not(doctest), $($def_attrs)*)])*
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        #[allow(clippy::allow_attributes)]
         #[allow(non_camel_case_types)]
         #[allow(non_snake_case)]
         #[allow(missing_docs)]
@@ -201,11 +212,13 @@ macro_rules! thrift_union_all_empty {
 ///  - When utilizing this macro the Thrift serialization traits and structs need to be in scope.
 #[doc(hidden)]
 #[macro_export]
+#[expect(clippy::allow_attributes)]
 #[allow(clippy::crate_in_macro_def)]
 macro_rules! thrift_union {
     ($(#[$($def_attrs:tt)*])* union $identifier:ident $(< $lt:lifetime >)? { $($(#[$($field_attrs:tt)*])* $field_id:literal : $( ( $field_type:ident $(< $element_type:ident >)? $(< $field_lt:lifetime >)?) )? $field_name:ident $(;)?)* }) => {
         $(#[cfg_attr(not(doctest), $($def_attrs)*)])*
         #[derive(Clone, Debug, Eq, PartialEq)]
+        #[allow(clippy::allow_attributes)]
         #[allow(non_camel_case_types)]
         #[allow(non_snake_case)]
         #[allow(missing_docs)]
@@ -273,11 +286,13 @@ macro_rules! thrift_union {
 /// When utilizing this macro the Thrift serialization traits and structs need to be in scope.
 #[doc(hidden)]
 #[macro_export]
+#[expect(clippy::allow_attributes)]
 #[allow(clippy::crate_in_macro_def)]
 macro_rules! thrift_union_with_unknown {
     ($(#[$($def_attrs:tt)*])* union $identifier:ident $(< $lt:lifetime >)? { $($(#[$($field_attrs:tt)*])* $field_id:literal : $( ( $field_type:ident $(< $element_type:ident >)? $(< $field_lt:lifetime >)?) )? $field_name:ident $(;)?)* }) => {
         $(#[cfg_attr(not(doctest), $($def_attrs)*)])*
         #[derive(Clone, Debug, Eq, PartialEq)]
+        #[allow(clippy::allow_attributes)]
         #[allow(non_camel_case_types)]
         #[allow(non_snake_case)]
         #[allow(missing_docs)]
@@ -353,6 +368,7 @@ macro_rules! thrift_struct {
     ($(#[$($def_attrs:tt)*])* $vis:vis struct $identifier:ident $(< $lt:lifetime >)? { $($(#[$($field_attrs:tt)*])* $field_id:literal : $required_or_optional:ident $field_type:ident $(< $field_lt:lifetime >)? $(< $element_type:ident >)? $field_name:ident $(= $default_value:literal)? $(;)?)* }) => {
         $(#[cfg_attr(not(doctest), $($def_attrs)*)])*
         #[derive(Clone, Debug, Eq, PartialEq)]
+        #[allow(clippy::allow_attributes)]
         #[allow(non_camel_case_types)]
         #[allow(non_snake_case)]
         #[allow(missing_docs)]
@@ -390,6 +406,7 @@ macro_rules! thrift_struct {
         impl $(<$lt>)? WriteThrift for $identifier $(<$lt>)? {
             const ELEMENT_TYPE: ElementType = ElementType::Struct;
 
+            #[allow(clippy::allow_attributes)]
             #[allow(unused_assignments)]
             fn write_thrift<W: Write>(&self, writer: &mut ThriftCompactOutputProtocol<W>) -> Result<()> {
                 #[allow(unused_mut, unused_variables)]

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -50,7 +50,7 @@ pub struct Row {
     fields: Vec<(String, Field)>,
 }
 
-#[allow(clippy::len_without_is_empty)]
+#[expect(clippy::len_without_is_empty)]
 impl Row {
     /// Constructs a `Row` from the list of `fields` and returns it.
     pub fn new(fields: Vec<(String, Field)>) -> Row {
@@ -326,7 +326,7 @@ pub struct List {
     elements: Vec<Field>,
 }
 
-#[allow(clippy::len_without_is_empty)]
+#[expect(clippy::len_without_is_empty)]
 impl List {
     /// Get the number of fields in this row
     pub fn len(&self) -> usize {
@@ -474,7 +474,7 @@ pub struct Map {
     entries: Vec<(Field, Field)>,
 }
 
-#[allow(clippy::len_without_is_empty)]
+#[expect(clippy::len_without_is_empty)]
 impl Map {
     /// Get the number of fields in this row
     pub fn len(&self) -> usize {
@@ -1022,7 +1022,7 @@ fn convert_decimal_to_string(decimal: &Decimal) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::many_single_char_names)]
+#[expect(clippy::many_single_char_names)]
 mod tests {
     use super::*;
 
@@ -2161,7 +2161,6 @@ mod tests {
 }
 
 #[cfg(test)]
-#[allow(clippy::many_single_char_names)]
 mod api_tests {
     use super::{Row, make_list, make_map};
     use crate::record::Field;

--- a/parquet/src/record/triplet.rs
+++ b/parquet/src/record/triplet.rs
@@ -42,7 +42,7 @@ macro_rules! triplet_enum_func {
 
 /// High level API wrapper on column reader.
 /// Provides per-element access for each primitive column.
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 pub enum TripletIter {
     BoolTripletIter(TypedTripletIter<BoolType>),
     Int32TripletIter(TypedTripletIter<Int32Type>),

--- a/parquet/src/schema/printer.rs
+++ b/parquet/src/schema/printer.rs
@@ -53,7 +53,7 @@ use crate::file::metadata::{ColumnChunkMetaData, FileMetaData, ParquetMetaData, 
 use crate::schema::types::Type;
 
 /// Prints Parquet metadata [`ParquetMetaData`] information.
-#[allow(unused_must_use)]
+#[expect(unused_must_use)]
 pub fn print_parquet_metadata(out: &mut dyn io::Write, metadata: &ParquetMetaData) {
     print_file_metadata(out, metadata.file_metadata());
     writeln!(out);
@@ -69,7 +69,7 @@ pub fn print_parquet_metadata(out: &mut dyn io::Write, metadata: &ParquetMetaDat
 }
 
 /// Prints file metadata [`FileMetaData`] information.
-#[allow(unused_must_use)]
+#[expect(unused_must_use)]
 pub fn print_file_metadata(out: &mut dyn io::Write, file_metadata: &FileMetaData) {
     writeln!(out, "version: {}", file_metadata.version());
     writeln!(out, "num of rows: {}", file_metadata.num_rows());
@@ -143,7 +143,7 @@ pub fn print_file_metadata(out: &mut dyn io::Write, file_metadata: &FileMetaData
 ///   }
 /// }
 /// ```
-#[allow(unused_must_use)]
+#[expect(unused_must_use)]
 pub fn print_schema(out: &mut dyn io::Write, tp: &Type) {
     // TODO: better if we can pass fmt::Write to Printer.
     // But how can we make it to accept both io::Write & fmt::Write?
@@ -155,7 +155,7 @@ pub fn print_schema(out: &mut dyn io::Write, tp: &Type) {
     writeln!(out, "{s}");
 }
 
-#[allow(unused_must_use)]
+#[expect(unused_must_use)]
 fn print_row_group_metadata(out: &mut dyn io::Write, rg_metadata: &RowGroupMetaData) {
     writeln!(out, "total byte size: {}", rg_metadata.total_byte_size());
     writeln!(out, "num of rows: {}", rg_metadata.num_rows());
@@ -170,7 +170,7 @@ fn print_row_group_metadata(out: &mut dyn io::Write, rg_metadata: &RowGroupMetaD
     }
 }
 
-#[allow(unused_must_use)]
+#[expect(unused_must_use)]
 fn print_column_chunk_metadata(out: &mut dyn io::Write, cc_metadata: &ColumnChunkMetaData) {
     writeln!(out, "column type: {}", cc_metadata.column_type());
     writeln!(out, "column path: {}", cc_metadata.column_path());
@@ -240,7 +240,7 @@ fn print_column_chunk_metadata(out: &mut dyn io::Write, cc_metadata: &ColumnChun
     writeln!(out);
 }
 
-#[allow(unused_must_use)]
+#[expect(unused_must_use)]
 fn print_dashes(out: &mut dyn io::Write, num: i32) {
     for _ in 0..num {
         write!(out, "-");
@@ -256,7 +256,7 @@ struct Printer<'a> {
     indent: i32,
 }
 
-#[allow(unused_must_use)]
+#[expect(unused_must_use)]
 impl<'a> Printer<'a> {
     fn new(output: &'a mut dyn fmt::Write) -> Self {
         Printer { output, indent: 0 }
@@ -365,7 +365,7 @@ fn print_logical_and_converted(
     }
 }
 
-#[allow(unused_must_use)]
+#[expect(unused_must_use)]
 impl Printer<'_> {
     pub fn print(&mut self, tp: &Type) {
         self.print_indent();

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -1255,7 +1255,7 @@ fn count_leaves(tp: &TypePtr, n_leaves: &mut usize) {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn build_tree<'a>(
     tp: &'a TypePtr,
     root_idx: usize,

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -954,7 +954,7 @@ impl From<Vec<u8>> for BitReader {
 ///
 /// Replace with `value.compress(mask)` when `uint_gather_scatter_bits`
 /// is stabilised: <https://github.com/rust-lang/rust/issues/149069>
-#[allow(dead_code)]
+#[cfg_attr(all(not(feature = "arrow"), not(test)), expect(dead_code))]
 #[inline]
 pub(crate) fn compress(value: u64, mask: u64) -> u64 {
     #[cfg(all(target_arch = "x86_64", target_feature = "bmi2"))]

--- a/parquet/src/util/interner.rs
+++ b/parquet/src/util/interner.rs
@@ -33,7 +33,6 @@ pub trait Storage {
     fn push(&mut self, value: &Self::Value) -> Self::Key;
 
     /// Return an estimate of the memory used in this storage, in bytes
-    #[allow(dead_code)] // not used in parquet_derive, so is dead there
     fn estimated_memory_size(&self) -> usize;
 }
 
@@ -75,7 +74,6 @@ impl<S: Storage> Interner<S> {
     }
 
     /// Return estimate of the memory used, in bytes
-    #[allow(dead_code)] // not used in parquet_derive, so is dead there
     pub fn estimated_memory_size(&self) -> usize {
         self.storage.estimated_memory_size() + self.dedup.allocation_size()
     }

--- a/parquet/src/util/test_common/rand_gen.rs
+++ b/parquet/src/util/test_common/rand_gen.rs
@@ -135,7 +135,7 @@ where
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn make_pages<T: DataType>(
     desc: ColumnDescPtr,
     encoding: Encoding,

--- a/parquet/tests/arrow_reader/io/mod.rs
+++ b/parquet/tests/arrow_reader/io/mod.rs
@@ -479,12 +479,12 @@ enum LogEntry {
     /// Read the metadata of the parquet file
     ReadMetadata(Range<usize>),
     /// Access previously parsed metadata
-    #[allow(dead_code)]
+    #[cfg_attr(not(feature = "async"), expect(dead_code))]
     GetProvidedMetadata,
     /// Read a single logical data object
     ReadData(ReadInfo),
     /// Read one or more logical data objects in a single operation
-    #[allow(dead_code)]
+    #[cfg_attr(not(feature = "async"), expect(dead_code))]
     ReadMultipleData(Vec<LogEntry>),
     /// Not known where the read came from
     Unknown(Range<usize>),

--- a/parquet/tests/arrow_writer/mod.rs
+++ b/parquet/tests/arrow_writer/mod.rs
@@ -112,7 +112,7 @@ fn subtract_live_bytes(size: usize) {
     });
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 unsafe impl GlobalAlloc for TrackingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let ptr = unsafe { self.inner.alloc(layout) };

--- a/parquet/tests/variant_integration.rs
+++ b/parquet/tests/variant_integration.rs
@@ -236,7 +236,7 @@ variant_test_case!(138);
 ///   "variant" : "Variant(metadata=VariantMetadata(dict={}), value=Variant(type=BOOLEAN_FALSE, value=false))"
 /// },
 /// ```
-#[allow(dead_code)] // some fields are not used except when printing the struct
+#[expect(dead_code)] // some fields are not used except when printing the struct
 #[derive(Debug, Clone, Deserialize)]
 struct VariantTestCase {
     /// Case number (e.g., 1, 2, 4, etc. - note: case 3 is missing any data)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Part of #10458.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Enable `clippy::allow_attributes` for the `parquet` crate.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Enable `clippy::allow_attributes` for `parquet`.
- Replace active `allow` attributes with `expect`.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->
Yes.
- `cargo clippy -p parquet --all-targets --all-features -- -D warnings -D clippy::allow_attributes`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
No.