### PR TITLE
Fix `clippy::return_and_then` lint from Rust 1.97

### DIFF
--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -1838,7 +1838,7 @@ impl<'a> StatisticsConverter<'a> {
         let distinct_counts = metadatas
             .into_iter()
             .map(|x| x.column(parquet_index).statistics())
-            .map(|s| s.and_then(|s| s.distinct_count_opt()));
+            .map(|s| s?.distinct_count_opt());
         Ok(UInt64Array::from_iter(distinct_counts))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A -- fixes CI on main

# Rationale for this change

CI clippy jobs on main are failing, e.g. https://github.com/apache/arrow-rs/actions/runs/32180217000/job/95851222817

```text
error: use the `?` operator instead of an `and_then` call
    --> parquet/src/arrow/arrow_reader/statistics.rs:1841:22
     |
1841 |             .map(|s| s.and_then(|s| s.distinct_count_opt()));
     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This is a logical merge conflict between two PRs that were each green on their own:

- #10721 (merged 2026-08-18 09:09 PT, follow-up to #10673) enabled the [`clippy::return_and_then`](https://rust-lang.github.io/rust-clippy/master/index.html#return_and_then) lint workspace-wide
- #10652 (CI last ran 2026-08-11, before the lint was enabled; merged 2026-08-18 12:58 PT) added the `and_then` closure above

# What changes are included in this PR?

Rewrite the closure to use the `?` operator as clippy suggests (semantically identical, no behavior change):

```rust
.map(|s| s?.distinct_count_opt());
```
