### PR TITLE
perf(parquet): compare before copying min/max in ByteArrayEncoder

### DIFF
--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -645,12 +645,18 @@ where
         if let Some(accumulator) = encoder.geo_stats_accumulator.as_mut() {
             update_geo_stats_accumulator(accumulator.as_mut(), values, indices.clone());
         } else if let Some((min, max)) = compute_min_max(values, indices.clone()) {
-            if encoder.min_value.as_ref().is_none_or(|m| m > &min) {
-                encoder.min_value = Some(min);
+            // Compare before copying: `write_gather` runs once per
+            // mini-batch, and a byte-budgeted mini-batch of large values can
+            // hold a single value, so an unconditional copy here would
+            // duplicate every value once for `min` and once for `max`.
+            let min = min.as_ref();
+            if encoder.min_value.as_ref().is_none_or(|m| m.data() > min) {
+                encoder.min_value = Some(min.to_vec().into());
             }
 
-            if encoder.max_value.as_ref().is_none_or(|m| m < &max) {
-                encoder.max_value = Some(max);
+            let max = max.as_ref();
+            if encoder.max_value.as_ref().is_none_or(|m| m.data() < max) {
+                encoder.max_value = Some(max.to_vec().into());
             }
         }
     }
@@ -773,7 +779,7 @@ fn count_within_budget_offsets<T: ByteArrayType>(
 fn compute_min_max<T>(
     array: T,
     mut valid: impl Iterator<Item = usize>,
-) -> Option<(ByteArray, ByteArray)>
+) -> Option<(T::Item, T::Item)>
 where
     T: ArrayAccessor,
     T::Item: Copy + Ord + AsRef<[u8]>,
@@ -788,7 +794,7 @@ where
         min = min.min(val);
         max = max.max(val);
     }
-    Some((min.as_ref().to_vec().into(), max.as_ref().to_vec().into()))
+    Some((min, max))
 }
 
 /// Updates geospatial statistics for the provided array and indices


### PR DESCRIPTION
- Follow-up to #10505 / #10554 (independent of both; #10554 is now stacked on top of this)

## What

`compute_min_max` in `arrow_writer/byte_array.rs` copies both the minimum and the maximum of every mini-batch into fresh `ByteArray`s (`to_vec()`) before `encode` has checked whether either one beats the running page min/max. `write_gather` runs once per mini-batch, and a byte-budgeted mini-batch of large values can hold a single value — so every large value was being allocated and copied twice more, on top of the copies the encoder itself needs.

This returns the borrowed extremes and copies only when the running value actually changes. Statistics are unchanged; the comparison is the same byte-lexicographic order `ByteArray` uses. It only ever removes copies, so it cannot cost more anywhere.

## Why now

Found while profiling #10554 (value-exact mini-batch windows), which showed **+12…15%** on `large_string_distinct_nullable/delta_byte_array` across three runner runs against both `main` and #10505. `samply` put the whole shift into `memmove` under `ByteArrayEncoder::write_gather`; the encoding work per value is identical, so the cost had to be per-mini-batch — and #10554 roughly doubles the mini-batch count on nullable columns. That was this copy.

## Measurements

Runner (`c4a-highmem-16`), three runs each way with identical-code controls; full tables and links in the [results comment](https://github.com/apache/arrow-rs/pull/10745#issuecomment-5339165212).

Isolated (stacked on #10554, vs #10554 head):

| benchmark | mean of 3 | control |
|---|---|---|
| `large_string_shared_prefix_nullable/delta_byte_array` | **−24.4%** | +0.8 |
| `large_string_shared_prefix_nullable_trailing/delta_byte_array` | **−23.2%** | −0.2 |
| `large_string_shared_prefix_nullable_dense/delta_byte_array` | **−22.0%** | +0.7 |
| `large_string_shared_prefix/delta_byte_array` (non-null) | **−21.9%** | −0.7 |
| `medium_string_shared_prefix_nullable/delta_byte_array` | −7.2% | +4.9 |
| `large_string_distinct_nullable/delta_byte_array` | −5.4% | −0.8 |
| `large_string_distinct/delta_byte_array` | −4.0% | −0.2 |

Effect on #10554's regression: `large_string_distinct_nullable/delta_byte_array` vs #10505 goes from **+14.7% to +5.4%**, and its `_nullable` shape from +18.3% to −13.6%.

Alone, vs `main`: the over-limit `DELTA_BYTE_ARRAY` benches are flat — there every over-limit value already opens its own page (the bug #10505 fixes), so `flush_data_page` takes the running min/max on every mini-batch and both copies happen regardless. `large_string_non_null/*` (1024 × 256 KiB, default properties) is **−7…−9%** in all three full runs with a flat control, so it pays today wherever a page holds more than one mini-batch of large values. Nothing else moves outside what the main-vs-main control moves on identical code.

## Tests

No behaviour change; full `parquet` suite green, `fmt` and `clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
