### PR TITLE
Mark unreachable panics with `#[expect(clippy::missing_panics_doc)]`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,6 +209,11 @@ Search for `expect(clippy::` in the codebase to identify lints that are intentio
 - If you have several lints on a function or module, you may disable the lint on the function or module.
 - If a lint is pervasive across multiple modules, you may disable it at the crate level.
 
+Tests, benchmarks and the helpers they use are free to panic, so they carry a file-level
+`#![expect(clippy::missing_panics_doc, ...)]` rather than a `# Panics` section per function.
+Public helper modules such as `arrow::util::bench_util` say so in their module docs, since
+the file-level suppression hides the panics from their own documentation.
+
 ## Performance Improvements
 
 Pull requests that improve performance, especially those that add non-trivial complexity or use `unsafe`, should include evidence of the improvement, such as benchmarks.

--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -251,6 +251,10 @@ where
 ///
 /// Return an error if the arrays have different lengths or
 /// the operation is under erroneous
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "the null buffers of two equal-length arrays with nulls always combine"
+)]
 pub fn try_binary<A: ArrayAccessor, B: ArrayAccessor, F, O>(
     a: A,
     b: B,
@@ -302,6 +306,10 @@ where
 /// Like [`try_unary`] the function is only evaluated for non-null indices.
 ///
 /// See [`binary_mut`] for errors and buffer reuse information.
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "the null buffers of two equal-length arrays with nulls always combine"
+)]
 pub fn try_binary_mut<T, F>(
     a: PrimitiveArray<T>,
     b: &PrimitiveArray<T>,

--- a/arrow-array/src/array/dictionary_array.rs
+++ b/arrow-array/src/array/dictionary_array.rs
@@ -496,6 +496,10 @@ impl<K: ArrowDictionaryKeyType> DictionaryArray<K> {
     /// Returns `PrimitiveDictionaryBuilder` of this dictionary array for mutating
     /// its keys and values if the underlying data buffer is not shared by others.
     #[expect(clippy::result_large_err)]
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "rebuilding the dictionary from its own keys and values always succeeds"
+    )]
     pub fn into_primitive_dict_builder<V>(self) -> Result<PrimitiveDictionaryBuilder<K, V>, Self>
     where
         V: ArrowPrimitiveType,

--- a/arrow-array/src/array/list_array.rs
+++ b/arrow-array/src/array/list_array.rs
@@ -206,6 +206,10 @@ impl<OffsetSize: OffsetSizeTrait> GenericListArray<OffsetSize> {
     /// * `offsets.last() > values.len()`
     /// * `!field.is_nullable() && values.is_nullable()`
     /// * `field.data_type() != values.data_type()`
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "an `OffsetBuffer` is never empty"
+    )]
     pub fn try_new(
         field: FieldRef,
         offsets: OffsetBuffer<OffsetSize>,

--- a/arrow-array/src/array/map_array.rs
+++ b/arrow-array/src/array/map_array.rs
@@ -62,6 +62,10 @@ impl MapArray {
     /// * `entries.columns().len() != 2`
     /// * `field.data_type() != entries.data_type()`
     /// * the keys field is nullable
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "an `OffsetBuffer` is never empty"
+    )]
     pub fn try_new(
         field: FieldRef,
         offsets: OffsetBuffer<i32>,

--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -381,6 +381,10 @@ impl UnionArray {
     /// # Ok(())
     /// # }
     /// ```
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "a `UnionArray` always has a union data type with a child per type id"
+    )]
     pub fn into_parts(
         self,
     ) -> (

--- a/arrow-array/src/builder/generic_bytes_view_builder.rs
+++ b/arrow-array/src/builder/generic_bytes_view_builder.rs
@@ -466,6 +466,10 @@ impl<T: ByteViewType + ?Sized> GenericByteViewBuilder<T> {
     /// # Ok::<(), arrow_schema::ArrowError>(())
     /// ```
     #[inline]
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "`try_append_value` always pushes exactly one view"
+    )]
     pub fn try_append_value_n(
         &mut self,
         value: impl AsRef<T::Native>,

--- a/arrow-buffer/src/buffer/immutable.rs
+++ b/arrow-buffer/src/buffer/immutable.rs
@@ -396,6 +396,10 @@ impl Buffer {
     /// ```
     ///
     /// [`ALIGNMENT`]: crate::alloc::ALIGNMENT
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "the buffer has no offset, so it starts at the allocation pointer"
+    )]
     pub fn into_mutable(self) -> Result<MutableBuffer, Self> {
         let ptr = self.ptr;
         let length = self.length;

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -743,6 +743,10 @@ fn timestamp_to_date32<T: ArrowTimestampType>(
 /// // NOTE: the timestamp is adjusted (08:33:20 instead of 03:33:20 as in previous example)
 /// assert_eq!("2033-05-18T08:33:20", display::array_value_to_string(&d, 1).unwrap());
 /// ```
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "an array always matches the concrete type of its data type"
+)]
 pub fn cast_with_options(
     array: &dyn Array,
     to_type: &DataType,

--- a/arrow-data/src/data.rs
+++ b/arrow-data/src/data.rs
@@ -321,6 +321,10 @@ impl ArrayData {
     /// or [`ArrayDataBuilder`].
     ///
     /// See also [`Self::into_parts`] to recover the fields
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "the local builder is never set to skip validation"
+    )]
     pub fn try_new(
         data_type: DataType,
         len: usize,

--- a/arrow-flight/src/sql/metadata/sql_info.rs
+++ b/arrow-flight/src/sql/metadata/sql_info.rs
@@ -406,6 +406,10 @@ pub struct SqlInfoData {
 impl SqlInfoData {
     /// Return a  [`RecordBatch`] containing only the requested `u32`, if any
     /// from [`CommandGetSqlInfo`]
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "the filters are built from the same array, so they have equal length"
+    )]
     pub fn record_batch(&self, info: impl IntoIterator<Item = u32>) -> Result<RecordBatch> {
         let arr = self.batch.column(0);
         let type_filter = info

--- a/arrow-flight/src/sql/metadata/tables.rs
+++ b/arrow-flight/src/sql/metadata/tables.rs
@@ -157,6 +157,10 @@ impl GetTablesBuilder {
     }
 
     /// builds a `RecordBatch` for `CommandGetTables`
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "the filters are built from the same array, so they have equal length"
+    )]
     pub fn build(self) -> Result<RecordBatch> {
         let schema = self.schema();
         let Self {

--- a/arrow-flight/tests/flight_sql_client.rs
+++ b/arrow-flight/tests/flight_sql_client.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![expect(clippy::missing_panics_doc, reason = "tests are free to panic")]
+
 mod common;
 
 use crate::common::fixture::TestFixture;

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![expect(clippy::missing_panics_doc, reason = "tests are free to panic")]
+
 mod common;
 
 use std::{pin::Pin, sync::Arc};

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -1207,6 +1207,10 @@ impl ArrowJsonBatch {
     /// to an empty `ArrowJsonColumn`.
     ///
     /// </div>
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "a column always matches the concrete type of its data type"
+    )]
     pub fn from_batch(batch: &RecordBatch) -> ArrowJsonBatch {
         let mut json_batch = ArrowJsonBatch {
             count: batch.num_rows(),

--- a/arrow-integration-testing/src/lib.rs
+++ b/arrow-integration-testing/src/lib.rs
@@ -20,6 +20,10 @@
 // The unused_crate_dependencies lint does not work well for crates defining additional examples/bin targets
 #![allow(unused_crate_dependencies)]
 #![warn(missing_docs)]
+#![expect(
+    clippy::missing_panics_doc,
+    reason = "these are integration test binaries, which are free to panic"
+)]
 use serde_json::Value;
 
 use arrow::array::{Array, StructArray};

--- a/arrow-ipc/src/reader.rs
+++ b/arrow-ipc/src/reader.rs
@@ -1093,6 +1093,10 @@ impl FileDecoder {
     }
 
     /// Read the dictionary with the given block and data buffer
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "the header type was just checked to be a dictionary batch"
+    )]
     pub fn read_dictionary(&mut self, block: &Block, buf: &Buffer) -> Result<(), ArrowError> {
         let message = self.read_message(buf)?;
         match message.header_type() {

--- a/arrow-ipc/src/reader/stream.rs
+++ b/arrow-ipc/src/reader/stream.rs
@@ -156,6 +156,10 @@ impl StreamDecoder {
     ///     Ok(())
     /// }
     /// ```
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "the header type was just checked to be a record batch"
+    )]
     pub fn decode(&mut self, buffer: &mut Buffer) -> Result<Option<RecordBatch>, ArrowError> {
         while !buffer.is_empty() {
             match &mut self.state {

--- a/arrow-json/src/writer/mod.rs
+++ b/arrow-json/src/writer/mod.rs
@@ -374,6 +374,10 @@ where
     }
 
     /// Serialize `batch` to JSON output
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "the root of a `RecordBatch` is never nullable"
+    )]
     pub fn write(&mut self, batch: &RecordBatch) -> Result<(), ArrowError> {
         if batch.num_rows() == 0 {
             return Ok(());

--- a/arrow-schema/src/fields.rs
+++ b/arrow-schema/src/fields.rs
@@ -136,6 +136,10 @@ impl Fields {
     /// ]);
     /// assert_eq!(filtered, expected);
     /// ```
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "the predicate passed to `try_filter_leaves` is infallible"
+    )]
     pub fn filter_leaves<F: FnMut(usize, &FieldRef) -> bool>(&self, mut filter: F) -> Self {
         self.try_filter_leaves(|idx, field| Ok(filter(idx, field)))
             .unwrap()

--- a/arrow-string/src/concat_elements.rs
+++ b/arrow-string/src/concat_elements.rs
@@ -414,6 +414,10 @@ pub fn concat_elements_string_view_array(
 /// # Errors
 ///
 /// This function errors if the arrays are of different types.
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "an array always matches the concrete type of its data type"
+)]
 pub fn concat_elements_dyn(left: &dyn Array, right: &dyn Array) -> Result<ArrayRef, ArrowError> {
     match (left.data_type(), right.data_type()) {
         (DataType::Utf8, DataType::Utf8) => {

--- a/arrow-string/src/concat_elements.rs
+++ b/arrow-string/src/concat_elements.rs
@@ -108,6 +108,10 @@ pub fn concat_element_binary<Offset: OffsetSizeTrait>(
 /// ```
 ///
 /// An error will be returned if the [`StringArray`] are of different lengths
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "the offsets of an array of length `size` always yield `size + 1` values"
+)]
 pub fn concat_elements_utf8_many<Offset: OffsetSizeTrait>(
     arrays: &[&GenericStringArray<Offset>],
 ) -> Result<GenericStringArray<Offset>, ArrowError> {

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -17,6 +17,11 @@
 
 //! Utils to make benchmarking easier
 
+#![expect(
+    clippy::missing_panics_doc,
+    reason = "benchmark helpers are free to panic"
+)]
+
 use crate::array::*;
 use crate::datatypes::*;
 use crate::util::test_util::seedable_rng;

--- a/arrow/src/util/bench_util.rs
+++ b/arrow/src/util/bench_util.rs
@@ -16,6 +16,9 @@
 // under the License.
 
 //! Utils to make benchmarking easier
+//!
+//! These helpers are meant for benchmarks, so they panic on invalid input
+//! instead of reporting it. The individual functions do not repeat that.
 
 #![expect(
     clippy::missing_panics_doc,

--- a/arrow/src/util/data_gen.rs
+++ b/arrow/src/util/data_gen.rs
@@ -63,6 +63,10 @@ pub fn create_random_batch(
 /// * `null_density` - The approximate fraction of null values in the resulting array (0.0 to 1.0)
 /// * `true_density` - The approximate fraction of true values in boolean arrays (0.0 to 1.0)
 ///
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "the null density is set to zero for non-nullable fields"
+)]
 pub fn create_random_array(
     field: &Field,
     size: usize,

--- a/arrow/src/util/test_util.rs
+++ b/arrow/src/util/test_util.rs
@@ -17,6 +17,8 @@
 
 //! Utils to make testing easier
 
+#![expect(clippy::missing_panics_doc, reason = "test helpers are free to panic")]
+
 use rand::{RngExt, SeedableRng, rngs::StdRng};
 use std::{env, error::Error, fs, io::Write, path::PathBuf};
 

--- a/arrow/src/util/test_util.rs
+++ b/arrow/src/util/test_util.rs
@@ -16,6 +16,9 @@
 // under the License.
 
 //! Utils to make testing easier
+//!
+//! These helpers are meant for tests, so they panic on invalid input instead of
+//! reporting it. The individual functions do not repeat that.
 
 #![expect(clippy::missing_panics_doc, reason = "test helpers are free to panic")]
 

--- a/parquet-variant-compute/benches/variant_kernels.rs
+++ b/parquet-variant-compute/benches/variant_kernels.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![expect(clippy::missing_panics_doc, reason = "benchmarks are free to panic")]
+
 use arrow::array::{Array, ArrayRef, BinaryViewArray, BinaryViewBuilder, StringArray, StructArray};
 use arrow::buffer::Buffer;
 use arrow_schema::{DataType, Field, FieldRef, Fields};

--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -126,6 +126,10 @@ impl VariantArrayBuilder {
     }
 
     /// Build the final builder
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "the builder only produces valid variant arrays"
+    )]
     pub fn build(self) -> VariantArray {
         let Self {
             mut nulls,

--- a/parquet/benches/parquet_round_trip.rs
+++ b/parquet/benches/parquet_round_trip.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![expect(clippy::missing_panics_doc, reason = "benchmarks are free to panic")]
+
 use arrow::array::{ArrayRef, RecordBatch};
 use arrow::datatypes::{DataType, Field, Float32Type, Float64Type, Int32Type, Int64Type, Schema};
 use arrow::util::bench_util::{

--- a/parquet/src/arrow/arrow_reader/statistics.rs
+++ b/parquet/src/arrow/arrow_reader/statistics.rs
@@ -2027,6 +2027,10 @@ impl<'a> StatisticsConverter<'a> {
     ///   extract the column offset index on a per row group per column basis.
     ///
     /// See docs on [`Self::data_page_mins`] for details.
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "a page location list in the offset index is never empty"
+    )]
     pub fn data_page_row_counts<I>(
         &self,
         column_offset_index: &ParquetOffsetIndex,

--- a/parquet/src/bloom_filter/mod.rs
+++ b/parquet/src/bloom_filter/mod.rs
@@ -391,6 +391,10 @@ impl Sbbf {
 
     /// Create a new [Sbbf] with given number of bytes, the exact number of bytes will be adjusted
     /// to the next power of two bounded by [BITSET_MIN_LENGTH] and [BITSET_MAX_LENGTH].
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "`optimal_num_of_bytes` always returns a multiple of the block size"
+    )]
     pub fn new_with_num_of_bytes(num_bytes: usize) -> Self {
         let num_bytes = optimal_num_of_bytes(num_bytes);
         assert_eq!(num_bytes % size_of::<Block>(), 0);

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -860,6 +860,10 @@ impl<'a, W: Write + Send> SerializedRowGroupWriter<'a, W> {
     }
 
     /// Closes this row group writer and returns row group metadata.
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "the row group metadata is set just above"
+    )]
     pub fn close(mut self) -> Result<RowGroupMetaDataPtr> {
         if self.row_group_metadata.is_none() {
             self.assert_previous_writer_closed()?;


### PR DESCRIPTION
# Which issue does this PR close?

- Part of https://github.com/apache/arrow-rs/issues/10553

# Rationale for this change

This is one of four PRs splitting up the `clippy::missing_panics_doc` work.
Each one stands on its own and touches its own set of functions, but they are
meant to land in order, since the later ones assume the earlier ones:

1. #10755 - return errors from fallible functions
2. #10759 - remove unreachable panics
3. #10760 - document the panics that genuinely remain
4. #10761 - `#[expect]` the unreachable ones, so the lint can be turned on

What is left after the first three PRs is functions whose `unwrap` cannot fail,
but where removing it would mean restructuring code for no gain. Those get an
`#[expect]` with a reason, which is the repo's documented convention for a lint
you disagree with on a given item.

With all four merged, `clippy::missing_panics_doc` is clean across the workspace,
so it can be turned on with the rest of the pedantic lints.

# What changes are included in this PR?

* `#[expect(clippy::missing_panics_doc, reason = "...")]` on the functions whose
  panic is unreachable, each reason naming the invariant that makes it so, for
  example "an `OffsetBuffer` is never empty" or "an array always matches the
  concrete type of its data type"
* file-level `#![expect(...)]` for tests, benchmarks and the helpers they use,
  since those are free to panic
* the same for the whole `arrow-integration-testing` crate, which is
  `publish = false` and holds only the integration test binaries, so nothing
  downstream reads its docs. `arrow-integration-test` keeps its `# Panics`
  sections, since it is published
* records that convention in CONTRIBUTING.md, next to the existing guidance on
  suppressing lints

The lint itself is still not enabled here; that comes with the rest of the
pedantic lints.

One trivial conflict is expected against #10755: both add something directly
above `concat_elements_utf8_many`, an `# Errors` section there and an `#[expect]`
here. Keep both. It resolves itself when this branch is rebased after #10755
lands.

# Are these changes tested?

Verified with `cargo clippy --workspace --all-features --all-targets` with
`missing_panics_doc = "warn"` added to `[workspace.lints.clippy]` locally, on top
of the other three PRs: no warnings, and no unfulfilled expectations.

# Are there any user-facing changes?

No.
