### PR TITLE
feat(ffi): add `FFI_ArrowDeviceArray` and `FFI_ArrowDeviceArrayStream`

### DIFF
--- a/arrow-array/src/ffi.rs
+++ b/arrow-array/src/ffi.rs
@@ -104,7 +104,7 @@ To export an array, create an `ArrowArray` using [ArrowArray::try_new].
 use std::{mem::size_of, ptr::NonNull, sync::Arc};
 
 use arrow_buffer::{Buffer, MutableBuffer, bit_util};
-pub use arrow_data::ffi::FFI_ArrowArray;
+pub use arrow_data::ffi::{ArrowDeviceType, FFI_ArrowArray, FFI_ArrowDeviceArray};
 use arrow_data::{ArrayData, layout};
 pub use arrow_schema::ffi::FFI_ArrowSchema;
 use arrow_schema::{ArrowError, DataType, UnionMode};
@@ -240,6 +240,54 @@ pub fn to_ffi(data: &ArrayData) -> Result<(FFI_ArrowArray, FFI_ArrowSchema)> {
     Ok((array, schema))
 }
 
+/// Export to the [C Device Data Interface] as CPU-resident data
+///
+/// The exported array declares [`ArrowDeviceType::CPU`], so any consumer of the device
+/// interface can read it. Exporting buffers that live on another device is the business of the
+/// crate that allocated them: build the [`FFI_ArrowArray`] and wrap it with
+/// [`FFI_ArrowDeviceArray::new`].
+///
+/// ```
+/// # use arrow_array::{Array, Int32Array};
+/// # use arrow_array::ffi::{ArrowDeviceType, from_device_ffi, to_device_ffi};
+/// # use arrow_schema::ArrowError;
+/// # fn main() -> Result<(), ArrowError> {
+/// let array = Int32Array::from(vec![Some(1), None, Some(3)]);
+///
+/// // export it over the device interface
+/// let (device_array, schema) = to_device_ffi(&array.to_data())?;
+/// assert_eq!(device_array.device_type(), ArrowDeviceType::CPU);
+///
+/// // import it back
+/// let data = unsafe { from_device_ffi(device_array, &schema) }?;
+///
+/// assert_eq!(Int32Array::from(data), array);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [C Device Data Interface]: https://arrow.apache.org/docs/format/CDeviceDataInterface.html
+pub fn to_device_ffi(data: &ArrayData) -> Result<(FFI_ArrowDeviceArray, FFI_ArrowSchema)> {
+    let array = FFI_ArrowDeviceArray::new_cpu(data);
+    let schema = FFI_ArrowSchema::try_from(data.data_type())?;
+    Ok((array, schema))
+}
+
+/// Import [ArrayData] from the [C Device Data Interface]
+///
+/// # Safety
+///
+/// This function assumes that the incoming data agrees with the C device data interface.
+///
+/// [C Device Data Interface]: https://arrow.apache.org/docs/format/CDeviceDataInterface.html
+pub unsafe fn from_device_ffi(
+    array: FFI_ArrowDeviceArray,
+    schema: &FFI_ArrowSchema,
+) -> Result<ArrayData> {
+    let array = require_cpu_resident(array)?;
+    unsafe { from_ffi(array, schema) }
+}
+
 /// Import [ArrayData] from the C Data Interface
 ///
 /// # Safety
@@ -286,6 +334,36 @@ pub unsafe fn from_ffi_and_data_type(
     // https://github.com/apache/arrow-rs/issues/10028 for context.
     data.align_buffers();
     Ok(data)
+}
+
+/// Import [ArrayData] from the [C Device Data Interface], with the type supplied by the caller
+///
+/// Like [`from_device_ffi`], this rejects any array not resident on
+/// [`ArrowDeviceType::CPU`].
+///
+/// # Safety
+///
+/// This function assumes that the incoming data agrees with the C device data interface.
+///
+/// [C Device Data Interface]: https://arrow.apache.org/docs/format/CDeviceDataInterface.html
+pub unsafe fn from_device_ffi_and_data_type(
+    array: FFI_ArrowDeviceArray,
+    data_type: DataType,
+) -> Result<ArrayData> {
+    let array = require_cpu_resident(array)?;
+    unsafe { from_ffi_and_data_type(array, data_type) }
+}
+
+/// Unwraps a device array arrow-rs can read the buffers of, or explains why it cannot
+fn require_cpu_resident(array: FFI_ArrowDeviceArray) -> Result<FFI_ArrowArray> {
+    let device_type = array.device_type();
+    if device_type != ArrowDeviceType::CPU {
+        return Err(ArrowError::CDataInterface(format!(
+            "Cannot import an ArrowDeviceArray with device_type {device_type}: arrow-rs can \
+             only read buffers resident on ARROW_DEVICE_CPU (1)"
+        )));
+    }
+    Ok(array.into_array())
 }
 
 #[derive(Debug)]
@@ -1897,5 +1975,134 @@ mod tests_from_ffi {
 
         test_case::<StringViewType>();
         test_case::<BinaryViewType>();
+    }
+}
+
+#[cfg(test)]
+mod tests_device_ffi {
+    use super::*;
+    use crate::{Array, Int32Array};
+
+    #[test]
+    fn cpu_array_round_trips_through_device_interface() {
+        let data = Int32Array::from(vec![Some(1), None, Some(3)]).into_data();
+
+        let (device_array, schema) = to_device_ffi(&data).unwrap();
+        assert_eq!(device_array.device_type(), ArrowDeviceType::CPU);
+
+        let imported = unsafe { from_device_ffi(device_array, &schema) }.unwrap();
+
+        assert_eq!(
+            Int32Array::from(imported),
+            Int32Array::from(vec![Some(1), None, Some(3)])
+        );
+    }
+
+    #[test]
+    fn non_cpu_device_array_is_rejected_on_import() {
+        let data = Int32Array::from(vec![1, 2, 3]).into_data();
+        let schema = FFI_ArrowSchema::try_from(data.data_type()).unwrap();
+
+        // Claim CUDA residency over host buffers. A correct import rejects on `device_type`
+        // alone, so the buffers are never dereferenced and this stays sound.
+        let device_array = unsafe {
+            FFI_ArrowDeviceArray::new(
+                FFI_ArrowArray::new(&data),
+                ArrowDeviceType::CUDA,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+
+        let err = unsafe { from_device_ffi(device_array, &schema) }.unwrap_err();
+        assert!(matches!(err, ArrowError::CDataInterface(_)), "{err}");
+        assert!(err.to_string().contains("CUDA"), "{err}");
+    }
+
+    #[test]
+    fn cpu_import_accepts_both_device_id_conventions() {
+        // The spec recommends -1 for a device type with no notion of a device identifier
+        // (apache/arrow#40801, resolved by apache/arrow#41101), which is what Arrow C++
+        // exports; nanoarrow and dlpack use 0. Neither is meaningful for CPU data, so both
+        // must import.
+        for device_id in [-1, 0] {
+            let data = Int32Array::from(vec![1, 2, 3]).into_data();
+            let schema = FFI_ArrowSchema::try_from(data.data_type()).unwrap();
+            let device_array = unsafe {
+                FFI_ArrowDeviceArray::new(
+                    FFI_ArrowArray::new(&data),
+                    ArrowDeviceType::CPU,
+                    device_id,
+                    std::ptr::null_mut(),
+                )
+            };
+
+            let imported = unsafe { from_device_ffi(device_array, &schema) }.unwrap();
+
+            assert_eq!(Int32Array::from(imported), Int32Array::from(vec![1, 2, 3]));
+        }
+    }
+
+    #[test]
+    fn cpu_export_uses_the_recommended_device_id() {
+        let data = Int32Array::from(vec![1, 2, 3]).into_data();
+
+        let (device_array, _schema) = to_device_ffi(&data).unwrap();
+
+        assert_eq!(device_array.device_id(), -1);
+    }
+
+    #[test]
+    fn device_metadata_is_carried_verbatim() {
+        // What a crate that does own device memory needs: wrap an exported array with its own
+        // device metadata and read it back unchanged. `sync_event` is opaque to arrow-rs,
+        // which never dereferences it, so a dangling value is safe here.
+        let data = Int32Array::from(vec![1, 2, 3]).into_data();
+        let sync_event = std::ptr::without_provenance_mut::<std::ffi::c_void>(0xdead_beef);
+
+        let device_array = unsafe {
+            FFI_ArrowDeviceArray::new(
+                FFI_ArrowArray::new(&data),
+                ArrowDeviceType::CUDA,
+                3,
+                sync_event,
+            )
+        };
+
+        assert_eq!(device_array.device_type(), ArrowDeviceType::CUDA);
+        assert_eq!(device_array.device_id(), 3);
+        assert_eq!(device_array.sync_event(), sync_event);
+    }
+
+    #[test]
+    fn cpu_export_has_no_sync_event() {
+        let data = Int32Array::from(vec![1, 2, 3]).into_data();
+
+        let (device_array, _schema) = to_device_ffi(&data).unwrap();
+
+        assert!(device_array.sync_event().is_null());
+    }
+
+    #[test]
+    fn an_unknown_device_type_is_preserved_and_rejected() {
+        // The device type list is kept in sync with dlpack upstream, so a producer may name a
+        // device this version of arrow-rs has never heard of. It must round-trip through the
+        // struct and be refused by name rather than silently treated as CPU.
+        let data = Int32Array::from(vec![1, 2, 3]).into_data();
+        let schema = FFI_ArrowSchema::try_from(data.data_type()).unwrap();
+        let future_device = ArrowDeviceType::new(99);
+
+        let device_array = unsafe {
+            FFI_ArrowDeviceArray::new(
+                FFI_ArrowArray::new(&data),
+                future_device,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(device_array.device_type(), future_device);
+
+        let err = unsafe { from_device_ffi(device_array, &schema) }.unwrap_err();
+        assert!(err.to_string().contains("99"), "{err}");
     }
 }

--- a/arrow-array/src/ffi_stream.rs
+++ b/arrow-array/src/ffi_stream.rs
@@ -17,6 +17,10 @@
 
 //! Contains declarations to bind to the [C Stream Interface](https://arrow.apache.org/docs/format/CStreamInterface.html).
 //!
+//! [`FFI_ArrowDeviceArrayStream`] and [`ArrowDeviceArrayStreamReader`] are the same pair for
+//! the [Device Stream Interface](https://arrow.apache.org/docs/format/CDeviceDataInterface.html#device-stream-interface),
+//! which carries the device each array is resident on.
+//!
 //! This module has two main interfaces:
 //! One interface maps C ABI to native Rust types, i.e. convert c-pointers, c_char, to native rust.
 //! This is handled by [FFI_ArrowArrayStream].
@@ -63,13 +67,13 @@ use std::{
     sync::Arc,
 };
 
-use arrow_data::ffi::FFI_ArrowArray;
+use arrow_data::ffi::{ArrowDeviceType, FFI_ArrowArray, FFI_ArrowDeviceArray};
 use arrow_schema::{ArrowError, Schema, SchemaRef, ffi::FFI_ArrowSchema};
 
 use crate::RecordBatchOptions;
 use crate::array::Array;
 use crate::array::StructArray;
-use crate::ffi::from_ffi_and_data_type;
+use crate::ffi::{from_device_ffi_and_data_type, from_ffi_and_data_type};
 use crate::record_batch::{RecordBatch, RecordBatchReader};
 
 type Result<T> = std::result::Result<T, ArrowError>;
@@ -436,6 +440,392 @@ impl RecordBatchReader for ArrowArrayStreamReader {
     }
 }
 
+/// ABI-compatible struct for `ArrowDeviceArrayStream` from the [C Device Data Interface]
+///
+/// See <https://arrow.apache.org/docs/format/CDeviceDataInterface.html#structure-definitions>
+///
+/// A stream produces data on a single device: `device_type` applies to every array it yields.
+/// A producer with data on several devices exposes one stream per device.
+///
+/// [C Device Data Interface]: https://arrow.apache.org/docs/format/CDeviceDataInterface.html
+#[repr(C)]
+#[derive(Debug)]
+pub struct FFI_ArrowDeviceArrayStream {
+    // Fields are intentionally private so safety guarantees can be upheld via
+    // explicit unsafe functions.
+    /// The device that this stream produces data on
+    device_type: ArrowDeviceType,
+    /// C function to get the schema of the stream, which is always CPU-accessible
+    get_schema: Option<unsafe extern "C" fn(arg1: *mut Self, out: *mut FFI_ArrowSchema) -> c_int>,
+    /// C function to get the next device array from the stream
+    get_next:
+        Option<unsafe extern "C" fn(arg1: *mut Self, out: *mut FFI_ArrowDeviceArray) -> c_int>,
+    /// C function to get the error from last operation on the stream
+    get_last_error: Option<unsafe extern "C" fn(arg1: *mut Self) -> *const c_char>,
+    /// C function to release the stream
+    release: Option<unsafe extern "C" fn(arg1: *mut Self)>,
+    /// Private data used by the stream, owned by the release callback.
+    private_data: *mut c_void,
+}
+
+unsafe impl Send for FFI_ArrowDeviceArrayStream {}
+
+// callback used to drop [FFI_ArrowDeviceArrayStream] when it is exported.
+unsafe extern "C" fn release_device_stream(stream: *mut FFI_ArrowDeviceArrayStream) {
+    if stream.is_null() {
+        return;
+    }
+    let stream = unsafe { &mut *stream };
+
+    stream.get_schema = None;
+    stream.get_next = None;
+    stream.get_last_error = None;
+
+    let private_data =
+        unsafe { Box::from_raw(stream.private_data.cast::<DeviceStreamPrivateData>()) };
+    drop(private_data);
+
+    stream.release = None;
+}
+
+struct DeviceStreamPrivateData {
+    batch_reader: Box<dyn RecordBatchReader + Send>,
+    last_error: Option<CString>,
+}
+
+// The callback used to get the stream schema
+unsafe extern "C" fn device_stream_get_schema(
+    stream: *mut FFI_ArrowDeviceArrayStream,
+    schema: *mut FFI_ArrowSchema,
+) -> c_int {
+    ExportedDeviceArrayStream { stream }.get_schema(schema)
+}
+
+// The callback used to get the next device array
+unsafe extern "C" fn device_stream_get_next(
+    stream: *mut FFI_ArrowDeviceArrayStream,
+    array: *mut FFI_ArrowDeviceArray,
+) -> c_int {
+    ExportedDeviceArrayStream { stream }.get_next(array)
+}
+
+// The callback used to get the error from the last operation on the stream
+unsafe extern "C" fn device_stream_get_last_error(
+    stream: *mut FFI_ArrowDeviceArrayStream,
+) -> *const c_char {
+    let mut ffi_stream = ExportedDeviceArrayStream { stream };
+    // The consumer should not take ownership of this string, we should return
+    // a const pointer to it.
+    match ffi_stream.get_last_error() {
+        Some(err_string) => err_string.as_ptr(),
+        None => std::ptr::null(),
+    }
+}
+
+impl Drop for FFI_ArrowDeviceArrayStream {
+    fn drop(&mut self) {
+        match self.release {
+            None => (),
+            Some(release) => unsafe { release(self) },
+        }
+    }
+}
+
+impl FFI_ArrowDeviceArrayStream {
+    /// Creates a new [`FFI_ArrowDeviceArrayStream`] from a [`RecordBatchReader`].
+    ///
+    /// The stream declares [`ArrowDeviceType::CPU`], since a [`RecordBatchReader`] yields
+    /// host-resident batches. Exporting a stream of arrays that live on another device means
+    /// supplying the callbacks directly with [`FFI_ArrowDeviceArrayStream::new_unchecked`].
+    pub fn new(batch_reader: Box<dyn RecordBatchReader + Send>) -> Self {
+        let private_data = Box::new(DeviceStreamPrivateData {
+            batch_reader,
+            last_error: None,
+        });
+
+        Self {
+            device_type: ArrowDeviceType::CPU,
+            get_schema: Some(device_stream_get_schema),
+            get_next: Some(device_stream_get_next),
+            get_last_error: Some(device_stream_get_last_error),
+            release: Some(release_device_stream),
+            private_data: Box::into_raw(private_data).cast::<c_void>(),
+        }
+    }
+
+    /// Creates a new [`FFI_ArrowDeviceArrayStream`] from callbacks a producer supplies itself.
+    ///
+    /// This is the entry point for a crate that produces arrays on a device arrow-rs cannot
+    /// read: it owns the memory and the synchronisation, and only borrows the struct layout so
+    /// that consumers do not have to guess at an incompatible one.
+    ///
+    /// # Safety
+    ///
+    /// The callbacks and `private_data` must together satisfy the [C Device Data Interface]
+    /// contract:
+    ///
+    /// * every array `get_next` writes must be resident on `device_type` and `device_id`, and
+    ///   individually releasable by the consumer
+    /// * the schema `get_schema` writes must be CPU-accessible and releasable independently of
+    ///   the stream
+    /// * `get_last_error` must return a pointer valid until the next operation on the stream
+    /// * `release` must free everything owned by `private_data` and must be idempotent
+    ///
+    /// [C Device Data Interface]: https://arrow.apache.org/docs/format/CDeviceDataInterface.html
+    pub unsafe fn new_unchecked(
+        device_type: ArrowDeviceType,
+        get_schema: unsafe extern "C" fn(*mut Self, *mut FFI_ArrowSchema) -> c_int,
+        get_next: unsafe extern "C" fn(*mut Self, *mut FFI_ArrowDeviceArray) -> c_int,
+        get_last_error: unsafe extern "C" fn(*mut Self) -> *const c_char,
+        release: unsafe extern "C" fn(*mut Self),
+        private_data: *mut c_void,
+    ) -> Self {
+        Self {
+            device_type,
+            get_schema: Some(get_schema),
+            get_next: Some(get_next),
+            get_last_error: Some(get_last_error),
+            release: Some(release),
+            private_data,
+        }
+    }
+
+    /// Takes ownership of the pointed to [`FFI_ArrowDeviceArrayStream`]
+    ///
+    /// This acts to [move] the data out of `raw_stream`, setting the release callback to NULL
+    ///
+    /// # Safety
+    ///
+    /// * `raw_stream` must be [valid] for reads and writes
+    /// * `raw_stream` must be properly aligned
+    /// * `raw_stream` must point to a properly initialized value of
+    ///   [`FFI_ArrowDeviceArrayStream`]
+    ///
+    /// [move]: https://arrow.apache.org/docs/format/CDataInterface.html#moving-an-array
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    pub unsafe fn from_raw(raw_stream: *mut FFI_ArrowDeviceArrayStream) -> Self {
+        unsafe { std::ptr::replace(raw_stream, Self::empty()) }
+    }
+
+    /// Creates a new empty [`FFI_ArrowDeviceArrayStream`]. Used to import from the C Device
+    /// Data Interface.
+    pub fn empty() -> Self {
+        Self {
+            // An empty stream names no device until a producer has filled it in.
+            device_type: ArrowDeviceType::new(0),
+            get_schema: None,
+            get_next: None,
+            get_last_error: None,
+            release: None,
+            private_data: std::ptr::null_mut(),
+        }
+    }
+
+    /// The device that every array in this stream is resident on
+    #[inline]
+    pub fn device_type(&self) -> ArrowDeviceType {
+        self.device_type
+    }
+
+    /// Returns the producer-provided release callback, if any.
+    pub fn release(&self) -> Option<unsafe extern "C" fn(arg1: *mut Self)> {
+        self.release
+    }
+
+    /// Returns the opaque producer-provided private data pointer.
+    pub fn private_data(&self) -> *mut c_void {
+        self.private_data
+    }
+}
+
+struct ExportedDeviceArrayStream {
+    stream: *mut FFI_ArrowDeviceArrayStream,
+}
+
+impl ExportedDeviceArrayStream {
+    fn get_private_data(&mut self) -> &mut DeviceStreamPrivateData {
+        unsafe {
+            &mut *(*self.stream)
+                .private_data
+                .cast::<DeviceStreamPrivateData>()
+        }
+    }
+
+    fn get_schema(&mut self, out: *mut FFI_ArrowSchema) -> i32 {
+        let private_data = self.get_private_data();
+        let reader = &private_data.batch_reader;
+
+        match FFI_ArrowSchema::try_from(reader.schema().as_ref()) {
+            Ok(schema) => {
+                unsafe { std::ptr::copy(addr_of!(schema), out, 1) };
+                std::mem::forget(schema);
+                0
+            }
+            Err(ref err) => {
+                private_data.last_error = Some(
+                    CString::new(err.to_string()).expect("Error string has a null byte in it."),
+                );
+                get_error_code(err)
+            }
+        }
+    }
+
+    fn get_next(&mut self, out: *mut FFI_ArrowDeviceArray) -> i32 {
+        let private_data = self.get_private_data();
+        let reader = &mut private_data.batch_reader;
+
+        match reader.next() {
+            None => {
+                // An empty device array marks the end of the stream.
+                unsafe { std::ptr::write(out, FFI_ArrowDeviceArray::empty()) }
+                0
+            }
+            Some(Ok(batch)) => {
+                let struct_array = StructArray::from(batch);
+                let array = FFI_ArrowDeviceArray::new_cpu(&struct_array.to_data());
+
+                unsafe { std::ptr::write_unaligned(out, array) };
+                0
+            }
+            Some(Err(err)) => {
+                private_data.last_error = Some(
+                    CString::new(err.to_string()).expect("Error string has a null byte in it."),
+                );
+                get_error_code(&err)
+            }
+        }
+    }
+
+    fn get_last_error(&mut self) -> Option<&CString> {
+        self.get_private_data().last_error.as_ref()
+    }
+}
+
+/// A [`RecordBatchReader`] which imports arrays from an [`FFI_ArrowDeviceArrayStream`].
+///
+/// Only a stream declaring [`ArrowDeviceType::CPU`] can be imported: arrow-rs has no way to
+/// read a buffer that lives on another device, so a stream that declares one is refused at
+/// construction rather than read as host memory.
+#[derive(Debug)]
+pub struct ArrowDeviceArrayStreamReader {
+    stream: FFI_ArrowDeviceArrayStream,
+    schema: SchemaRef,
+}
+
+/// Gets the schema from a raw pointer of `FFI_ArrowDeviceArrayStream`, to cache it when
+/// constructing an `ArrowDeviceArrayStreamReader`.
+fn get_device_stream_schema(stream_ptr: *mut FFI_ArrowDeviceArrayStream) -> Result<SchemaRef> {
+    let mut schema = FFI_ArrowSchema::empty();
+
+    let ret_code = unsafe { (*stream_ptr).get_schema.unwrap()(stream_ptr, &mut schema) };
+
+    if ret_code == 0 {
+        let schema = Schema::try_from(&schema)?;
+        Ok(Arc::new(schema))
+    } else {
+        Err(ArrowError::CDataInterface(format!(
+            "Cannot get schema from input stream. Error code: {ret_code:?}"
+        )))
+    }
+}
+
+impl ArrowDeviceArrayStreamReader {
+    /// Creates a new `ArrowDeviceArrayStreamReader` from an [`FFI_ArrowDeviceArrayStream`].
+    /// This is used to import from the C Device Data Interface.
+    ///
+    /// Returns an error if the stream has already been released, or if it declares a
+    /// `device_type` other than [`ArrowDeviceType::CPU`].
+    pub fn try_new(mut stream: FFI_ArrowDeviceArrayStream) -> Result<Self> {
+        if stream.release.is_none() {
+            return Err(ArrowError::CDataInterface(
+                "input stream is already released".to_string(),
+            ));
+        }
+
+        let device_type = stream.device_type();
+        if device_type != ArrowDeviceType::CPU {
+            return Err(ArrowError::CDataInterface(format!(
+                "Cannot import an ArrowDeviceArrayStream with device_type {device_type}: \
+                 arrow-rs can only read buffers resident on ARROW_DEVICE_CPU (1)"
+            )));
+        }
+
+        let schema = get_device_stream_schema(&mut stream)?;
+
+        Ok(Self { stream, schema })
+    }
+
+    /// Creates a new `ArrowDeviceArrayStreamReader` from a raw pointer to an
+    /// [`FFI_ArrowDeviceArrayStream`].
+    ///
+    /// Assumes that the pointer represents a valid C Device Data Interface stream.
+    /// This function copies the content from the raw pointer and cleans it up to prevent
+    /// double-dropping. The caller is responsible for freeing up the memory allocated for
+    /// the pointer.
+    ///
+    /// # Safety
+    ///
+    /// See [`FFI_ArrowDeviceArrayStream::from_raw`]
+    pub unsafe fn from_raw(raw_stream: *mut FFI_ArrowDeviceArrayStream) -> Result<Self> {
+        Self::try_new(unsafe { FFI_ArrowDeviceArrayStream::from_raw(raw_stream) })
+    }
+
+    /// Get the last error from the stream
+    fn get_stream_last_error(&mut self) -> Option<String> {
+        let get_last_error = self.stream.get_last_error?;
+
+        let error_str = unsafe { get_last_error(&mut self.stream) };
+        if error_str.is_null() {
+            return None;
+        }
+
+        let error_str = unsafe { CStr::from_ptr(error_str) };
+        Some(error_str.to_string_lossy().to_string())
+    }
+}
+
+impl Iterator for ArrowDeviceArrayStreamReader {
+    type Item = Result<RecordBatch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut array = FFI_ArrowDeviceArray::empty();
+
+        let ret_code = unsafe { self.stream.get_next.unwrap()(&mut self.stream, &mut array) };
+
+        if ret_code == 0 {
+            // The end of stream has been reached
+            if array.array().is_released() {
+                return None;
+            }
+
+            let result = unsafe {
+                from_device_ffi_and_data_type(
+                    array,
+                    DataType::Struct(self.schema().fields().clone()),
+                )
+            };
+            Some(result.and_then(|data| {
+                let len = data.len();
+                RecordBatch::try_new_with_options(
+                    self.schema.clone(),
+                    StructArray::from(data).into_parts().1,
+                    &RecordBatchOptions::new().with_row_count(Some(len)),
+                )
+            }))
+        } else {
+            let last_error = self.get_stream_last_error();
+            let err = ArrowError::CDataInterface(last_error.unwrap());
+            Some(Err(err))
+        }
+    }
+}
+
+impl RecordBatchReader for ArrowDeviceArrayStreamReader {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -647,5 +1037,94 @@ mod tests {
 
         drop(stream); // runs wrapping_release, which chains to the original
         assert!(STREAM_WRAPPER_RAN.load(Ordering::SeqCst));
+    }
+
+    /// Field offsets and size of [`FFI_ArrowDeviceArrayStream`] against
+    /// `struct ArrowDeviceArrayStream` in `apache/arrow` `cpp/src/arrow/c/abi.h`.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn device_array_stream_layout_matches_c_abi() {
+        use std::mem::offset_of;
+
+        assert_eq!(size_of::<FFI_ArrowDeviceArrayStream>(), 48);
+        assert_eq!(align_of::<FFI_ArrowDeviceArrayStream>(), 8);
+        assert_eq!(offset_of!(FFI_ArrowDeviceArrayStream, device_type), 0);
+        assert_eq!(offset_of!(FFI_ArrowDeviceArrayStream, get_schema), 8);
+        assert_eq!(offset_of!(FFI_ArrowDeviceArrayStream, get_next), 16);
+        assert_eq!(offset_of!(FFI_ArrowDeviceArrayStream, get_last_error), 24);
+        assert_eq!(offset_of!(FFI_ArrowDeviceArrayStream, release), 32);
+        assert_eq!(offset_of!(FFI_ArrowDeviceArrayStream, private_data), 40);
+    }
+
+    #[test]
+    fn cpu_record_batches_round_trip_through_the_device_stream() {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![Some(1), None, Some(3)]))],
+        )
+        .unwrap();
+        let iter = Box::new(vec![batch.clone(), batch.clone()].into_iter().map(Ok)) as _;
+        let reader = Box::new(TestRecordBatchReader::new(schema.clone(), iter));
+
+        let stream = FFI_ArrowDeviceArrayStream::new(reader);
+        assert_eq!(stream.device_type(), ArrowDeviceType::CPU);
+
+        let mut imported = ArrowDeviceArrayStreamReader::try_new(stream).unwrap();
+        assert_eq!(imported.schema(), schema);
+
+        let produced = imported.by_ref().collect::<Result<Vec<_>>>().unwrap();
+
+        assert_eq!(produced, vec![batch.clone(), batch]);
+    }
+
+    // A producer streaming CUDA-resident arrays. Neither data callback may be called: import
+    // has to refuse on `device_type` alone, and must still release the stream it refused.
+    static REJECTED_STREAM_RELEASED: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+
+    unsafe extern "C" fn cuda_get_schema(
+        _: *mut FFI_ArrowDeviceArrayStream,
+        _: *mut FFI_ArrowSchema,
+    ) -> c_int {
+        unreachable!("a non-CPU stream must be rejected before its schema is requested")
+    }
+
+    unsafe extern "C" fn cuda_get_next(
+        _: *mut FFI_ArrowDeviceArrayStream,
+        _: *mut FFI_ArrowDeviceArray,
+    ) -> c_int {
+        unreachable!("a non-CPU stream must be rejected before it is read")
+    }
+
+    unsafe extern "C" fn cuda_get_last_error(_: *mut FFI_ArrowDeviceArrayStream) -> *const c_char {
+        std::ptr::null()
+    }
+
+    unsafe extern "C" fn cuda_release(_: *mut FFI_ArrowDeviceArrayStream) {
+        REJECTED_STREAM_RELEASED.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[test]
+    fn a_non_cpu_device_stream_is_rejected_on_import() {
+        let stream = unsafe {
+            FFI_ArrowDeviceArrayStream::new_unchecked(
+                ArrowDeviceType::CUDA,
+                cuda_get_schema,
+                cuda_get_next,
+                cuda_get_last_error,
+                cuda_release,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(stream.device_type(), ArrowDeviceType::CUDA);
+
+        let err = ArrowDeviceArrayStreamReader::try_new(stream).unwrap_err();
+
+        assert!(err.to_string().contains("CUDA"), "{err}");
+        assert!(
+            REJECTED_STREAM_RELEASED.load(std::sync::atomic::Ordering::SeqCst),
+            "the refused stream was leaked instead of released"
+        );
     }
 }

--- a/arrow-data/src/ffi.rs
+++ b/arrow-data/src/ffi.rs
@@ -16,6 +16,9 @@
 // under the License.
 
 //! Contains declarations to bind to the [C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html).
+//!
+//! [`FFI_ArrowDeviceArray`] extends [`FFI_ArrowArray`] with the device metadata of the
+//! [C Device Data Interface](https://arrow.apache.org/docs/format/CDeviceDataInterface.html).
 
 use crate::bit_mask::set_bits;
 use crate::{ArrayData, layout};
@@ -384,6 +387,237 @@ impl FFI_ArrowArray {
     }
 }
 
+/// The type of device on which the memory backing an [`FFI_ArrowDeviceArray`] is allocated.
+///
+/// Corresponds to `ArrowDeviceType` in the [C Device Data Interface], whose values are the
+/// same as dlpack's `DLDeviceType` and are kept in sync with it upstream. This is a newtype
+/// over `i32` rather than an enum on purpose: a producer may legitimately send a device type
+/// that this version of arrow-rs does not know about, and materialising an unrecognised
+/// discriminant into a Rust enum would be undefined behaviour.
+///
+/// [C Device Data Interface]: https://arrow.apache.org/docs/format/CDeviceDataInterface.html
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ArrowDeviceType(i32);
+
+impl ArrowDeviceType {
+    /// `ARROW_DEVICE_CPU`: the same memory as an [`FFI_ArrowArray`] used directly.
+    pub const CPU: Self = Self(1);
+    /// `ARROW_DEVICE_CUDA`: CUDA GPU device.
+    pub const CUDA: Self = Self(2);
+    /// `ARROW_DEVICE_CUDA_HOST`: pinned CUDA CPU memory allocated by `cudaMallocHost`.
+    pub const CUDA_HOST: Self = Self(3);
+    /// `ARROW_DEVICE_OPENCL`: OpenCL device.
+    pub const OPENCL: Self = Self(4);
+    /// `ARROW_DEVICE_VULKAN`: Vulkan buffer for next-gen graphics.
+    pub const VULKAN: Self = Self(7);
+    /// `ARROW_DEVICE_METAL`: Metal for Apple GPU.
+    pub const METAL: Self = Self(8);
+    /// `ARROW_DEVICE_VPI`: Verilog simulator buffer.
+    pub const VPI: Self = Self(9);
+    /// `ARROW_DEVICE_ROCM`: ROCm GPU for AMD GPUs.
+    pub const ROCM: Self = Self(10);
+    /// `ARROW_DEVICE_ROCM_HOST`: pinned ROCm CPU memory allocated by `hipMallocHost`.
+    pub const ROCM_HOST: Self = Self(11);
+    /// `ARROW_DEVICE_EXT_DEV`: reserved for extension.
+    pub const EXT_DEV: Self = Self(12);
+    /// `ARROW_DEVICE_CUDA_MANAGED`: CUDA managed/unified memory allocated by `cudaMallocManaged`.
+    pub const CUDA_MANAGED: Self = Self(13);
+    /// `ARROW_DEVICE_ONEAPI`: unified shared memory allocated on a oneAPI non-partitioned device.
+    pub const ONEAPI: Self = Self(14);
+    /// `ARROW_DEVICE_WEBGPU`: GPU support for the WebGPU standard.
+    pub const WEBGPU: Self = Self(15);
+    /// `ARROW_DEVICE_HEXAGON`: Qualcomm Hexagon DSP.
+    pub const HEXAGON: Self = Self(16);
+
+    /// Returns the device type with the given raw value, which need not be one of the
+    /// constants this version of arrow-rs knows about.
+    pub const fn new(value: i32) -> Self {
+        Self(value)
+    }
+
+    /// Returns the raw value of this device type.
+    pub const fn value(&self) -> i32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ArrowDeviceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match *self {
+            Self::CPU => "CPU",
+            Self::CUDA => "CUDA",
+            Self::CUDA_HOST => "CUDA_HOST",
+            Self::OPENCL => "OPENCL",
+            Self::VULKAN => "VULKAN",
+            Self::METAL => "METAL",
+            Self::VPI => "VPI",
+            Self::ROCM => "ROCM",
+            Self::ROCM_HOST => "ROCM_HOST",
+            Self::EXT_DEV => "EXT_DEV",
+            Self::CUDA_MANAGED => "CUDA_MANAGED",
+            Self::ONEAPI => "ONEAPI",
+            Self::WEBGPU => "WEBGPU",
+            Self::HEXAGON => "HEXAGON",
+            _ => return write!(f, "unknown device type {}", self.0),
+        };
+        write!(f, "{name} ({})", self.0)
+    }
+}
+
+/// ABI-compatible struct for `ArrowDeviceArray` from the [C Device Data Interface]
+///
+/// See <https://arrow.apache.org/docs/format/CDeviceDataInterface.html#structure-definitions>
+///
+/// Unlike [`FFI_ArrowArray`] this struct carries no release callback of its own: the data is
+/// owned by the embedded [`FFI_ArrowArray`], and releasing that releases the whole device
+/// array.
+///
+/// [C Device Data Interface]: https://arrow.apache.org/docs/format/CDeviceDataInterface.html
+#[repr(C)]
+#[derive(Debug)]
+pub struct FFI_ArrowDeviceArray {
+    // Fields are intentionally private so safety guarantees can be upheld via
+    // explicit unsafe functions.
+    /// The allocated array. The buffers it and its children point to are what is
+    /// allocated on the device.
+    array: FFI_ArrowArray,
+    /// The device id identifying a specific device of `device_type`
+    device_id: i64,
+    /// The type of device which can access the memory backing `array`
+    device_type: ArrowDeviceType,
+    /// An opaque, device-specific event-like object to synchronise on if needed, or null
+    sync_event: *mut c_void,
+    /// Reserved bytes for future expansion; must be zero
+    reserved: [i64; 3],
+}
+
+// SAFETY: the same guarantee [`FFI_ArrowArray`] gives, plus `sync_event`, which arrow-rs
+// treats as an opaque value and never dereferences. Synchronising on it is the job of the
+// consumer that understands `device_type`.
+unsafe impl Send for FFI_ArrowDeviceArray {}
+unsafe impl Sync for FFI_ArrowDeviceArray {}
+
+impl FFI_ArrowDeviceArray {
+    /// Creates a new `FFI_ArrowDeviceArray` describing CPU-resident data.
+    ///
+    /// `device_id` is set to -1 and `sync_event` to null, which is what the [C Device Data
+    /// Interface] recommends for a device type with no intrinsic notion of a device
+    /// identifier.
+    ///
+    /// [C Device Data Interface]: https://arrow.apache.org/docs/format/CDeviceDataInterface.html#c.ArrowDeviceArray.device_id
+    pub fn new_cpu(data: &ArrayData) -> Self {
+        Self {
+            array: FFI_ArrowArray::new(data),
+            device_id: -1,
+            device_type: ArrowDeviceType::CPU,
+            sync_event: std::ptr::null_mut(),
+            reserved: [0; 3],
+        }
+    }
+
+    /// Creates a new `FFI_ArrowDeviceArray` from an already-exported [`FFI_ArrowArray`] and
+    /// the device metadata describing where its buffers live.
+    ///
+    /// This is the entry point for a crate that manages non-CPU memory: build the
+    /// [`FFI_ArrowArray`] with buffer pointers valid on `device_type`, then wrap it here.
+    /// arrow-rs itself neither allocates nor synchronises device memory.
+    ///
+    /// # Safety
+    ///
+    /// * `device_type` and `device_id` must describe the memory that `array`'s buffers — and
+    ///   those of its children and dictionary — actually point to. A consumer is entitled to
+    ///   hand those pointers to that device, so misdeclaring them is undefined behaviour on
+    ///   the consumer's side.
+    /// * `sync_event` must be null, or a pointer to an event object of the type `device_type`
+    ///   expects which stays valid until the consumer has synchronised on it.
+    pub unsafe fn new(
+        array: FFI_ArrowArray,
+        device_type: ArrowDeviceType,
+        device_id: i64,
+        sync_event: *mut c_void,
+    ) -> Self {
+        Self {
+            array,
+            device_id,
+            device_type,
+            sync_event,
+            reserved: [0; 3],
+        }
+    }
+
+    /// Takes ownership of the pointed to [`FFI_ArrowDeviceArray`]
+    ///
+    /// This acts to [move] the data out of `array`, leaving an empty device array behind so
+    /// that the producer's release callback runs exactly once.
+    ///
+    /// # Safety
+    ///
+    /// * `array` must be [valid] for reads and writes
+    /// * `array` must be properly aligned
+    /// * `array` must point to a properly initialized value of [`FFI_ArrowDeviceArray`]
+    ///
+    /// [move]: https://arrow.apache.org/docs/format/CDataInterface.html#moving-an-array
+    /// [valid]: https://doc.rust-lang.org/std/ptr/index.html#safety
+    pub unsafe fn from_raw(array: *mut FFI_ArrowDeviceArray) -> Self {
+        unsafe { std::ptr::replace(array, Self::empty()) }
+    }
+
+    /// Creates an empty `FFI_ArrowDeviceArray`, to be passed to a producer as an out-parameter
+    ///
+    /// Every field is zero, including `device_type`: an empty device array names no device
+    /// until a producer has filled it in.
+    pub fn empty() -> Self {
+        Self {
+            array: FFI_ArrowArray::empty(),
+            device_id: 0,
+            device_type: ArrowDeviceType::new(0),
+            sync_event: std::ptr::null_mut(),
+            reserved: [0; 3],
+        }
+    }
+
+    /// The embedded [`FFI_ArrowArray`], whose buffers point into `device_type` memory
+    #[inline]
+    pub fn array(&self) -> &FFI_ArrowArray {
+        &self.array
+    }
+
+    /// The type of device which can access the memory backing this array
+    #[inline]
+    pub fn device_type(&self) -> ArrowDeviceType {
+        self.device_type
+    }
+
+    /// The device id identifying which device of [`FFI_ArrowDeviceArray::device_type`] can
+    /// access this array
+    ///
+    /// Carries no meaning for [`ArrowDeviceType::CPU`], where producers are split between the
+    /// spec's recommended -1 and dlpack's 0.
+    #[inline]
+    pub fn device_id(&self) -> i64 {
+        self.device_id
+    }
+
+    /// The opaque, device-specific event to synchronise on before reading this array's
+    /// buffers, or null if none is needed
+    ///
+    /// arrow-rs never dereferences this pointer; it is carried so that a consumer which
+    /// understands [`FFI_ArrowDeviceArray::device_type`] can synchronise on it.
+    #[inline]
+    pub fn sync_event(&self) -> *mut c_void {
+        self.sync_event
+    }
+
+    /// Moves the embedded [`FFI_ArrowArray`] out, discarding the device metadata
+    ///
+    /// The returned array owns the data, so releasing it releases what this device array
+    /// described.
+    pub fn into_array(self) -> FFI_ArrowArray {
+        self.array
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -403,5 +637,64 @@ mod tests {
         assert_eq!(0, private_data.buffers_ptr.len());
 
         let _ = Box::into_raw(private_data);
+    }
+
+    /// Field offsets and size of [`FFI_ArrowDeviceArray`] against `struct ArrowDeviceArray`
+    /// in `apache/arrow` `cpp/src/arrow/c/abi.h`. A `#[repr(C)]` struct whose fields are
+    /// declared in the wrong order compiles cleanly and still round-trips within Rust, so
+    /// this is the only check that catches it.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn device_array_layout_matches_c_abi() {
+        assert_eq!(size_of::<FFI_ArrowArray>(), 80);
+        assert_eq!(size_of::<FFI_ArrowDeviceArray>(), 128);
+        assert_eq!(align_of::<FFI_ArrowDeviceArray>(), 8);
+        assert_eq!(std::mem::offset_of!(FFI_ArrowDeviceArray, array), 0);
+        assert_eq!(std::mem::offset_of!(FFI_ArrowDeviceArray, device_id), 80);
+        assert_eq!(std::mem::offset_of!(FFI_ArrowDeviceArray, device_type), 88);
+        assert_eq!(std::mem::offset_of!(FFI_ArrowDeviceArray, sync_event), 96);
+        assert_eq!(std::mem::offset_of!(FFI_ArrowDeviceArray, reserved), 104);
+    }
+
+    /// How a consumer takes ownership of an `ArrowDeviceArray` out-parameter a C producer has
+    /// filled in: move it out, leaving the source released so that dropping both does not
+    /// release the data twice.
+    #[test]
+    fn moving_a_device_array_out_of_a_raw_pointer_empties_the_source() {
+        let data = ArrayData::new_null(&DataType::Int32, 3);
+        let mut produced = FFI_ArrowDeviceArray::new_cpu(&data);
+        assert!(!produced.array().is_released());
+
+        let moved = unsafe { FFI_ArrowDeviceArray::from_raw(&mut produced) };
+
+        assert!(produced.array().is_released());
+        assert!(!moved.array().is_released());
+        assert_eq!(moved.device_type(), ArrowDeviceType::CPU);
+        assert_eq!(moved.device_id(), -1);
+
+        drop(produced);
+        drop(moved);
+    }
+
+    #[test]
+    fn an_empty_device_array_holds_nothing() {
+        let empty = FFI_ArrowDeviceArray::empty();
+
+        assert!(empty.array().is_released());
+        assert!(empty.sync_event().is_null());
+    }
+
+    /// A device array must cross a thread boundary the same way an [`FFI_ArrowArray`] does, so
+    /// that a consumer can hand a batch to a worker without re-wrapping it.
+    #[test]
+    fn a_device_array_can_be_moved_between_threads() {
+        let data = ArrayData::new_null(&DataType::Int32, 3);
+        let device_array = FFI_ArrowDeviceArray::new_cpu(&data);
+
+        let device_type = std::thread::spawn(move || device_array.device_type())
+            .join()
+            .unwrap();
+
+        assert_eq!(device_type, ArrowDeviceType::CPU);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10752.

# Rationale for this change

arrow-rs binds `ArrowArray`, `ArrowSchema` and `ArrowArrayStream`, but nothing from the
[C Device Data Interface](https://arrow.apache.org/docs/format/CDeviceDataInterface.html). A
crate holding a device-resident Arrow array has no shared struct to pass it through, so it
defines its own `#[repr(C)]` copy of `ArrowDeviceArray`, and two crates that both do that cannot
interoperate. Arrow C++, nanoarrow and pyarrow all implement the interface already.

This makes arrow-rs able to speak the interface and carry a device array's metadata faithfully.
It does not make arrow-rs device-aware: no vendor dependency, no allocation, no copying, no
synchronisation, and `sync_event` is never dereferenced. That is the split described in #7618 —
kernels outside arrow-rs, but arrow-rs "able to receive arrays stored in GPU memory and pass them
to kernels that can process them in the GPU".

It is also a prerequisite for the async device stream interface raised in #7228:
`ArrowAsyncTask::extract_data` writes into a `struct ArrowDeviceArray*`, so that interface cannot
be bound in Rust until this struct exists. Async additionally raises the `futures` dependency
question from #7228; the sync structs do not. It is not in this PR.

# What changes are included in this PR?

`arrow-data::ffi`, next to `FFI_ArrowArray`:

- `ArrowDeviceType`, a `#[repr(transparent)]` newtype over `i32` with the constants from
  `abi.h`. Not an enum: the values track dlpack's `DLDeviceType` upstream, so a producer may
  send a device type this version does not know, and materialising an unrecognised discriminant
  into a Rust enum would be UB.
- `FFI_ArrowDeviceArray`, with `new_cpu`, an `unsafe new` for callers that own device memory,
  `from_raw`, `empty`, and accessors. It has no release callback of its own, per the spec — the
  embedded `FFI_ArrowArray` owns the data.

`arrow-array::ffi`:

- `to_device_ffi`, `from_device_ffi`, `from_device_ffi_and_data_type`. Import rejects any
  `device_type` other than `ARROW_DEVICE_CPU` with an `ArrowError::CDataInterface` naming the
  device, rather than reading a device pointer as host memory.
- Both types re-exported, so they reach `arrow::ffi` as `FFI_ArrowArray` does.

`arrow-array::ffi_stream`:

- `FFI_ArrowDeviceArrayStream`, with `new` from a `RecordBatchReader` (declaring
  `ARROW_DEVICE_CPU`) and an `unsafe new_unchecked` for a producer supplying its own callbacks.
- `ArrowDeviceArrayStreamReader`, a `RecordBatchReader` over one, refusing a non-CPU stream at
  construction.

Export declares a `device_id` of -1, which apache/arrow#41101 added to the spec for device types
with no intrinsic device identifier and which Arrow C++ and pyarrow both emit. Import accepts any
`device_id` for CPU data, since nanoarrow uses 0.

No new dependencies or features; all of it sits behind the existing `ffi` feature.

# Are these changes tested?

Yes, and no GPU is needed.

- `size_of`, `align_of` and `offset_of!` for both structs, gated to 64-bit targets. This is the
  check that matters: a `#[repr(C)]` struct with its fields in the wrong order compiles cleanly
  and round-trips fine within Rust.
- CPU round trips for the array and the stream, shaped like the existing `to_ffi` / `from_ffi`
  tests, plus a doctest on `to_device_ffi`.
- Non-CPU rejection for both. The stream test's `get_schema` and `get_next` are `unreachable!()`,
  so it fails if import touches the producer before checking `device_type`, and it asserts the
  refused stream is released rather than leaked.
- An unknown `device_type` of 99 round-trips through the struct and is refused by number.
- Both `device_id` conventions import for CPU.
- `from_raw` leaves the source released, and a device array can be moved across a thread
  boundary.

Cross-checked locally against two other implementations, which CI cannot do:

- apache/arrow's `abi.h`, compiled with gcc 15.3: every `sizeof` and `offsetof` asserted here
  agrees, for both structs, as do the `ARROW_DEVICE_*` constants.
- pyarrow 25.0.1: an int32 array with nulls and a utf8 array exported here and imported with
  `Array._import_from_c_device`, and the reverse via `Array._export_to_c_device`. pyarrow also
  emits `device_id == -1` for CPU data.

I can add the pyarrow direction to `arrow-pyarrow-integration-testing` if that is wanted; it
would need a minimum pyarrow version for the device methods.

# Are there any user-facing changes?

New public API only, and no breaking changes. arrow-rs still reads only CPU buffers: a non-CPU
array is refused with an error, never dereferenced.

Not included, each separable: the async device stream interface, device-resident `Buffer`s or
kernels that can read them, and `sync_event` semantics beyond passing the pointer through.

Assisted-by: Claude Opus 5 (claude-opus-5[1m]) via Claude Code 2.1.233
