### PR TITLE
bench(arrow): sweep byte-view scalar comparison across a size range

### DIFF
--- a/arrow/benches/comparison_kernels.rs
+++ b/arrow/benches/comparison_kernels.rs
@@ -25,7 +25,7 @@ use arrow::{array::*, datatypes::Float32Type, datatypes::Int32Type};
 use arrow_buffer::IntervalMonthDayNano;
 use arrow_string::like::*;
 use arrow_string::regexp::regexp_is_match_scalar;
-use criterion::Criterion;
+use criterion::{Criterion, Throughput};
 use rand::RngExt;
 use rand::rngs::StdRng;
 use std::hint;
@@ -529,6 +529,23 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("eq dictionary[10] string[4])", |b| {
         b.iter(|| eq(&dict_arr_a, &dict_arr_b).unwrap())
     });
+
+    // eq scalar benchmarks across sizes: 16 bytes of view a row, so the largest is bandwidth-bound
+
+    let mut group = c.benchmark_group("stringview_scalar_eq");
+
+    for rows in [65_536usize, 1024 * 1024, 1024 * 1024 * 8] {
+        let mut rng = seedable_rng();
+        let values = StringViewArray::from_iter(make_string_array(rows, &mut rng));
+        let scalar = StringViewArray::new_scalar("xxxx");
+
+        group.throughput(Throughput::Elements(rows as u64));
+        group.bench_function(format!("eq_scalar(rows={rows})"), |b| {
+            b.iter(|| eq(&values, &scalar).unwrap())
+        });
+    }
+
+    group.finish();
 
     // RunEndEncoded benchmarks
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10727.

# Rationale for this change

The byte-view scalar comparison benchmarks in arrow/benches/comparison_kernels.rs all run at one size: 1024 * 1024 * 8 = 8,388,608 rows, or 134 MB of views. That is far past cache, so they measure memory bandwidth more than the per-row comparison, and only at a single point on the size curve. Split out of #10689 at @alamb's request so it can go through the automated benchmarking scripts first.

# What changes are included in this PR?

A new stringview_scalar_eq benchmark group running eq(StringViewArray, StringViewArray::new_scalar("xxxx")) at 65,536 / 1,048,576 / 8,388,608 rows, with Throughput::Elements so criterion reports elements/sec across the sizes. Existing benchmarks are untouched.

# Are these changes tested?

yes

# Are there any user-facing changes?

no