### PR TITLE
minor/doc: document saftey for `extend_bool_trusted_len`

### DIFF
--- a/arrow-buffer/src/buffer/mutable.rs
+++ b/arrow-buffer/src/buffer/mutable.rs
@@ -802,7 +802,10 @@ impl MutableBuffer {
     /// for the same reasons as [`MutableBuffer::reserve`].
     ///
     /// # Safety
-    /// Callers must ensure that `iter` reports an exact size via `size_hint`.
+    /// Callers must ensure that `iter` reports an exact size via `size_hint`
+    /// and that `I::next()` does not panic, or `set_len` will leave the buffer
+    /// in an inconsistent state, exposing uninitialized/stale bytes as though
+    /// they were valid.
     #[inline]
     pub unsafe fn extend_bool_trusted_len<I: Iterator<Item = bool>>(
         &mut self,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10380.

# Rationale for this change
see https://github.com/apache/arrow-rs/issues/10380#issuecomment-5305597389
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

the safety section of `extend_bool_trust_len` now points out  that `I::next` must not panic

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
yes
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
