### PR TITLE
Fix: Error rather than panic on invalid dictionary index bit width in Parquet reader

### DIFF
--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -298,7 +298,14 @@ where
     ) -> Result<()> {
         let decoder = match encoding {
             Encoding::RLE_DICTIONARY | Encoding::PLAIN_DICTIONARY => {
-                let bit_width = data[0];
+                let bit_width = *data
+                    .first()
+                    .ok_or_else(|| general_err!("dictionary index page is empty"))?;
+                if bit_width > 32 {
+                    return Err(general_err!(
+                        "Invalid or corrupted RLE bit width {bit_width}. Max allowed is 32"
+                    ));
+                }
                 let mut decoder = RleDecoder::new(bit_width);
                 decoder.set_data(data.slice(1..))?;
                 MaybeDictionaryDecoder::Dict {
@@ -687,5 +694,32 @@ mod tests {
             assert_eq!(array.null_count(), 8);
             assert_eq!(array.logical_null_count(), 8);
         }
+    }
+
+    #[test]
+    fn test_dictionary_decoder_empty_data() {
+        let column_desc = utf8_column();
+        let mut decoder = DictionaryDecoder::<i32, i32>::new(&column_desc);
+        let err = decoder
+            .set_data(Encoding::RLE_DICTIONARY, Bytes::new(), 0, None)
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Parquet error: dictionary index page is empty"
+        );
+    }
+
+    #[test]
+    fn test_dictionary_decoder_invalid_bit_width() {
+        let column_desc = utf8_column();
+        let mut decoder = DictionaryDecoder::<i32, i32>::new(&column_desc);
+        let data = Bytes::from_static(&[33, 0, 0, 0]);
+        let err = decoder
+            .set_data(Encoding::RLE_DICTIONARY, data, 1, None)
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Parquet error: Invalid or corrupted RLE bit width 33. Max allowed is 32"
+        );
     }
 }

--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -31,7 +31,7 @@ use crate::arrow::schema::parquet_to_arrow_field;
 use crate::basic::{ConvertedType, Encoding};
 use crate::column::page::PageIterator;
 use crate::column::reader::decoder::ColumnValueDecoder;
-use crate::encodings::rle::RleDecoder;
+use crate::encodings::rle::{MAX_RLE_DICTIONARY_BIT_WIDTH, RleDecoder};
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
 use crate::util::bit_util::FromBitpacked;
@@ -301,9 +301,9 @@ where
                 let bit_width = *data
                     .first()
                     .ok_or_else(|| general_err!("dictionary index page is empty"))?;
-                if bit_width > 32 {
+                if bit_width > MAX_RLE_DICTIONARY_BIT_WIDTH {
                     return Err(general_err!(
-                        "Invalid or corrupted RLE bit width {bit_width}. Max allowed is 32"
+                        "Invalid or corrupted RLE bit width {bit_width}. Max allowed is {MAX_RLE_DICTIONARY_BIT_WIDTH}"
                     ));
                 }
                 let mut decoder = RleDecoder::new(bit_width);

--- a/parquet/src/arrow/decoder/dictionary_index.rs
+++ b/parquet/src/arrow/decoder/dictionary_index.rs
@@ -17,7 +17,7 @@
 
 use bytes::Bytes;
 
-use crate::encodings::rle::RleDecoder;
+use crate::encodings::rle::{MAX_RLE_DICTIONARY_BIT_WIDTH, RleDecoder};
 use crate::errors::{ParquetError, Result};
 
 /// Decoder for `Encoding::RLE_DICTIONARY` indices
@@ -46,9 +46,9 @@ impl DictIndexDecoder {
         let bit_width = *data
             .first()
             .ok_or_else(|| general_err!("dictionary index page is empty"))?;
-        if bit_width > 32 {
+        if bit_width > MAX_RLE_DICTIONARY_BIT_WIDTH {
             return Err(general_err!(
-                "Invalid or corrupted RLE bit width {bit_width}. Max allowed is 32"
+                "Invalid or corrupted RLE bit width {bit_width}. Max allowed is {MAX_RLE_DICTIONARY_BIT_WIDTH}"
             ));
         }
         let mut decoder = RleDecoder::new(bit_width);

--- a/parquet/src/arrow/decoder/dictionary_index.rs
+++ b/parquet/src/arrow/decoder/dictionary_index.rs
@@ -18,7 +18,7 @@
 use bytes::Bytes;
 
 use crate::encodings::rle::RleDecoder;
-use crate::errors::Result;
+use crate::errors::{ParquetError, Result};
 
 /// Decoder for `Encoding::RLE_DICTIONARY` indices
 pub struct DictIndexDecoder {
@@ -43,7 +43,14 @@ impl DictIndexDecoder {
     /// Create a new [`DictIndexDecoder`] with the provided data page, the number of levels
     /// associated with this data page, and the number of non-null values (if known)
     pub fn new(data: Bytes, num_levels: usize, num_values: Option<usize>) -> Result<Self> {
-        let bit_width = data[0];
+        let bit_width = *data
+            .first()
+            .ok_or_else(|| general_err!("dictionary index page is empty"))?;
+        if bit_width > 32 {
+            return Err(general_err!(
+                "Invalid or corrupted RLE bit width {bit_width}. Max allowed is 32"
+            ));
+        }
         let mut decoder = RleDecoder::new(bit_width);
         decoder.set_data(data.slice(1..))?;
 
@@ -117,5 +124,33 @@ impl DictIndexDecoder {
             }
         }
         Ok(values_skip)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dict_index_decoder_empty_data() {
+        let Err(err) = DictIndexDecoder::new(Bytes::new(), 0, None) else {
+            panic!("expected error");
+        };
+        assert_eq!(
+            err.to_string(),
+            "Parquet error: dictionary index page is empty"
+        );
+    }
+
+    #[test]
+    fn test_dict_index_decoder_invalid_bit_width() {
+        let data = Bytes::from_static(&[33, 0, 0, 0]);
+        let Err(err) = DictIndexDecoder::new(data, 1, None) else {
+            panic!("expected error");
+        };
+        assert_eq!(
+            err.to_string(),
+            "Parquet error: Invalid or corrupted RLE bit width 33. Max allowed is 32"
+        );
     }
 }

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -21,7 +21,7 @@ use bytes::Bytes;
 use num_traits::{FromPrimitive, WrappingAdd};
 use std::{cmp, marker::PhantomData, mem};
 
-use super::rle::RleDecoder;
+use super::rle::{MAX_RLE_DICTIONARY_BIT_WIDTH, RleDecoder};
 
 use crate::basic::*;
 use crate::data_type::private::ParquetValueType;
@@ -386,10 +386,9 @@ impl<T: DataType> Decoder<T> for DictDecoder<T> {
         }
 
         let bit_width = data.as_ref()[0];
-        if bit_width > 32 {
+        if bit_width > MAX_RLE_DICTIONARY_BIT_WIDTH {
             return Err(general_err!(
-                "Invalid or corrupted RLE bit width {}. Max allowed is 32",
-                bit_width
+                "Invalid or corrupted RLE bit width {bit_width}. Max allowed is {MAX_RLE_DICTIONARY_BIT_WIDTH}"
             ));
         }
         let mut rle_decoder = RleDecoder::new(bit_width);

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -361,6 +361,7 @@ pub struct RleDecoder {
 
 impl RleDecoder {
     pub fn new(bit_width: u8) -> Self {
+        debug_assert!(bit_width <= 64, "Bit width must be <= 64");
         RleDecoder {
             bit_width,
             rle_left: 0,

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -41,6 +41,12 @@ use bytes::Bytes;
 use crate::errors::{ParquetError, Result};
 use crate::util::bit_util::{self, BitReader, BitWriter, FromBitpacked};
 
+/// Maximum bit width for dictionary page indices encoded with RLE / Bit-Packing hybrid encoding.
+///
+/// Parquet dictionary indices are represented as 32-bit signed integers, so dictionary
+/// index bit widths must not exceed 32.
+pub const MAX_RLE_DICTIONARY_BIT_WIDTH: u8 = 32;
+
 /// Number of values in one bit-packed group. The Parquet RLE/bit-packing hybrid
 /// format always bit-packs values in multiples of this count (see the
 /// [format spec](https://github.com/apache/parquet-format/blob/master/Encodings.md#run-length-encoding--bit-packing-hybrid-rle--3):
@@ -360,6 +366,10 @@ pub struct RleDecoder {
 }
 
 impl RleDecoder {
+    /// Creates a new `RleDecoder` with the specified bit width.
+    ///
+    /// Bit width must be between 0 and 64 (inclusive). Note that for dictionary indices
+    /// specifically, the bit width cannot exceed [`MAX_RLE_DICTIONARY_BIT_WIDTH`] (32).
     pub fn new(bit_width: u8) -> Self {
         debug_assert!(bit_width <= 64, "Bit width must be <= 64");
         RleDecoder {


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10722.

# Rationale for this change

When reading dictionary-encoded Parquet data pages with DictIndexDecoder or ByteArrayDictionaryReader, the first byte was read via data[0] without checking if data is empty, and the index it_width was passed to RleDecoder without checking the 