### PR TITLE
Enable `allow_attributes` lint workspace-wide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,7 @@ rather than to individual crates, so that they apply everywhere.
 
 One of the concerns with `clippy` is that it often produces a lot of false positives, or that some recommendations may hurt readability. We do not have a policy of which lints are ignored, but if you disagree with a `clippy` lint, you may disable the lint and briefly justify it.
 
-Search for `allow(clippy::` in the codebase to identify lints that are ignored/allowed. We currently prefer ignoring lints on the lowest unit possible.
+Search for `expect(clippy::` in the codebase to identify lints that are intentionally suppressed. We currently prefer suppressing lints on the lowest unit possible.
 
 - If you are introducing a line that returns a lint warning or error, you may disable the lint on that line.
 - If you have several lints on a function or module, you may disable the lint on the function or module.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ broken_intra_doc_links = "warn"
 missing_crate_level_docs = "warn"
 
 [workspace.lints.clippy]
+allow_attributes = "warn"
 as_ptr_cast_mut = "warn"
 assigning_clones = "warn"
 bool_to_int_with_if = "warn"

--- a/arrow-arith/src/lib.rs
+++ b/arrow-arith/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 pub mod aggregate;
 #[doc(hidden)] // Kernels to be removed in a future release

--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -226,7 +226,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
 

--- a/arrow-avro/src/lib.rs
+++ b/arrow-avro/src/lib.rs
@@ -217,7 +217,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 /// Core functionality for reading Avro data into Arrow arrays

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -37,7 +37,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 pub mod alloc;

--- a/arrow-cast/src/lib.rs
+++ b/arrow-cast/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 pub mod cast;
 pub use cast::*;

--- a/arrow-cmp/src/lib.rs
+++ b/arrow-cmp/src/lib.rs
@@ -29,7 +29,6 @@
 //! downstream user of `arrow-array` to compile the comparator machinery whether
 //! they need it or not.
 
-#![deny(clippy::allow_attributes)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
 

--- a/arrow-csv/src/lib.rs
+++ b/arrow-csv/src/lib.rs
@@ -24,7 +24,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 pub mod reader;

--- a/arrow-data/src/lib.rs
+++ b/arrow-data/src/lib.rs
@@ -24,7 +24,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 mod data;
 pub use data::*;

--- a/arrow-flight/gen/src/main.rs
+++ b/arrow-flight/gen/src/main.rs
@@ -17,8 +17,6 @@
 
 //! Generates the Rust bindings for the Arrow Flight protobuf definitions.
 
-#![deny(clippy::allow_attributes)]
-
 use std::{fs::OpenOptions, io::Write, path::Path};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -42,7 +42,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![allow(rustdoc::invalid_html_tags)]
 #![warn(missing_docs)]
 // The unused_crate_dependencies lint does not work well for crates defining additional examples/bin targets

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -34,7 +34,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano, ScalarBuffer};
 use hex::decode;

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -19,7 +19,6 @@
 
 // The unused_crate_dependencies lint does not work well for crates defining additional examples/bin targets
 #![allow(unused_crate_dependencies)]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 use serde_json::Value;
 

--- a/arrow-ipc/src/lib.rs
+++ b/arrow-ipc/src/lib.rs
@@ -43,7 +43,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 pub mod convert;
 pub mod reader;

--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -80,7 +80,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
 

--- a/arrow-ord/src/lib.rs
+++ b/arrow-ord/src/lib.rs
@@ -48,7 +48,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 pub mod cmp;
 #[doc(hidden)]

--- a/arrow-pyarrow/src/lib.rs
+++ b/arrow-pyarrow/src/lib.rs
@@ -69,8 +69,6 @@
 //! Input hints name the pyarrow classes only, and are therefore narrower than what is accepted: the
 //! PyCapsule interface is duck-typed and has no canonical Python type to name.
 
-#![deny(clippy::allow_attributes)]
-
 use std::convert::{From, TryFrom};
 use std::ffi::CStr;
 use std::ptr::NonNull;

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -158,7 +158,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 mod datatype;

--- a/arrow-select/src/lib.rs
+++ b/arrow-select/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 pub mod coalesce;

--- a/arrow-string/src/lib.rs
+++ b/arrow-string/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 
 mod binary_like;

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -393,7 +393,6 @@
     html_favicon_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_transparent-bg.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![deny(clippy::redundant_clone)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]

--- a/parquet-geospatial/src/lib.rs
+++ b/parquet-geospatial/src/lib.rs
@@ -20,7 +20,6 @@
 //! [Geometry and Geography Encoding]: https://github.com/apache/parquet-format/blob/master/Geospatial.md
 //! [Apache Parquet]: https://parquet.apache.org/
 
-#![deny(clippy::allow_attributes)]
 pub mod bounding;
 pub mod interval;
 pub mod testing;

--- a/parquet-variant-compute/src/lib.rs
+++ b/parquet-variant-compute/src/lib.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![deny(clippy::allow_attributes)]
-
 //! [`VariantArray`] and compute kernels for the [Variant Binary Encoding] from [Apache Parquet].
 //!
 //! ## Main APIs

--- a/parquet-variant-json/src/lib.rs
+++ b/parquet-variant-json/src/lib.rs
@@ -31,8 +31,6 @@
 //!
 //! [Variant issue]: https://github.com/apache/arrow-rs/issues/6736
 
-#![deny(clippy::allow_attributes)]
-
 mod from_json;
 mod to_json;
 

--- a/parquet-variant/src/lib.rs
+++ b/parquet-variant/src/lib.rs
@@ -31,8 +31,6 @@
 //!
 //! [Variant issue]: https://github.com/apache/arrow-rs/issues/6736
 
-#![warn(clippy::allow_attributes)]
-
 mod builder;
 mod decoder;
 mod path;

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -143,7 +143,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 /// Defines a an item with an experimental public API
 ///

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -23,7 +23,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![warn(missing_docs)]
 #![recursion_limit = "128"]
 

--- a/parquet_derive_test/src/lib.rs
+++ b/parquet_derive_test/src/lib.rs
@@ -22,7 +22,6 @@
     html_favicon_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(clippy::allow_attributes)]
 #![allow(clippy::approx_constant)]
 
 use parquet_derive::{ParquetRecordReader, ParquetRecordWriter};


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #10458.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Since all workspace crates have now been migrated, the lint can be enabled at the workspace level.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Enable `clippy::allow_attributes` in the workspace lint config.
- Remove the temporary crate-level lint declarations.
- Update the lint suppression guidance in `CONTRIBUTING.md`.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->
Yes. Format, clippy for all workspace targets and features, nightly documentation, and relevant crate tests pass.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
No.