### PR TITLE
ci: run clippy for arrow-pyarrow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -238,6 +238,16 @@ jobs:
           cargo test -p arrow-pyarrow --all-features
           cd arrow-pyarrow-testing
           cargo test
+      - name: Clippy arrow-pyarrow
+        run: |
+          source venv/bin/activate
+          # Here rather than in arrow.yml's clippy job: that one runs in a
+          # container with no interpreter for pyo3 to link against.
+          cargo clippy -p arrow-pyarrow --all-targets --all-features -- -D warnings
+          # Dependency check excluding tests & benches. The crate declares no
+          # default features, so the --no-default-features variant arrow.yml
+          # also runs would be this same command.
+          cargo clippy -p arrow-pyarrow --all-features -- -D unused_crate_dependencies
       - name: Run Python tests
         run: |
           source venv/bin/activate


### PR DESCRIPTION
# Which issue does this PR close?

Closes #10757.

# Rationale for this change

Continuing from #10724, which added the missing test and clippy steps for `arrow-cmp`. `arrow-pyarrow` was the other one, and it's the last published crate in the workspace with no clippy run at all.

# What changes are included in this PR?

One step in `integration.yml`'s `Pyarrow C Data Interface` job, after the Rust tests and inside the same venv.

It goes there rather than in `arrow.yml`'s clippy job, where the rest of the `arrow-*` crates are linted, because that job runs in the `amd64/rust` container and pyo3 needs an interpreter to link against. This job already has one, and its toolchain step already installs clippy without using it.

Two invocations instead of the four `arrow.yml` runs per crate: `arrow-pyarrow` declares no `default` feature, so the bare and `--no-default-features` forms of the dependency check are the same command as `--all-features`.

# Are these changes tested?

Both commands pass on `main` as written, so nothing goes red on merge — the point is that a future warning will. I ran them under a fresh venv the way the job does, and dropped a probe lint into `arrow-pyarrow/src/lib.rs` to confirm the step fails rather than passing vacuously.

One thing I'd rather you decided: the job is a three-way matrix over pyarrow 15/16/17, and the lint result doesn't depend on which one, so this runs three times for the same answer. I left it that way because gating a step on a matrix value isn't a pattern used anywhere else in these workflows, but a standalone clippy job — only needing `setup-python`, not the venv or pyarrow itself — would run it once, and I'm happy to send that instead.
