### PR TITLE
feat(parquet): configurable `DictionaryFallback` policy for dictionary encoding fallback

### DIFF
--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -335,6 +335,11 @@ struct DictEncoder {
     interner: Interner<ByteArrayStorage>,
     indices: Vec<u64>,
     variable_length_bytes: i64,
+    /// Total bytes the values appended to this column chunk would occupy
+    /// PLAIN-encoded (4-byte length prefix + payload per value), accumulated
+    /// over all appended values (not just the dictionary's unique values);
+    /// never reset per page
+    plain_encoded_bytes: u64,
 }
 
 impl DictEncoder {
@@ -351,6 +356,7 @@ impl DictEncoder {
             let interned = self.interner.intern(value.as_ref());
             self.indices.push(interned);
             self.variable_length_bytes += value.as_ref().len() as i64;
+            self.plain_encoded_bytes += 4 + value.as_ref().len() as u64;
         }
     }
 
@@ -589,6 +595,10 @@ impl ColumnValueEncoder for ByteArrayEncoder {
 
     fn estimated_dict_page_size(&self) -> Option<usize> {
         Some(self.dict_encoder.as_ref()?.estimated_dict_page_size())
+    }
+
+    fn estimated_plain_encoded_bytes(&self) -> Option<u64> {
+        Some(self.dict_encoder.as_ref()?.plain_encoded_bytes)
     }
 
     /// Returns an estimate of the data page size in bytes

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2076,15 +2076,16 @@ mod tests {
     use arrow::{array::*, buffer::Buffer};
     use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano, NullBuffer, OffsetBuffer, i256};
     use arrow_schema::Fields;
+    use arrow_select::concat::concat_batches;
     use half::f16;
     use num_traits::{FromPrimitive, ToPrimitive};
     use tempfile::tempfile;
 
-    use crate::basic::Encoding;
+    use crate::basic::{Encoding, PageType};
     use crate::data_type::AsBytes;
     use crate::file::metadata::{ColumnChunkMetaData, ParquetMetaData, ParquetMetaDataReader};
     use crate::file::properties::{
-        BloomFilterPosition, EnabledStatistics, ReaderProperties, WriterVersion,
+        BloomFilterPosition, DictionaryFallback, EnabledStatistics, ReaderProperties, WriterVersion,
     };
     use crate::file::serialized_reader::ReadOptionsBuilder;
     use crate::file::{
@@ -5587,6 +5588,237 @@ mod tests {
 
         assert_eq!(get_dict_page_size(col0_meta), 1024 * 1024);
         assert_eq!(get_dict_page_size(col1_meta), 1024 * 1024 * 4);
+    }
+
+    /// A single-column batch of `pool_size * repeats` strings, each of the
+    /// `pool_size` distinct `value_len` byte values repeated `repeats` times
+    /// consecutively. The consecutive runs keep the ratio of distinct to total
+    /// values seen so far at `1 / repeats`, independent of how the writer
+    /// slices the batch internally
+    fn repetitive_string_batch(pool_size: usize, value_len: usize, repeats: usize) -> RecordBatch {
+        let pool: Vec<String> = (0..pool_size)
+            .map(|i| {
+                let mut v = format!("value-{i:06}-").repeat(value_len / 8 + 1);
+                v.truncate(value_len);
+                v
+            })
+            .collect();
+        let array =
+            StringArray::from_iter_values((0..pool_size * repeats).map(|i| &pool[i / repeats]));
+        let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, false)]));
+        RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
+    }
+
+    /// Writes `batch` with `props`, returning the encoded bytes and the metadata
+    fn write_batch_with_props(
+        batch: &RecordBatch,
+        props: WriterProperties,
+    ) -> (Bytes, ParquetMetaData) {
+        let mut writer = ArrowWriter::try_new(Vec::new(), batch.schema(), Some(props)).unwrap();
+        writer.write(batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+        let options = ReadOptionsBuilder::new()
+            .with_encoding_stats_as_mask(false)
+            .build();
+        let reader = SerializedFileReader::new_with_options(data.clone(), options).unwrap();
+        let metadata = reader.metadata().clone();
+        (data, metadata)
+    }
+
+    /// Returns the number of data pages in the first column chunk of the first
+    /// row group encoded with the dictionary, and the number encoded otherwise
+    /// (i.e. with the fallback encoding)
+    fn count_dict_and_fallback_pages(metadata: &ParquetMetaData) -> (i32, i32) {
+        let stats = metadata
+            .row_group(0)
+            .column(0)
+            .page_encoding_stats()
+            .unwrap();
+        let mut num_dict = 0;
+        let mut num_fallback = 0;
+        for s in stats {
+            if s.page_type == PageType::DATA_PAGE || s.page_type == PageType::DATA_PAGE_V2 {
+                match s.encoding {
+                    Encoding::RLE_DICTIONARY | Encoding::PLAIN_DICTIONARY => num_dict += s.count,
+                    _ => num_fallback += s.count,
+                }
+            }
+        }
+        (num_dict, num_fallback)
+    }
+
+    #[test]
+    fn test_dictionary_fallback_explicit_default_policy_unchanged() {
+        // Explicitly configuring `DictionaryFallback::OnPageSizeLimit` must be
+        // byte-identical to the default properties, on data that does overflow
+        // the dictionary page size limit and trigger the fallback
+        let batch = repetitive_string_batch(64, 2048, 32);
+
+        let default_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .build();
+        let explicit_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_dictionary_fallback(DictionaryFallback::OnPageSizeLimit)
+            .build();
+
+        let (default_data, default_metadata) = write_batch_with_props(&batch, default_props);
+        let (explicit_data, _) = write_batch_with_props(&batch, explicit_props);
+
+        assert_eq!(default_data, explicit_data);
+
+        // the dictionary overflowed the 64 KiB limit, so the writer fell back
+        let (num_dict, num_fallback) = count_dict_and_fallback_pages(&default_metadata);
+        assert!(num_dict > 0, "expected dictionary encoded pages");
+        assert!(num_fallback > 0, "expected fallback encoded pages");
+    }
+
+    #[test]
+    fn test_dictionary_fallback_when_profitable_keeps_dictionary() {
+        // 64 distinct 2 KiB values (~131 KiB dictionary) overflow a 64 KiB
+        // dictionary page size limit, but each value recurs 32 times: the
+        // dictionary is profitable, so `WhenProfitable` must keep it while
+        // `OnPageSizeLimit` falls back
+        let batch = repetitive_string_batch(64, 2048, 32);
+
+        let default_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .build();
+        let profitable_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_dictionary_fallback(DictionaryFallback::WhenProfitable {
+                worth_ratio: 0.1,
+                max_dictionary_page_size: 64 * 1024 * 1024,
+            })
+            .build();
+
+        let (default_data, _) = write_batch_with_props(&batch, default_props);
+        let (profitable_data, profitable_metadata) =
+            write_batch_with_props(&batch, profitable_props);
+
+        // no fallback: all data pages are dictionary encoded and the
+        // dictionary page is present
+        let (num_dict, num_fallback) = count_dict_and_fallback_pages(&profitable_metadata);
+        assert!(num_dict > 0, "expected dictionary encoded pages");
+        assert_eq!(num_fallback, 0, "expected no fallback encoded pages");
+        let column = profitable_metadata.row_group(0).column(0);
+        assert!(column.dictionary_page_offset().is_some());
+
+        // deduplicating the repeated values must beat writing them out in full
+        assert!(
+            profitable_data.len() < default_data.len() / 2,
+            "expected dictionary encoded file to be much smaller, got {} vs {}",
+            profitable_data.len(),
+            default_data.len()
+        );
+
+        // roundtrip: the data must read back identically
+        let read = ParquetRecordBatchReader::try_new(profitable_data, 2048)
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+        let read = concat_batches(&batch.schema(), &read).unwrap();
+        assert_eq!(read, batch);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_when_profitable_hard_cap() {
+        // 80 distinct 2 KiB values (~164 KiB dictionary) are profitable at a
+        // worth_ratio of 0.5, but the 128 KiB `max_dictionary_page_size` cap
+        // must force the fallback regardless
+        let batch = repetitive_string_batch(80, 2048, 16);
+
+        let props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_dictionary_fallback(DictionaryFallback::WhenProfitable {
+                worth_ratio: 0.5,
+                max_dictionary_page_size: 128 * 1024,
+            })
+            .build();
+
+        let (_, metadata) = write_batch_with_props(&batch, props);
+
+        let (_, num_fallback) = count_dict_and_fallback_pages(&metadata);
+        assert!(num_fallback > 0, "expected fallback encoded pages");
+    }
+
+    #[test]
+    fn test_dictionary_fallback_when_profitable_high_cardinality_matches_default() {
+        // On a column of unique values the dictionary is never profitable: the
+        // profitability test fails right at the dictionary page size limit, so
+        // `WhenProfitable` must produce output byte-identical to the default
+        // policy. This uses an Int64 column to also exercise the non-byte-array
+        // dictionary encoder
+        let array = Arc::new(Int64Array::from_iter(0..1024 * 1024));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "col",
+            arrow_schema::DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let default_props = WriterProperties::builder().build();
+        let profitable_props = WriterProperties::builder()
+            .set_dictionary_fallback(DictionaryFallback::WhenProfitable {
+                worth_ratio: 0.1,
+                max_dictionary_page_size: 64 * 1024 * 1024,
+            })
+            .build();
+
+        let (default_data, default_metadata) = write_batch_with_props(&batch, default_props);
+        let (profitable_data, _) = write_batch_with_props(&batch, profitable_props);
+
+        // both fall back at the dictionary page size limit
+        let (_, num_fallback) = count_dict_and_fallback_pages(&default_metadata);
+        assert!(num_fallback > 0, "expected fallback encoded pages");
+        assert_eq!(default_data, profitable_data);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_when_profitable_int64_keeps_dictionary() {
+        // Exercise the non-byte-array dictionary encoder's profitability
+        // accounting: 16 Ki distinct Int64 values (128 KiB dictionary), each
+        // repeated 16 times, against a 64 KiB dictionary page size limit
+        let array = Arc::new(Int64Array::from_iter(
+            (0..16 * 1024i64).flat_map(|i| std::iter::repeat_n(i, 16)),
+        ));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "col",
+            arrow_schema::DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_column_dictionary_fallback(
+                ColumnPath::from("col"),
+                DictionaryFallback::WhenProfitable {
+                    worth_ratio: 0.1,
+                    max_dictionary_page_size: 64 * 1024 * 1024,
+                },
+            )
+            .build();
+
+        let (data, metadata) = write_batch_with_props(&batch, props);
+
+        let (num_dict, num_fallback) = count_dict_and_fallback_pages(&metadata);
+        assert!(num_dict > 0, "expected dictionary encoded pages");
+        assert_eq!(num_fallback, 0, "expected no fallback encoded pages");
+        assert!(
+            metadata
+                .row_group(0)
+                .column(0)
+                .dictionary_page_offset()
+                .is_some()
+        );
+
+        let read = ParquetRecordBatchReader::try_new(data, 8192)
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+        let read = concat_batches(&batch.schema(), &read).unwrap();
+        assert_eq!(read, batch);
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -5596,15 +5596,33 @@ mod tests {
     /// values seen so far at `1 / repeats`, independent of how the writer
     /// slices the batch internally
     fn repetitive_string_batch(pool_size: usize, value_len: usize, repeats: usize) -> RecordBatch {
-        let pool: Vec<String> = (0..pool_size)
+        let pool = string_pool(pool_size, value_len);
+        string_batch(pool_size * repeats, |i| &pool[i / repeats])
+    }
+
+    /// As [`repetitive_string_batch`], but cycling the pool rather than
+    /// ordering it into runs: every distinct value is seen before any value
+    /// repeats, so the dictionary is as large as the data it has deduplicated
+    /// by the time it reaches the dictionary page size limit
+    fn interleaved_string_batch(pool_size: usize, value_len: usize, repeats: usize) -> RecordBatch {
+        let pool = string_pool(pool_size, value_len);
+        string_batch(pool_size * repeats, |i| &pool[i % pool_size])
+    }
+
+    /// `pool_size` distinct strings of `value_len` bytes each
+    fn string_pool(pool_size: usize, value_len: usize) -> Vec<String> {
+        (0..pool_size)
             .map(|i| {
                 let mut v = format!("value-{i:06}-").repeat(value_len / 8 + 1);
                 v.truncate(value_len);
                 v
             })
-            .collect();
-        let array =
-            StringArray::from_iter_values((0..pool_size * repeats).map(|i| &pool[i / repeats]));
+            .collect()
+    }
+
+    /// A single non-nullable `Utf8` column of `len` values drawn by `value`
+    fn string_batch<'a>(len: usize, value: impl Fn(usize) -> &'a str) -> RecordBatch {
+        let array = StringArray::from_iter_values((0..len).map(value));
         let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, false)]));
         RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
     }
@@ -5667,9 +5685,13 @@ mod tests {
 
         assert_eq!(default_data, explicit_data);
 
-        // the dictionary overflowed the 64 KiB limit, so the writer fell back
-        let (num_dict, num_fallback) = count_dict_and_fallback_pages(&default_metadata);
-        assert!(num_dict > 0, "expected dictionary encoded pages");
+        // The dictionary overflowed the 64 KiB limit, so the writer fell back.
+        // Only the presence of fallback-encoded pages is asserted: whether any
+        // dictionary-encoded page survives the fallback is up to the writer,
+        // which may re-encode the values buffered at that point rather than
+        // seal them as one more dictionary-encoded page. What this policy
+        // controls is *when* the fallback happens, not what it does.
+        let (_, num_fallback) = count_dict_and_fallback_pages(&default_metadata);
         assert!(num_fallback > 0, "expected fallback encoded pages");
     }
 
@@ -5740,6 +5762,37 @@ mod tests {
 
         let (_, num_fallback) = count_dict_and_fallback_pages(&metadata);
         assert!(num_fallback > 0, "expected fallback encoded pages");
+    }
+
+    #[test]
+    fn test_dictionary_fallback_when_profitable_interleaved_matches_default() {
+        // Profitability is judged against the values appended so far, so the
+        // same pool of values can decide either way depending on the order it
+        // arrives in. Cycled, every distinct value is seen before any repeat,
+        // so when the dictionary reaches the page size limit it has
+        // deduplicated barely more than its own size and `WhenProfitable`
+        // falls back exactly where the default policy does. The identical
+        // pool ordered into runs keeps its dictionary instead, in
+        // `test_dictionary_fallback_when_profitable_keeps_dictionary`.
+        let batch = interleaved_string_batch(64, 2048, 32);
+
+        let default_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .build();
+        let profitable_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_dictionary_fallback(DictionaryFallback::WhenProfitable {
+                worth_ratio: 0.1,
+                max_dictionary_page_size: 64 * 1024 * 1024,
+            })
+            .build();
+
+        let (default_data, default_metadata) = write_batch_with_props(&batch, default_props);
+        let (profitable_data, _) = write_batch_with_props(&batch, profitable_props);
+
+        let (_, num_fallback) = count_dict_and_fallback_pages(&default_metadata);
+        assert!(num_fallback > 0, "expected fallback encoded pages");
+        assert_eq!(default_data, profitable_data);
     }
 
     #[test]

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -139,6 +139,18 @@ pub trait ColumnValueEncoder {
     /// Returns an estimate of the encoded size of dictionary page size in bytes, or `None` if no dictionary
     fn estimated_dict_page_size(&self) -> Option<usize>;
 
+    /// Returns an estimate of the total bytes the values appended to this column
+    /// chunk so far would occupy PLAIN-encoded, or `None` if unknown
+    ///
+    /// Used together with [`Self::estimated_dict_page_size`] to decide whether
+    /// dictionary encoding is still paying for itself relative to the fallback
+    /// encoding, see [`DictionaryFallback::WhenProfitable`]
+    ///
+    /// [`DictionaryFallback::WhenProfitable`]: crate::file::properties::DictionaryFallback::WhenProfitable
+    fn estimated_plain_encoded_bytes(&self) -> Option<u64> {
+        None
+    }
+
     /// Returns an estimate of the encoded data page size in bytes
     ///
     /// This should include:
@@ -349,6 +361,10 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
 
     fn estimated_dict_page_size(&self) -> Option<usize> {
         Some(self.dict_encoder.as_ref()?.dict_encoded_size())
+    }
+
+    fn estimated_plain_encoded_bytes(&self) -> Option<u64> {
+        Some(self.dict_encoder.as_ref()?.plain_encoded_bytes())
     }
 
     fn estimated_data_page_size(&self) -> usize {

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -45,7 +45,7 @@ use crate::file::metadata::{
     OffsetIndexBuilder, PageEncodingStats,
 };
 use crate::file::properties::{
-    EnabledStatistics, WriterProperties, WriterPropertiesPtr, WriterVersion,
+    DictionaryFallback, EnabledStatistics, WriterProperties, WriterPropertiesPtr, WriterVersion,
 };
 use crate::file::statistics::{Statistics, ValueStatistics};
 use crate::schema::types::{BasicTypeInfo, ColumnDescPtr, ColumnDescriptor};
@@ -1048,17 +1048,40 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
 
     /// Returns true if we need to fall back to non-dictionary encoding.
     ///
-    /// We can only fall back if dictionary encoder is set and we have exceeded dictionary
-    /// size.
+    /// We can only fall back if a dictionary encoder is set. When and whether the
+    /// dictionary is abandoned is controlled by the column's [`DictionaryFallback`]
+    /// policy.
     #[inline]
     fn should_dict_fallback(&self) -> bool {
-        match self.encoder.estimated_dict_page_size() {
-            Some(size) => {
-                size >= self
-                    .props
-                    .column_dictionary_page_size_limit(self.descr.path())
+        let Some(dict_page_size) = self.encoder.estimated_dict_page_size() else {
+            return false;
+        };
+
+        let limit = self
+            .props
+            .column_dictionary_page_size_limit(self.descr.path());
+
+        match self.props.column_dictionary_fallback(self.descr.path()) {
+            DictionaryFallback::OnPageSizeLimit => dict_page_size >= limit,
+            DictionaryFallback::WhenProfitable {
+                worth_ratio,
+                max_dictionary_page_size,
+            } => {
+                if dict_page_size >= max_dictionary_page_size {
+                    return true;
+                }
+
+                if dict_page_size < limit {
+                    return false;
+                }
+
+                match self.encoder.estimated_plain_encoded_bytes() {
+                    Some(plain_bytes) => dict_page_size as f64 > worth_ratio * plain_bytes as f64,
+                    // No estimate of the plain-encoded size is available:
+                    // preserve the absolute-limit behavior
+                    None => true,
+                }
             }
-            None => false,
         }
     }
 

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -88,6 +88,11 @@ pub struct DictEncoder<T: DataType> {
 
     /// The buffered indices
     indices: Vec<u64>,
+
+    /// Total bytes the values appended to this column chunk would occupy
+    /// PLAIN-encoded, accumulated over all appended values (not just the
+    /// dictionary's unique values); never reset per page
+    plain_encoded_bytes: u64,
 }
 
 impl<T: DataType> DictEncoder<T> {
@@ -102,6 +107,7 @@ impl<T: DataType> DictEncoder<T> {
         Self {
             interner: Interner::new(storage),
             indices: vec![],
+            plain_encoded_bytes: 0,
         }
     }
 
@@ -145,7 +151,20 @@ impl<T: DataType> DictEncoder<T> {
         Ok(encoder.consume().into())
     }
 
+    /// Returns the total bytes the values appended to this encoder would occupy
+    /// PLAIN-encoded.
+    pub fn plain_encoded_bytes(&self) -> u64 {
+        self.plain_encoded_bytes
+    }
+
     fn put_one(&mut self, value: &T::T) {
+        let (base_size, num_elements) = value.dict_encoding_size();
+        let plain_size = match T::get_physical_type() {
+            Type::BYTE_ARRAY => base_size + num_elements,
+            Type::FIXED_LEN_BYTE_ARRAY => self.interner.storage().type_length,
+            _ => base_size,
+        };
+        self.plain_encoded_bytes += plain_size as u64;
         self.indices.push(self.interner.intern(value));
     }
 

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -38,6 +38,8 @@ pub const DEFAULT_COMPRESSION: Compression = Compression::UNCOMPRESSED;
 pub const DEFAULT_DICTIONARY_ENABLED: bool = true;
 /// Default value for [`WriterProperties::dictionary_page_size_limit`]
 pub const DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT: usize = DEFAULT_PAGE_SIZE;
+/// Default value for [`WriterProperties::dictionary_fallback`]
+pub const DEFAULT_DICTIONARY_FALLBACK: DictionaryFallback = DictionaryFallback::OnPageSizeLimit;
 /// Default value for [`WriterProperties::data_page_row_count_limit`]
 pub const DEFAULT_DATA_PAGE_ROW_COUNT_LIMIT: usize = 20_000;
 /// Default value for [`WriterProperties::statistics_enabled`]
@@ -331,6 +333,26 @@ impl WriterProperties {
             .and_then(|c| c.dictionary_page_size_limit())
             .or_else(|| self.default_column_properties.dictionary_page_size_limit())
             .unwrap_or(DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT)
+    }
+
+    /// Returns the default dictionary fallback policy.
+    ///
+    /// For more details see [`WriterPropertiesBuilder::set_dictionary_fallback`]
+    pub fn dictionary_fallback(&self) -> DictionaryFallback {
+        self.default_column_properties
+            .dictionary_fallback()
+            .unwrap_or(DEFAULT_DICTIONARY_FALLBACK)
+    }
+
+    /// Returns the dictionary fallback policy for a specific column.
+    ///
+    /// Takes precedence over [`Self::dictionary_fallback`].
+    pub fn column_dictionary_fallback(&self, col: &ColumnPath) -> DictionaryFallback {
+        self.column_properties
+            .get(col)
+            .and_then(|c| c.dictionary_fallback())
+            .or_else(|| self.default_column_properties.dictionary_fallback())
+            .unwrap_or(DEFAULT_DICTIONARY_FALLBACK)
     }
 
     /// Returns the maximum page row count
@@ -1099,6 +1121,22 @@ impl WriterPropertiesBuilder {
         self
     }
 
+    /// Sets the default [`DictionaryFallback`] policy for all columns (defaults to
+    /// [`DictionaryFallback::OnPageSizeLimit`] via [`DEFAULT_DICTIONARY_FALLBACK`]).
+    ///
+    /// This controls when the writer gives up on dictionary encoding for a
+    /// column chunk and switches to the column's fallback encoding.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the policy is [`DictionaryFallback::WhenProfitable`] with a
+    /// `worth_ratio` that is not finite or is not strictly positive.
+    pub fn set_dictionary_fallback(mut self, value: DictionaryFallback) -> Self {
+        self.default_column_properties
+            .set_dictionary_fallback(value);
+        self
+    }
+
     /// Sets best effort maximum size of a data page in bytes (defaults to `1024 * 1024`
     /// via [`DEFAULT_PAGE_SIZE`]).
     ///
@@ -1252,6 +1290,23 @@ impl WriterPropertiesBuilder {
     pub fn set_column_dictionary_page_size_limit(mut self, col: ColumnPath, value: usize) -> Self {
         self.get_mut_props(col)
             .set_dictionary_page_size_limit(value);
+        self
+    }
+
+    /// Sets the [`DictionaryFallback`] policy for a specific column.
+    ///
+    /// Takes precedence over [`Self::set_dictionary_fallback`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the policy is [`DictionaryFallback::WhenProfitable`] with a
+    /// `worth_ratio` that is not finite or is not strictly positive.
+    pub fn set_column_dictionary_fallback(
+        mut self,
+        col: ColumnPath,
+        value: DictionaryFallback,
+    ) -> Self {
+        self.get_mut_props(col).set_dictionary_fallback(value);
         self
     }
 
@@ -1443,6 +1498,73 @@ impl Default for EnabledStatistics {
     }
 }
 
+/// Controls when dictionary encoding falls back to the column's fallback encoding.
+///
+/// While dictionary encoding is enabled for a column, the writer buffers a
+/// dictionary of the distinct values seen so far. This policy decides when the
+/// writer gives up on dictionary encoding for the remainder of the column chunk
+/// and switches to the fallback encoding (e.g. `PLAIN`, or a delta encoding
+/// with [`WriterVersion::PARQUET_2_0`]).
+///
+/// This enum is `#[non_exhaustive]`: additional policies may be added in the
+/// future.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub enum DictionaryFallback {
+    /// Fall back as soon as the dictionary page exceeds
+    /// [`WriterProperties::dictionary_page_size_limit`].
+    ///
+    /// This is the default, and the historical behavior of this crate.
+    OnPageSizeLimit,
+    /// Keep the dictionary past [`WriterProperties::dictionary_page_size_limit`]
+    /// (which acts as a grace floor) for as long as it stays profitable,
+    /// falling back unconditionally at `max_dictionary_page_size`.
+    ///
+    /// The dictionary is considered profitable while the dictionary page is
+    /// smaller than `worth_ratio` times the total size the values appended so
+    /// far would occupy PLAIN-encoded. For example, with a `worth_ratio` of
+    /// `0.1` the dictionary is kept (past the grace floor) only while it is at
+    /// least 10x smaller than the PLAIN encoding of the data.
+    ///
+    /// This helps columns whose values are large but highly repetitive: with
+    /// [`Self::OnPageSizeLimit`], a handful of distinct multi-kilobyte values
+    /// overflows the (default 1 MiB) dictionary page size limit and each
+    /// repeated value is written out in full by the fallback encoding, even
+    /// though a slightly larger dictionary would have deduplicated them.
+    ///
+    /// `max_dictionary_page_size` is a memory guard: readers must decompress
+    /// and materialize the entire dictionary page (the format allows at most
+    /// one dictionary page per column chunk, so it cannot be split), so an
+    /// unboundedly profitable dictionary must still be capped. A value of
+    /// `64 * 1024 * 1024` (64 MiB) is a reasonable upper bound; a
+    /// `worth_ratio` of `0.1` is a conservative choice that avoids regressions
+    /// on columns where a delta fallback encoding would beat a nominally
+    /// "profitable" dictionary (e.g. sorted numeric keys).
+    ///
+    /// The PLAIN-encoded size is used as a pessimistic upper bound for the
+    /// fallback encoding's size: the Parquet specification requires the delta
+    /// encodings to never exceed the PLAIN encoding of the same values. The
+    /// exact profitability estimate is an implementation detail and may be
+    /// refined in the future (for example, by measuring the actual fallback
+    /// encoding) without changing this API.
+    WhenProfitable {
+        /// Maximum ratio of the dictionary page size to the PLAIN-encoded size
+        /// of the values appended so far for the dictionary to be considered
+        /// profitable. Must be finite and greater than zero.
+        worth_ratio: f64,
+        /// Hard cap on the dictionary page size, in bytes: the writer always
+        /// falls back once the dictionary page reaches this size, regardless
+        /// of profitability.
+        max_dictionary_page_size: usize,
+    },
+}
+
+impl Default for DictionaryFallback {
+    fn default() -> Self {
+        DEFAULT_DICTIONARY_FALLBACK
+    }
+}
+
 /// Controls the bloom filter to be computed by the writer.
 ///
 /// The bloom filter is initially sized for `ndv` distinct values at the given `fpp`, then
@@ -1629,6 +1751,7 @@ struct ColumnProperties {
     data_page_size_limit: Option<usize>,
     dictionary_page_size_limit: Option<usize>,
     dictionary_enabled: Option<bool>,
+    dictionary_fallback: Option<DictionaryFallback>,
     statistics_enabled: Option<EnabledStatistics>,
     write_page_header_statistics: Option<bool>,
     /// bloom filter related properties
@@ -1673,6 +1796,22 @@ impl ColumnProperties {
     /// Sets dictionary page size limit for this column.
     fn set_dictionary_page_size_limit(&mut self, value: usize) {
         self.dictionary_page_size_limit = Some(value);
+    }
+
+    /// Sets the dictionary fallback policy for this column.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the policy is [`DictionaryFallback::WhenProfitable`] with a
+    /// `worth_ratio` that is not finite or is not strictly positive.
+    fn set_dictionary_fallback(&mut self, value: DictionaryFallback) {
+        if let DictionaryFallback::WhenProfitable { worth_ratio, .. } = value {
+            assert!(
+                worth_ratio.is_finite() && worth_ratio > 0.0,
+                "worth_ratio must be a positive finite number, got {worth_ratio}"
+            );
+        }
+        self.dictionary_fallback = Some(value);
     }
 
     /// Sets the statistics level for this column.
@@ -1763,6 +1902,11 @@ impl ColumnProperties {
     /// Returns optional dictionary page size limit for this column.
     fn dictionary_page_size_limit(&self) -> Option<usize> {
         self.dictionary_page_size_limit
+    }
+
+    /// Returns optional dictionary fallback policy for this column.
+    fn dictionary_fallback(&self) -> Option<DictionaryFallback> {
+        self.dictionary_fallback
     }
 
     /// Returns optional data page size limit for this column.
@@ -1963,6 +2107,11 @@ mod tests {
             props.dictionary_enabled(&ColumnPath::from("col")),
             DEFAULT_DICTIONARY_ENABLED
         );
+        assert_eq!(props.dictionary_fallback(), DEFAULT_DICTIONARY_FALLBACK);
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("col")),
+            DEFAULT_DICTIONARY_FALLBACK
+        );
         assert_eq!(
             props.statistics_enabled(&ColumnPath::from("col")),
             DEFAULT_STATISTICS_ENABLED
@@ -1972,6 +2121,50 @@ mod tests {
                 .bloom_filter_properties(&ColumnPath::from("col"))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_writer_properties_dictionary_fallback() {
+        let when_profitable = DictionaryFallback::WhenProfitable {
+            worth_ratio: 0.1,
+            max_dictionary_page_size: 64 * 1024 * 1024,
+        };
+        let props = WriterProperties::builder()
+            .set_dictionary_fallback(when_profitable)
+            .set_column_dictionary_fallback(
+                ColumnPath::from("col"),
+                DictionaryFallback::OnPageSizeLimit,
+            )
+            .build();
+        assert_eq!(props.dictionary_fallback(), when_profitable);
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("other")),
+            when_profitable
+        );
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("col")),
+            DictionaryFallback::OnPageSizeLimit
+        );
+
+        // survives the round trip through into_builder
+        let props = props.into_builder().build();
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("col")),
+            DictionaryFallback::OnPageSizeLimit
+        );
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("other")),
+            when_profitable
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "worth_ratio must be a positive finite number")]
+    fn test_writer_properties_dictionary_fallback_invalid_ratio() {
+        WriterProperties::builder().set_dictionary_fallback(DictionaryFallback::WhenProfitable {
+            worth_ratio: 0.0,
+            max_dictionary_page_size: 64 * 1024 * 1024,
+        });
     }
 
     #[test]

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -1517,44 +1517,26 @@ pub enum DictionaryFallback {
     /// This is the default, and the historical behavior of this crate.
     OnPageSizeLimit,
     /// Keep the dictionary past [`WriterProperties::dictionary_page_size_limit`]
-    /// (which acts as a grace floor) for as long as it stays profitable,
-    /// falling back unconditionally at `max_dictionary_page_size`.
+    /// (which acts as a grace floor) while the dictionary page stays smaller
+    /// than `worth_ratio` times the PLAIN-encoded size of the values appended
+    /// so far, falling back unconditionally at `max_dictionary_page_size`.
     ///
-    /// The dictionary is considered profitable while the dictionary page is
-    /// smaller than `worth_ratio` times the total size the values appended so
-    /// far would occupy PLAIN-encoded. For example, with a `worth_ratio` of
-    /// `0.1` the dictionary is kept (past the grace floor) only while it is at
-    /// least 10x smaller than the PLAIN encoding of the data.
+    /// This helps columns with large but highly repetitive values, where a
+    /// handful of distinct values overflows the page size limit even though
+    /// the dictionary is deduplicating many times its size. A `worth_ratio`
+    /// of `0.1` and a `max_dictionary_page_size` of 64 MiB are reasonable
+    /// starting points.
     ///
-    /// This helps columns whose values are large but highly repetitive: with
-    /// [`Self::OnPageSizeLimit`], a handful of distinct multi-kilobyte values
-    /// overflows the (default 1 MiB) dictionary page size limit and each
-    /// repeated value is written out in full by the fallback encoding, even
-    /// though a slightly larger dictionary would have deduplicated them.
-    ///
-    /// `max_dictionary_page_size` is a memory guard: readers must decompress
-    /// and materialize the entire dictionary page (the format allows at most
-    /// one dictionary page per column chunk, so it cannot be split), so an
-    /// unboundedly profitable dictionary must still be capped. A value of
-    /// `64 * 1024 * 1024` (64 MiB) is a reasonable upper bound; a
-    /// `worth_ratio` of `0.1` is a conservative choice that avoids regressions
-    /// on columns where a delta fallback encoding would beat a nominally
-    /// "profitable" dictionary (e.g. sorted numeric keys).
-    ///
-    /// The PLAIN-encoded size is used as a pessimistic upper bound for the
-    /// fallback encoding's size: the Parquet specification requires the delta
-    /// encodings to never exceed the PLAIN encoding of the same values. The
-    /// exact profitability estimate is an implementation detail and may be
-    /// refined in the future (for example, by measuring the actual fallback
-    /// encoding) without changing this API.
+    /// PLAIN size is a pessimistic upper bound for the fallback encoding's
+    /// size; the exact profitability estimate may be refined in the future
+    /// without changing this API.
     WhenProfitable {
-        /// Maximum ratio of the dictionary page size to the PLAIN-encoded size
-        /// of the values appended so far for the dictionary to be considered
-        /// profitable. Must be finite and greater than zero.
+        /// Maximum ratio of dictionary page size to the PLAIN-encoded size of
+        /// the values appended so far. Must be finite and greater than zero.
         worth_ratio: f64,
-        /// Hard cap on the dictionary page size, in bytes: the writer always
-        /// falls back once the dictionary page reaches this size, regardless
-        /// of profitability.
+        /// Hard cap on the dictionary page size, in bytes; the writer always
+        /// falls back at this size. Bounds the memory a reader needs to
+        /// materialize the dictionary page.
         max_dictionary_page_size: usize,
     },
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Part of #9699.

This revives the direction of #9700 by @mzabaluev (closed as stale), whose design discussion shaped this API: a configurable fallback *policy* enum with per-variant parameters (as proposed by @etseidl in the #9700 discussion) rather than a change to the default heuristics (per @alamb's feedback there). Full credit to @mzabaluev for the prior art and the `DictionaryFallback` name.

# Rationale for this change

Today the writer abandons dictionary encoding for a column chunk as soon as the dictionary page exceeds `dictionary_page_size_limit` (1 MiB default), regardless of whether the dictionary is paying for itself. For columns whose values are large but highly repetitive — e.g. multi-KiB metadata/payload blobs where a few thousand distinct values recur throughout the file — a handful of distinct values overflows the limit, and every subsequent repeat is written out in full by the fallback encoding. Raising `dictionary_page_size_limit` file-wide is a blunt instrument: it also grows dictionaries on columns where the dictionary is *not* profitable, and the limit exists for a reason (readers must decompress and materialize the entire dictionary page; the format allows at most one dictionary page per column chunk, so it cannot be split).

This PR adds an opt-in policy that keeps the dictionary past the limit only while it remains profitable:

```rust
#[non_exhaustive]
pub enum DictionaryFallback {
    /// Fall back when the dictionary page exceeds `dictionary_page_size_limit`.
    /// (Current behavior; default.)
    OnPageSizeLimit,
    /// Keep the dictionary past `dictionary_page_size_limit` (the grace floor)
    /// while it stays profitable — dictionary page smaller than `worth_ratio` ×
    /// the PLAIN-encoded size of the values appended so far — falling back
    /// unconditionally at `max_dictionary_page_size` (reader memory guard).
    WhenProfitable { worth_ratio: f64, max_dictionary_page_size: usize },
}
```

The PLAIN-encoded size is a cheap, pessimistic upper bound for the fallback encoding: the spec requires the delta encodings to not exceed PLAIN for the same values (as noted by @etseidl and @mzabaluev in #9700). The profitability estimate is documented as an implementation detail so a future PR can replace it with a measured comparison without changing this API. Suggested opt-in values: `worth_ratio: 0.1`, `max_dictionary_page_size: 64 * 1024 * 1024`.

**The default is `OnPageSizeLimit` and default output is bit-identical to today.**

# What changes are included in this PR?

- `DictionaryFallback` enum in `file/properties.rs`, plumbed file-wide (`set_dictionary_fallback`) and per-column (`set_column_dictionary_fallback`), following the existing `dictionary_page_size_limit` pattern.
- Both dictionary encoders (the generic `DictEncoder` and the arrow byte-array `DictEncoder`) accumulate the PLAIN-encoded size of appended values (one add per value), exposed via a defaulted `ColumnValueEncoder::estimated_plain_encoded_bytes`.
- `should_dict_fallback` implements the policy: hard cap first, then the grace floor, then the profitability ratio; encoders with no estimate preserve the absolute-limit behavior.
- Tests: explicit `OnPageSizeLimit` byte-identical to default properties on fallback-triggering data; opt-in keeps the dictionary past the limit on a repetitive column (no fallback-encoded pages, dictionary page present, less than half the default-policy file size, roundtrip equality); the hard cap forces fallback even when profitable; a high-cardinality Int64 column produces byte-identical output to stock under the opt-in policy; property plumbing incl. `into_builder()` roundtrip and `worth_ratio` validation.

# Benchmarks

Methodology: every file of each dataset is rewritten with `ArrowWriter`, ZSTD level 1, otherwise default properties, with **only the fallback policy differing between arms**; numbers are the sum of output file bytes over the same file set.

## Repetitive large values (seeded reproducer)

A pool of 1000 distinct 16 KiB random blobs over 16384 rows × 4 files (seed 42), values recurring in short runs of 16 — bursty local repeats that recur file-wide, farther apart than a codec window. Generator (pyarrow):

```python
import numpy as np, pyarrow as pa, pyarrow.parquet as pq, os, string
OUT = "repetitive_large_values_runs"
os.makedirs(OUT, exist_ok=True)
rng = np.random.default_rng(42)
alphabet = np.frombuffer(bytes(string.ascii_letters + string.digits, "ascii"), dtype=np.uint8)
pool = ["".join(map(chr, rng.choice(alphabet, size=16384))) for _ in range(1000)]
for f in range(4):
    idx = np.repeat(rng.integers(0, 1000, size=1024), 16)
    t = pa.table({
        "id": pa.array(np.arange(f * 16384, (f + 1) * 16384), pa.int64()),
        "key": pa.array(idx, pa.int64()),
        "val": pa.array([pool[i] for i in idx], pa.string()),
    })
    pq.write_table(t, f"{OUT}/part-{f}.parquet", compression="zstd")
```

| Arm | Total bytes | vs stock |
|---|---:|---:|
| Stock (`OnPageSizeLimit`) | 50,874,519 | — |
| `WhenProfitable` (ratio 0.1, cap 64 MiB) | 31,186,188 | **−38.7%** |
| Dictionary disabled | ≈ stock | ≈ 0% |

Disabling dictionary encoding does not help here — every repeat is still written in full — which addresses the "why not just disable the dictionary" question from #9700: the win comes from *keeping* the dictionary, not from avoiding it.

Known limitation (disclosed): with the same data uniformly shuffled, the policy does not diverge from stock. The decision is made when the dictionary crosses the grace floor (after ~64 values here), before any repeats are visible, so the ratio test fails and the writer falls back exactly as stock does. Fixing this requires deferring the decision until more values have been sampled — future work below. Stock behaves identically on the shuffled data, so this is a missed win, not a regression.

## ClickBench (hits_0..hits_29, ~4.1 GB of parquet)

| Arm | Total bytes | vs stock |
|---|---:|---:|
| Stock | 2,655,573,968 | — |
| `WhenProfitable` ratio 0.1 | 2,646,247,827 | −0.35% (no regressions) |
| `WhenProfitable` ratio 0.5 | 2,430,100,561 | −8.5% |

At ratio 0.5 the top movers are `Title` −143.4 MB, `URL` −70.5 MB, `Referer` −38.9 MB; the regressions are `UserID` +13.2 MB and `FUniqID` +8.3 MB — sorted/high-cardinality keys where DELTA_BINARY_PACKED beats a nominally "profitable" dictionary. That regression class is exactly why the conservative 0.1 is the suggested default: PLAIN size is a pessimistic bound for the delta fallbacks, so a small ratio keeps the policy honest where delta would win.

## Controls

- **TPC-H SF1**: ratio 0.1 is bit-identical to stock (0 diverged column chunks). Ratio 0.5: +2.1% (`l_orderkey`/`ps_partkey`, the same sorted-key class as above).
- **TPC-DS SF1**: ±0.04% at both ratios.
- **large_values** (unique 16 KiB values, no repetition): all arms byte-identical — the policy is a strict no-op when dictionaries don't pay.

# Are there any user-facing changes?

New opt-in API: `DictionaryFallback` (marked `#[non_exhaustive]`), `WriterPropertiesBuilder::set_dictionary_fallback` / `set_column_dictionary_fallback`, `WriterProperties::dictionary_fallback` / `column_dictionary_fallback`, and `DEFAULT_DICTIONARY_FALLBACK`. Default behavior is unchanged (bit-identical output with default properties).

# Future work

- #9739: on fallback the writer eagerly dumps the oversized dictionary page instead of re-encoding the already-buffered dictionary-encoded data — a companion fix that makes falling back cheaper and is independent of this PR.
- #8378: sampling more values before deciding, which together with a measured (rather than PLAIN-bounded) comparison would let a future `DictionaryFallback` variant handle the shuffled-data case above without changing this API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
