### PR TITLE
ci: match the integration path filter to what the jobs build

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,19 +30,22 @@ on:
     paths:
       - .github/**
       - rust-toolchain.toml
+      - arrow-arith/**
       - arrow-array/**
       - arrow-buffer/**
       - arrow-cast/**
+      - arrow-cmp/**
       - arrow-csv/**
       - arrow-data/**
+      - arrow-flight/**
       - arrow-integration-test/**
       - arrow-integration-testing/**
       - arrow-ipc/**
       - arrow-json/**
-      - arrow-avro/**
       - arrow-ord/**
       - arrow-pyarrow-integration-testing/**
       - arrow-pyarrow/**
+      - arrow-row/**
       - arrow-schema/**
       - arrow-select/**
       - arrow-string/**


### PR DESCRIPTION
# Which issue does this PR close?

Closes #10750.

# Rationale for this change

Answering @Rich-T-kid's question on #10724: yes there are others, and it turns out it goes both ways.

# What changes are included in this PR?

`arrow-arith`, `arrow-cmp`, `arrow-flight` and `arrow-row` added to `integration.yml`'s path filter, `arrow-avro` dropped. One file, four lines added and one removed.

I kept the list alphabetical, which is where the existing entries already sit apart from `arrow-avro` — it was appended after `arrow-json` rather than sorted in.

# Are these changes tested?

Nothing fails today; this only changes when the workflow starts. What I did instead was derive both sets and compare them. `cargo tree -p arrow-integration-testing --edges normal` plus the same inside `arrow-pyarrow-integration-testing` gives the 20 crates the two jobs compile, and after this change the filter is those same 20, with the difference empty in both directions. Dropping any one line back out, or putting `arrow-avro` back, makes the comparison flag it.

I didn't touch `miri.yaml`, which lists a different set for its own reasons.

# Are there any user-facing changes?

No.
