### PR TITLE
ci: run the arrow test and clippy jobs for arrow-cmp

### DIFF
--- a/.github/workflows/arrow.yml
+++ b/.github/workflows/arrow.yml
@@ -35,6 +35,7 @@ on:
       - arrow-array/**
       - arrow-buffer/**
       - arrow-cast/**
+      - arrow-cmp/**
       - arrow-csv/**
       - arrow-data/**
       - arrow-integration-test/**
@@ -75,6 +76,8 @@ jobs:
           cargo test -p arrow-array --all-features
           # Disable feature `force_validate`
           cargo test -p arrow-array --features=ffi
+      - name: Test arrow-cmp
+        run: cargo test -p arrow-cmp --all-features
       - name: Test arrow-select
         run: cargo test -p arrow-select --all-features
       - name: Test arrow-cast
@@ -235,6 +238,14 @@ jobs:
       - name: Clippy arrow-array
         run: |
           mod=arrow-array
+          cargo clippy -p "$mod" --all-targets --all-features -- -D warnings
+          # Dependency checks excluding tests & benches.
+          cargo clippy -p "$mod" -- -D unused_crate_dependencies
+          cargo clippy -p "$mod" --all-features -- -D unused_crate_dependencies
+          cargo clippy -p "$mod" --no-default-features -- -D unused_crate_dependencies
+      - name: Clippy arrow-cmp
+        run: |
+          mod=arrow-cmp
           cargo clippy -p "$mod" --all-targets --all-features -- -D warnings
           # Dependency checks excluding tests & benches.
           cargo clippy -p "$mod" -- -D unused_crate_dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,7 +45,6 @@ on:
       - arrow-pyarrow/**
       - arrow-schema/**
       - arrow-select/**
-      - arrow-sort/**
       - arrow-string/**
       - arrow/**
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #10723.

# Rationale for this change

`arrow-cmp` landed in #10325 but was never added to `.github/workflows/arrow.yml`, so it is the one `arrow-*` crate outside that workflow's per-crate coverage. Every other crate there has a `cargo test -p <crate> --all-features` step and a clippy block; `arrow-cmp` has neither, and it is missing from the workflow's `paths:` filter, so a change touching only `arrow-cmp/**` does not start the workflow at all.

What it does get is the workspace `cargo test` in `rust.yml`, `cargo fmt`, the MSRV sweep and miri. None of those run clippy, so a lint regression or an unused dependency in this crate reaches `main` unseen.

# What changes are included in this PR?

Two commits.

`arrow.yml` — `arrow-cmp/**` in the path filter, a `cargo test -p arrow-cmp --all-features` step, and the same four-command clippy block the neighbouring crates use. All three are placed where `arrow-cmp` falls in the order the lists already follow: after `arrow-array`, before `arrow-select`, which is also the dependency order.

I did not add it to the release-profile job. That list is explicitly a subset — "only run the low level crates in release mode which are the most likely to have overflow tests" — and `arrow-cmp` arguably qualifies, but that is your call rather than mine.

`integration.yml` — drops `arrow-sort/**` from the path filter. It has been there since `db9084e7` (2022-12-21); that commit's own tree has no `arrow-sort` directory, no such crate exists on crates.io, and GitHub code search finds the string exactly once in the repository, which is that line. Happy to split this out if you would rather keep the PR to one file.

# Are these changes tested?

Nothing is failing today. At `bb1e6cd0` the four commands this adds are clean — clippy exits 0 in all four configurations and `cargo test -p arrow-cmp --all-features` is 44 passed — so this closes a gap rather than fixing a failure.

To check that the gap is real rather than theoretical, I planted two defects in `arrow-cmp` and ran both sides:

- a `pub fn` taking `&Vec<u8>`, returning with `return v.len();`, and carrying no doc comment
- an unused `ahash` dependency in `arrow-cmp/Cargo.toml`

With both in place, what CI runs on this crate today still passes: `cargo fmt -p arrow-cmp -- --check` exits 0 and `cargo test -p arrow-cmp` exits 0. The commands this PR adds fail on them — `needless_return`, `ptr_arg` and `missing_docs` from `-D warnings`, and `extern crate ``ahash`` is unused in crate ``arrow_cmp``` from each of the three `unused_crate_dependencies` configurations.

Both workflow files parse as YAML. `cargo fmt --all -- --check` is clean. Full sequence run twice on an identical file hash for both files.

# Are there any user-facing changes?

No. CI configuration only.
