### PR TITLE
fix(parquet): re-encode buffered values on dictionary fallback when the dictionary would be unreferenced

### DIFF
--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -179,24 +179,28 @@ impl FallbackEncoder {
         T: ArrayAccessor + Copy,
         T::Item: AsRef<[u8]>,
     {
-        self.num_values += indices.len();
+        self.encode_all(indices.map(|idx| values.value(idx)))
+    }
+
+    /// Encode each value yielded by `values` to the in-progress page
+    fn encode_all(&mut self, values: impl Iterator<Item = impl AsRef<[u8]>>) {
         match &mut self.encoder {
             FallbackEncoderImpl::Plain { buffer } => {
-                for idx in indices {
-                    let value = values.value(idx);
+                for value in values {
                     let value = value.as_ref();
                     buffer.extend_from_slice((value.len() as u32).as_bytes());
                     buffer.extend_from_slice(value);
                     self.variable_length_bytes += value.len() as i64;
+                    self.num_values += 1;
                 }
             }
             FallbackEncoderImpl::DeltaLength { buffer, lengths } => {
-                for idx in indices {
-                    let value = values.value(idx);
+                for value in values {
                     let value = value.as_ref();
                     lengths.put(&[value.len() as i32]).unwrap();
                     buffer.extend_from_slice(value);
                     self.variable_length_bytes += value.len() as i64;
+                    self.num_values += 1;
                 }
             }
             FallbackEncoderImpl::Delta {
@@ -205,8 +209,7 @@ impl FallbackEncoder {
                 prefix_lengths,
                 suffix_lengths,
             } => {
-                for idx in indices {
-                    let value = values.value(idx);
+                for value in values {
                     let value = value.as_ref();
 
                     let prefix_length = common_prefix_length(last_value, value);
@@ -219,6 +222,7 @@ impl FallbackEncoder {
                     prefix_lengths.put(&[prefix_length as i32]).unwrap();
                     suffix_lengths.put(&[suffix_length as i32]).unwrap();
                     self.variable_length_bytes += value.len() as i64;
+                    self.num_values += 1;
                 }
             }
         }
@@ -424,6 +428,12 @@ impl DictEncoder {
 pub struct ByteArrayEncoder {
     fallback: FallbackEncoder,
     dict_encoder: Option<DictEncoder>,
+    /// A dictionary encoder retained by
+    /// [`ColumnValueEncoder::fall_back_from_dictionary`] so that
+    /// [`ColumnValueEncoder::flush_dict_page`] can still produce the dictionary
+    /// page required by already flushed dictionary-encoded data pages. It no
+    /// longer receives values.
+    retired_dict_encoder: Option<DictEncoder>,
     statistics_enabled: EnabledStatistics,
     min_value: Option<ByteArray>,
     max_value: Option<ByteArray>,
@@ -463,6 +473,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
             bloom_filter,
             bloom_filter_target_fpp,
             dict_encoder: dictionary,
+            retired_dict_encoder: None,
             min_value: None,
             max_value: None,
             geo_stats_accumulator,
@@ -617,18 +628,43 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     }
 
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>> {
-        match self.dict_encoder.take() {
+        let encoder = match self.dict_encoder.take() {
             Some(encoder) => {
                 if !encoder.indices.is_empty() {
                     return Err(general_err!(
                         "Must flush data pages before flushing dictionary"
                     ));
                 }
-
-                Ok(Some(encoder.flush_dict_page()))
+                encoder
             }
-            _ => Ok(None),
+            // A dictionary retained by `fall_back_from_dictionary`: its
+            // buffered indices were re-encoded through the fallback encoder
+            // when the fallback happened.
+            None => match self.retired_dict_encoder.take() {
+                Some(encoder) => encoder,
+                None => return Ok(None),
+            },
+        };
+
+        Ok(Some(encoder.flush_dict_page()))
+    }
+
+    fn fall_back_from_dictionary(&mut self, retain_dictionary: bool) -> Result<()> {
+        if let Some(mut dict_encoder) = self.dict_encoder.take() {
+            // Statistics, bloom filter and variable length bytes were all
+            // updated when these values were first written; `encode_all`
+            // re-counts `variable_length_bytes` in the fallback encoder, so
+            // reset the dictionary's per-page count to match.
+            let storage = dict_encoder.interner.storage();
+            self.fallback
+                .encode_all(dict_encoder.indices.iter().map(|&idx| storage.get(idx)));
+            dict_encoder.indices.clear();
+            dict_encoder.variable_length_bytes = 0;
+            if retain_dictionary {
+                self.retired_dict_encoder = Some(dict_encoder);
+            }
         }
+        Ok(())
     }
 
     fn flush_data_page(&mut self) -> Result<DataPageValues<ByteArray>> {

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -18,7 +18,7 @@
 use crate::basic::Encoding;
 use crate::bloom_filter::Sbbf;
 use crate::column::writer::encoder::{
-    ColumnValueEncoder, DataPageValues, DictionaryPage, create_bloom_filter,
+    ColumnValueEncoder, DataPageValues, DictionaryPage, DictionaryState, create_bloom_filter,
 };
 use crate::data_type::{AsBytes, ByteArray, Int32Type};
 use crate::encodings::encoding::{DeltaBitPackEncoder, Encoder};
@@ -427,41 +427,13 @@ impl DictEncoder {
 
 pub struct ByteArrayEncoder {
     fallback: FallbackEncoder,
-    dict_encoder: Option<DictEncoder>,
-    /// Set by [`ColumnValueEncoder::fall_back_from_dictionary`] once this
-    /// chunk has abandoned dictionary encoding for good.
-    ///
-    /// While it is set, `dict_encoder` is no longer an encoder: it is only the
-    /// source of the buffered ids still to be re-encoded through `fallback`,
-    /// and is dropped as soon as they are drained. Everything that asks about
-    /// the dictionary goes through [`Self::active_dict_encoder`] so that the
-    /// chunk behaves from this point on as if it had never been dictionary
-    /// encoded.
-    dictionary_abandoned: bool,
+    dict_encoder: DictionaryState<DictEncoder>,
     statistics_enabled: EnabledStatistics,
     min_value: Option<ByteArray>,
     max_value: Option<ByteArray>,
     bloom_filter: Option<Sbbf>,
     bloom_filter_target_fpp: f64,
     geo_stats_accumulator: Option<Box<dyn GeoStatsAccumulator>>,
-}
-
-impl ByteArrayEncoder {
-    /// The dictionary encoder, while it is still encoding values.
-    ///
-    /// Returns `None` once the chunk has fallen back, even though
-    /// `dict_encoder` may still hold ids waiting to be re-encoded.
-    fn active_dict_encoder(&self) -> Option<&DictEncoder> {
-        self.dict_encoder
-            .as_ref()
-            .filter(|_| !self.dictionary_abandoned)
-    }
-
-    /// Mutable counterpart of [`Self::active_dict_encoder`].
-    fn active_dict_encoder_mut(&mut self) -> Option<&mut DictEncoder> {
-        let abandoned = self.dictionary_abandoned;
-        self.dict_encoder.as_mut().filter(|_| !abandoned)
-    }
 }
 
 impl ColumnValueEncoder for ByteArrayEncoder {
@@ -477,9 +449,10 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     where
         Self: Sized,
     {
-        let dictionary = props
-            .dictionary_enabled(descr.path())
-            .then(DictEncoder::default);
+        let dictionary = match props.dictionary_enabled(descr.path()) {
+            true => DictionaryState::Active(DictEncoder::default()),
+            false => DictionaryState::Absent,
+        };
 
         let fallback = FallbackEncoder::new(descr, props)?;
 
@@ -495,7 +468,6 @@ impl ColumnValueEncoder for ByteArrayEncoder {
             bloom_filter,
             bloom_filter_target_fpp,
             dict_encoder: dictionary,
-            dictionary_abandoned: false,
             min_value: None,
             max_value: None,
             geo_stats_accumulator,
@@ -596,26 +568,26 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     }
 
     fn num_values(&self) -> usize {
-        match self.active_dict_encoder() {
+        match self.dict_encoder.active() {
             Some(encoder) => encoder.indices.len(),
             None => self.fallback.num_values,
         }
     }
 
     fn has_dictionary(&self) -> bool {
-        self.active_dict_encoder().is_some()
+        self.dict_encoder.active().is_some()
     }
 
     fn compresses_against_previous_value(&self) -> bool {
         // While dictionary encoding is active the data page holds RLE
         // indices, which carry no cross-value state; only the DELTA_BYTE_ARRAY
         // fallback shares prefixes with the preceding value.
-        self.active_dict_encoder().is_none()
+        self.dict_encoder.active().is_none()
             && matches!(self.fallback.encoder, FallbackEncoderImpl::Delta { .. })
     }
 
     fn estimated_memory_size(&self) -> usize {
-        let encoder_size = match self.active_dict_encoder() {
+        let encoder_size = match self.dict_encoder.active() {
             Some(encoder) => encoder.estimated_memory_size(),
             // For the FallbackEncoder, these unflushed bytes are already encoded.
             // Therefore, the size should be the same as estimated_data_page_size.
@@ -635,7 +607,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {
-        Some(self.active_dict_encoder()?.estimated_dict_page_size())
+        Some(self.dict_encoder.active()?.estimated_dict_page_size())
     }
 
     /// Returns an estimate of the data page size in bytes
@@ -643,35 +615,28 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     /// This includes:
     /// <already_written_encoded_byte_size> + <estimated_encoded_size_of_unflushed_bytes>
     fn estimated_data_page_size(&self) -> usize {
-        match self.active_dict_encoder() {
+        match self.dict_encoder.active() {
             Some(encoder) => encoder.estimated_data_page_size(),
             None => self.fallback.estimated_data_page_size(),
         }
     }
 
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>> {
-        if self.dictionary_abandoned {
-            // The chunk fell back before any data page referenced the
-            // dictionary, so there is no dictionary page to write.
-            self.dict_encoder = None;
+        // An abandoned dictionary yields no page: the chunk fell back before any
+        // data page referenced it.
+        let Some(encoder) = self.dict_encoder.take_for_dict_page() else {
             return Ok(None);
+        };
+        if !encoder.indices.is_empty() {
+            return Err(general_err!(
+                "Must flush data pages before flushing dictionary"
+            ));
         }
-        match self.dict_encoder.take() {
-            Some(encoder) => {
-                if !encoder.indices.is_empty() {
-                    return Err(general_err!(
-                        "Must flush data pages before flushing dictionary"
-                    ));
-                }
-                Ok(Some(encoder.flush_dict_page()))
-            }
-            None => Ok(None),
-        }
+        Ok(Some(encoder.flush_dict_page()))
     }
 
     fn fall_back_from_dictionary(&mut self, max_values: usize) -> Result<usize> {
-        self.dictionary_abandoned = true;
-        let Some(dict_encoder) = self.dict_encoder.as_mut() else {
+        let Some(dict_encoder) = self.dict_encoder.abandon() else {
             return Ok(0);
         };
 
@@ -689,7 +654,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
         dict_encoder.indices.drain(..num_values);
 
         if dict_encoder.indices.is_empty() {
-            self.dict_encoder = None;
+            self.dict_encoder = DictionaryState::Absent;
         }
         Ok(num_values)
     }
@@ -698,7 +663,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
         let min_value = self.min_value.take();
         let max_value = self.max_value.take();
 
-        match self.active_dict_encoder_mut() {
+        match self.dict_encoder.active_mut() {
             Some(encoder) => Ok(encoder.flush_data_page(min_value, max_value)),
             _ => self.fallback.flush_data_page(min_value, max_value),
         }
@@ -745,7 +710,7 @@ where
         }
     }
 
-    match encoder.active_dict_encoder_mut() {
+    match encoder.dict_encoder.active_mut() {
         Some(dict_encoder) => dict_encoder.encode(values, indices),
         None => encoder.fallback.encode(values, indices),
     }

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -428,18 +428,40 @@ impl DictEncoder {
 pub struct ByteArrayEncoder {
     fallback: FallbackEncoder,
     dict_encoder: Option<DictEncoder>,
-    /// A dictionary encoder retained by
-    /// [`ColumnValueEncoder::fall_back_from_dictionary`] so that
-    /// [`ColumnValueEncoder::flush_dict_page`] can still produce the dictionary
-    /// page required by already flushed dictionary-encoded data pages. It no
-    /// longer receives values.
-    retired_dict_encoder: Option<DictEncoder>,
+    /// Set by [`ColumnValueEncoder::fall_back_from_dictionary`] once this
+    /// chunk has abandoned dictionary encoding for good.
+    ///
+    /// While it is set, `dict_encoder` is no longer an encoder: it is only the
+    /// source of the buffered ids still to be re-encoded through `fallback`,
+    /// and is dropped as soon as they are drained. Everything that asks about
+    /// the dictionary goes through [`Self::active_dict_encoder`] so that the
+    /// chunk behaves from this point on as if it had never been dictionary
+    /// encoded.
+    dictionary_abandoned: bool,
     statistics_enabled: EnabledStatistics,
     min_value: Option<ByteArray>,
     max_value: Option<ByteArray>,
     bloom_filter: Option<Sbbf>,
     bloom_filter_target_fpp: f64,
     geo_stats_accumulator: Option<Box<dyn GeoStatsAccumulator>>,
+}
+
+impl ByteArrayEncoder {
+    /// The dictionary encoder, while it is still encoding values.
+    ///
+    /// Returns `None` once the chunk has fallen back, even though
+    /// `dict_encoder` may still hold ids waiting to be re-encoded.
+    fn active_dict_encoder(&self) -> Option<&DictEncoder> {
+        self.dict_encoder
+            .as_ref()
+            .filter(|_| !self.dictionary_abandoned)
+    }
+
+    /// Mutable counterpart of [`Self::active_dict_encoder`].
+    fn active_dict_encoder_mut(&mut self) -> Option<&mut DictEncoder> {
+        let abandoned = self.dictionary_abandoned;
+        self.dict_encoder.as_mut().filter(|_| !abandoned)
+    }
 }
 
 impl ColumnValueEncoder for ByteArrayEncoder {
@@ -473,7 +495,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
             bloom_filter,
             bloom_filter_target_fpp,
             dict_encoder: dictionary,
-            retired_dict_encoder: None,
+            dictionary_abandoned: false,
             min_value: None,
             max_value: None,
             geo_stats_accumulator,
@@ -574,26 +596,26 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     }
 
     fn num_values(&self) -> usize {
-        match &self.dict_encoder {
+        match self.active_dict_encoder() {
             Some(encoder) => encoder.indices.len(),
             None => self.fallback.num_values,
         }
     }
 
     fn has_dictionary(&self) -> bool {
-        self.dict_encoder.is_some()
+        self.active_dict_encoder().is_some()
     }
 
     fn compresses_against_previous_value(&self) -> bool {
         // While dictionary encoding is active the data page holds RLE
         // indices, which carry no cross-value state; only the DELTA_BYTE_ARRAY
         // fallback shares prefixes with the preceding value.
-        self.dict_encoder.is_none()
+        self.active_dict_encoder().is_none()
             && matches!(self.fallback.encoder, FallbackEncoderImpl::Delta { .. })
     }
 
     fn estimated_memory_size(&self) -> usize {
-        let encoder_size = match &self.dict_encoder {
+        let encoder_size = match self.active_dict_encoder() {
             Some(encoder) => encoder.estimated_memory_size(),
             // For the FallbackEncoder, these unflushed bytes are already encoded.
             // Therefore, the size should be the same as estimated_data_page_size.
@@ -613,7 +635,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {
-        Some(self.dict_encoder.as_ref()?.estimated_dict_page_size())
+        Some(self.active_dict_encoder()?.estimated_dict_page_size())
     }
 
     /// Returns an estimate of the data page size in bytes
@@ -621,57 +643,62 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     /// This includes:
     /// <already_written_encoded_byte_size> + <estimated_encoded_size_of_unflushed_bytes>
     fn estimated_data_page_size(&self) -> usize {
-        match &self.dict_encoder {
+        match self.active_dict_encoder() {
             Some(encoder) => encoder.estimated_data_page_size(),
             None => self.fallback.estimated_data_page_size(),
         }
     }
 
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>> {
-        let encoder = match self.dict_encoder.take() {
+        if self.dictionary_abandoned {
+            // The chunk fell back before any data page referenced the
+            // dictionary, so there is no dictionary page to write.
+            self.dict_encoder = None;
+            return Ok(None);
+        }
+        match self.dict_encoder.take() {
             Some(encoder) => {
                 if !encoder.indices.is_empty() {
                     return Err(general_err!(
                         "Must flush data pages before flushing dictionary"
                     ));
                 }
-                encoder
+                Ok(Some(encoder.flush_dict_page()))
             }
-            // A dictionary retained by `fall_back_from_dictionary`: its
-            // buffered indices were re-encoded through the fallback encoder
-            // when the fallback happened.
-            None => match self.retired_dict_encoder.take() {
-                Some(encoder) => encoder,
-                None => return Ok(None),
-            },
-        };
-
-        Ok(Some(encoder.flush_dict_page()))
+            None => Ok(None),
+        }
     }
 
-    fn fall_back_from_dictionary(&mut self, retain_dictionary: bool) -> Result<()> {
-        if let Some(mut dict_encoder) = self.dict_encoder.take() {
-            // Statistics, bloom filter and variable length bytes were all
-            // updated when these values were first written; `encode_all`
-            // re-counts `variable_length_bytes` in the fallback encoder, so
-            // reset the dictionary's per-page count to match.
-            let storage = dict_encoder.interner.storage();
-            self.fallback
-                .encode_all(dict_encoder.indices.iter().map(|&idx| storage.get(idx)));
-            dict_encoder.indices.clear();
-            dict_encoder.variable_length_bytes = 0;
-            if retain_dictionary {
-                self.retired_dict_encoder = Some(dict_encoder);
-            }
+    fn fall_back_from_dictionary(&mut self, max_values: usize) -> Result<usize> {
+        self.dictionary_abandoned = true;
+        let Some(dict_encoder) = self.dict_encoder.as_mut() else {
+            return Ok(0);
+        };
+
+        let num_values = max_values.min(dict_encoder.indices.len());
+        // Statistics, bloom filter and variable length bytes were all updated
+        // when these values were first written; `encode_all` re-counts
+        // `variable_length_bytes` in the fallback encoder, so the dictionary's
+        // own per-page count is simply discarded with it below.
+        let storage = dict_encoder.interner.storage();
+        self.fallback.encode_all(
+            dict_encoder.indices[..num_values]
+                .iter()
+                .map(|&idx| storage.get(idx)),
+        );
+        dict_encoder.indices.drain(..num_values);
+
+        if dict_encoder.indices.is_empty() {
+            self.dict_encoder = None;
         }
-        Ok(())
+        Ok(num_values)
     }
 
     fn flush_data_page(&mut self) -> Result<DataPageValues<ByteArray>> {
         let min_value = self.min_value.take();
         let max_value = self.max_value.take();
 
-        match &mut self.dict_encoder {
+        match self.active_dict_encoder_mut() {
             Some(encoder) => Ok(encoder.flush_data_page(min_value, max_value)),
             _ => self.fallback.flush_data_page(min_value, max_value),
         }
@@ -718,7 +745,7 @@ where
         }
     }
 
-    match &mut encoder.dict_encoder {
+    match encoder.active_dict_encoder_mut() {
         Some(dict_encoder) => dict_encoder.encode(values, indices),
         None => encoder.fallback.encode(values, indices),
     }

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -4318,6 +4318,75 @@ mod tests {
     }
 
     #[test]
+    fn arrow_writer_dict_fallback_before_first_data_page() {
+        // All values distinct: the dictionary overflows its 1 KiB size limit
+        // long before the first data page is flushed. The buffered values are
+        // re-encoded with the fallback encoding and the dictionary discarded:
+        // no dictionary page is written and no data page is dictionary
+        // encoded, and in particular no dictionary page exceeding the
+        // configured limit reaches the reader.
+        let values: Vec<String> = (0..1024).map(|i| format!("value-{i:04}")).collect();
+        let array = Arc::new(StringArray::from_iter_values(&values)) as ArrayRef;
+        let batch = RecordBatch::try_from_iter([("col", array)]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_writer_version(WriterVersion::PARQUET_1_0)
+            .set_dictionary_page_size_limit(1024)
+            .build();
+
+        // Validates the values roundtrip, across the fallback point included.
+        let file = roundtrip_opts(&batch, props);
+
+        let reader = SerializedFileReader::new(file).unwrap();
+        let column = reader.metadata().row_group(0).column(0);
+        assert_eq!(column.dictionary_page_offset(), None);
+        let encodings: Vec<_> = column.encodings().collect();
+        assert!(
+            !encodings.contains(&Encoding::RLE_DICTIONARY),
+            "unexpected dictionary encoding: {encodings:?}"
+        );
+        let mask = column.page_encoding_stats_mask().unwrap();
+        assert!(
+            mask.is_only(Encoding::PLAIN),
+            "expected only plain-encoded data pages: {mask:?}"
+        );
+    }
+
+    #[test]
+    fn arrow_writer_dict_fallback_after_data_page_keeps_dictionary() {
+        // Flush dictionary-encoded data pages every 32 rows, so that when the
+        // dictionary overflows its size limit part-way through the chunk,
+        // pages referencing it have already been written: the dictionary page
+        // must then still be written, while the remainder of the chunk uses
+        // the fallback encoding.
+        let values: Vec<String> = (0..1024).map(|i| format!("value-{i:04}")).collect();
+        let array = Arc::new(StringArray::from_iter_values(&values)) as ArrayRef;
+        let batch = RecordBatch::try_from_iter([("col", array)]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_writer_version(WriterVersion::PARQUET_1_0)
+            .set_dictionary_page_size_limit(4096)
+            .set_data_page_row_count_limit(32)
+            .set_write_batch_size(32)
+            .build();
+
+        let file = roundtrip_opts(&batch, props);
+
+        let reader = SerializedFileReader::new(file).unwrap();
+        let column = reader.metadata().row_group(0).column(0);
+        assert!(column.dictionary_page_offset().is_some());
+        let mask = column.page_encoding_stats_mask().unwrap();
+        assert!(
+            mask.is_set(Encoding::RLE_DICTIONARY),
+            "expected dictionary-encoded pages before the fallback: {mask:?}"
+        );
+        assert!(
+            mask.is_set(Encoding::PLAIN),
+            "expected plain pages after the fallback: {mask:?}"
+        );
+    }
+
+    #[test]
     #[cfg_attr(miri, ignore)] // Takes too long
     fn arrow_writer_string_dictionary() {
         // define schema

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -4352,13 +4352,96 @@ mod tests {
         );
     }
 
+    /// The data pages of the first column of the first row group, as
+    /// `(encoding, num_values, encoded page size)`.
+    fn column_data_pages(data: &Bytes) -> Vec<(Encoding, u32, usize)> {
+        let mut metadata = ParquetMetaDataReader::new();
+        metadata.try_parse(data).unwrap();
+        let metadata = metadata.finish().unwrap();
+        let row_group = metadata.row_group(0);
+        let num_rows = row_group.num_rows() as usize;
+        let mut reader =
+            SerializedPageReader::new(Arc::new(data.clone()), row_group.column(0), num_rows, None)
+                .unwrap();
+
+        let mut pages = vec![];
+        while let Some(page) = reader.get_next_page().unwrap() {
+            match page {
+                Page::DictionaryPage { .. } => {}
+                Page::DataPage {
+                    buf,
+                    num_values,
+                    encoding,
+                    ..
+                }
+                | Page::DataPageV2 {
+                    buf,
+                    num_values,
+                    encoding,
+                    ..
+                } => pages.push((encoding, num_values, buf.len())),
+            }
+        }
+        pages
+    }
+
+    #[test]
+    fn arrow_writer_dict_fallback_bounds_reencoded_page_size() {
+        // While dictionary encoding is active the in-progress data page holds
+        // only small RLE indices, so it can buffer a great many large values
+        // without ever reaching the data page size limit. Re-encoding that
+        // buffer on fallback turns those indices back into the values
+        // themselves, which for large values is orders of magnitude more
+        // bytes. The fallback therefore drains the buffer in increments and
+        // seals a page whenever the limit is reached, instead of emitting the
+        // whole buffer as one page far above the configured limit.
+        const DATA_PAGE_SIZE_LIMIT: usize = 4 * 1024;
+        const VALUE_LEN: usize = 1024;
+
+        // Distinct values, so the dictionary grows until it spills, but few
+        // enough indices that the dictionary-encoded page stays well under
+        // the data page size limit until then.
+        let values: Vec<String> = (0..1024)
+            .map(|i| format!("{i:06}").repeat(VALUE_LEN / 6))
+            .collect();
+        let array = Arc::new(StringArray::from_iter_values(&values)) as ArrayRef;
+        let batch = RecordBatch::try_from_iter_with_nullable([("col", array, false)]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_writer_version(WriterVersion::PARQUET_1_0)
+            .set_data_page_size_limit(DATA_PAGE_SIZE_LIMIT)
+            .build();
+
+        // Validates the values roundtrip, across the fallback point included.
+        let data = roundtrip_opts(&batch, props);
+
+        let pages = column_data_pages(&data);
+        assert!(
+            pages.len() > 1,
+            "expected the re-encoded values to be split across pages: {pages:?}"
+        );
+        // A page is sealed once it reaches the limit, so the value that takes
+        // it there is written in full: allow one value of slack.
+        let max_page_size = DATA_PAGE_SIZE_LIMIT + 2 * VALUE_LEN;
+        for (encoding, num_values, size) in &pages {
+            assert!(
+                *size <= max_page_size,
+                "page of {size} bytes ({num_values} values, {encoding}) exceeds \
+                 {max_page_size}: {pages:?}"
+            );
+        }
+    }
+
     #[test]
     fn arrow_writer_dict_fallback_after_data_page_keeps_dictionary() {
-        // Flush dictionary-encoded data pages every 32 rows, so that when the
-        // dictionary overflows its size limit part-way through the chunk,
-        // pages referencing it have already been written: the dictionary page
-        // must then still be written, while the remainder of the chunk uses
-        // the fallback encoding.
+        // Once a dictionary-encoded data page has been written the dictionary
+        // page has to be written too, and every value it already covers is
+        // paid for whether or not later values use it. Re-encoding the
+        // buffered ids would then pay for them a second time, so the buffer is
+        // sealed as one more dictionary-encoded page instead and only the
+        // values after the fallback use the fallback encoding.
+        const ROWS_PER_PAGE: usize = 96;
+
         let values: Vec<String> = (0..1024).map(|i| format!("value-{i:04}")).collect();
         let array = Arc::new(StringArray::from_iter_values(&values)) as ArrayRef;
         let batch = RecordBatch::try_from_iter([("col", array)]).unwrap();
@@ -4366,23 +4449,47 @@ mod tests {
         let props = WriterProperties::builder()
             .set_writer_version(WriterVersion::PARQUET_1_0)
             .set_dictionary_page_size_limit(4096)
-            .set_data_page_row_count_limit(32)
+            .set_data_page_row_count_limit(ROWS_PER_PAGE)
             .set_write_batch_size(32)
             .build();
 
-        let file = roundtrip_opts(&batch, props);
+        let data = roundtrip_opts(&batch, props);
 
-        let reader = SerializedFileReader::new(file).unwrap();
-        let column = reader.metadata().row_group(0).column(0);
-        assert!(column.dictionary_page_offset().is_some());
-        let mask = column.page_encoding_stats_mask().unwrap();
+        let mut metadata = ParquetMetaDataReader::new();
+        metadata.try_parse(&data).unwrap();
+        let column_meta = metadata.finish().unwrap().row_group(0).column(0).clone();
+        assert!(column_meta.dictionary_page_offset().is_some());
+
+        let pages = column_data_pages(&data);
+        let dictionary_pages = pages
+            .iter()
+            .filter(|(encoding, ..)| *encoding == Encoding::RLE_DICTIONARY)
+            .count();
         assert!(
-            mask.is_set(Encoding::RLE_DICTIONARY),
-            "expected dictionary-encoded pages before the fallback: {mask:?}"
+            dictionary_pages > 0,
+            "expected dictionary-encoded pages before the fallback: {pages:?}"
         );
         assert!(
-            mask.is_set(Encoding::PLAIN),
-            "expected plain pages after the fallback: {mask:?}"
+            pages.len() > dictionary_pages,
+            "expected fallback-encoded pages after the fallback: {pages:?}"
+        );
+
+        // The dictionary-encoded pages come first and are contiguous.
+        assert!(
+            pages[dictionary_pages..]
+                .iter()
+                .all(|(encoding, ..)| *encoding == Encoding::PLAIN),
+            "expected every page after the fallback to be plain: {pages:?}"
+        );
+
+        // The values buffered when the dictionary spilled were sealed as one
+        // last dictionary-encoded page, which the row count limit had not yet
+        // filled. Had they been re-encoded instead, every dictionary-encoded
+        // page would be a full one.
+        let (_, last_dict_page_values, _) = pages[dictionary_pages - 1];
+        assert!(
+            (last_dict_page_values as usize) < ROWS_PER_PAGE,
+            "expected the fallback to seal a partial dictionary-encoded page: {pages:?}"
         );
     }
 

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -173,6 +173,20 @@ pub trait ColumnValueEncoder {
     /// are any pending page values
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>>;
 
+    /// Falls back from dictionary encoding to the fallback encoding for the
+    /// remainder of this column chunk: any values buffered for the in-progress
+    /// data page (currently held as dictionary ids) are re-encoded through the
+    /// fallback encoder, and subsequent writes will not be dictionary encoded.
+    ///
+    /// If `retain_dictionary` is true the dictionary itself is kept, so that a
+    /// subsequent call to [`Self::flush_dict_page`] can produce the dictionary
+    /// page required by dictionary-encoded data pages that were already
+    /// flushed. Otherwise the dictionary is discarded and
+    /// [`Self::flush_dict_page`] will return `None`.
+    ///
+    /// Does nothing if no dictionary encoder is active.
+    fn fall_back_from_dictionary(&mut self, retain_dictionary: bool) -> Result<()>;
+
     /// Flush the next data page for this column chunk
     fn flush_data_page(&mut self) -> Result<DataPageValues<Self::T>>;
 
@@ -189,6 +203,11 @@ pub trait ColumnValueEncoder {
 pub struct ColumnValueEncoderImpl<T: DataType> {
     encoder: Box<dyn Encoder<T>>,
     dict_encoder: Option<DictEncoder<T>>,
+    /// A dictionary encoder retained by [`Self::fall_back_from_dictionary`] so
+    /// that [`Self::flush_dict_page`] can still produce the dictionary page
+    /// required by already flushed dictionary-encoded data pages. It no longer
+    /// receives values.
+    retired_dict_encoder: Option<DictEncoder<T>>,
     descr: ColumnDescPtr,
     num_values: usize,
     statistics_enabled: EnabledStatistics,
@@ -276,6 +295,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
         Ok(Self {
             encoder,
             dict_encoder,
+            retired_dict_encoder: None,
             descr: descr.clone(),
             num_values: 0,
             statistics_enabled,
@@ -386,24 +406,44 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>> {
-        match self.dict_encoder.take() {
+        let encoder = match self.dict_encoder.take() {
             Some(encoder) => {
                 if self.num_values != 0 {
                     return Err(general_err!(
                         "Must flush data pages before flushing dictionary"
                     ));
                 }
-
-                let buf = encoder.write_dict()?;
-
-                Ok(Some(DictionaryPage {
-                    buf,
-                    num_values: encoder.num_entries(),
-                    is_sorted: encoder.is_sorted(),
-                }))
+                encoder
             }
-            _ => Ok(None),
+            // A dictionary retained by `fall_back_from_dictionary`: the values
+            // buffered when the fallback happened were re-encoded through the
+            // fallback encoder, so pending page values are fine here.
+            None => match self.retired_dict_encoder.take() {
+                Some(encoder) => encoder,
+                None => return Ok(None),
+            },
+        };
+
+        let buf = encoder.write_dict()?;
+
+        Ok(Some(DictionaryPage {
+            buf,
+            num_values: encoder.num_entries(),
+            is_sorted: encoder.is_sorted(),
+        }))
+    }
+
+    fn fall_back_from_dictionary(&mut self, retain_dictionary: bool) -> Result<()> {
+        if let Some(mut dict_encoder) = self.dict_encoder.take() {
+            // Statistics, bloom filter and variable length bytes were all
+            // updated when these values were first written, so the re-encoded
+            // values deliberately bypass `write_slice`.
+            self.encoder.put(&dict_encoder.take_buffered_values())?;
+            if retain_dictionary {
+                self.retired_dict_encoder = Some(dict_encoder);
+            }
         }
+        Ok(())
     }
 
     fn flush_data_page(&mut self) -> Result<DataPageValues<T::T>> {

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -204,19 +204,78 @@ pub trait ColumnValueEncoder {
     fn flush_geospatial_statistics(&mut self) -> Option<Box<GeospatialStatistics>>;
 }
 
+/// The dictionary encoding state of a column chunk.
+///
+/// A chunk that falls back part-way through keeps its dictionary encoder for a
+/// little longer, but only as the source of the ids it has already buffered:
+/// it takes no further values and its dictionary will never be written. That
+/// is a state of its own, so that "is the dictionary still live?" is a single
+/// match rather than a flag that has to be consulted alongside an `Option`.
+pub(crate) enum DictionaryState<D> {
+    /// Values written to the chunk are dictionary encoded.
+    Active(D),
+    /// The chunk has fallen back and the dictionary is abandoned; the encoder
+    /// survives only until the ids buffered for the in-progress data page have
+    /// been re-encoded through the fallback encoder.
+    Draining(D),
+    /// No dictionary: either never enabled for this chunk, or abandoned and
+    /// fully drained.
+    Absent,
+}
+
+impl<D> DictionaryState<D> {
+    /// The dictionary encoder, while it is still encoding values.
+    ///
+    /// Returns `None` once the chunk has fallen back, even though the encoder
+    /// may still hold ids waiting to be re-encoded.
+    pub(crate) fn active(&self) -> Option<&D> {
+        match self {
+            Self::Active(encoder) => Some(encoder),
+            Self::Draining(_) | Self::Absent => None,
+        }
+    }
+
+    /// Mutable counterpart of [`Self::active`].
+    pub(crate) fn active_mut(&mut self) -> Option<&mut D> {
+        match self {
+            Self::Active(encoder) => Some(encoder),
+            Self::Draining(_) | Self::Absent => None,
+        }
+    }
+
+    /// Abandons the dictionary for the rest of the chunk, returning the
+    /// encoder holding the ids buffered for the in-progress data page.
+    ///
+    /// Returns `None` if there is nothing left to re-encode, either because
+    /// the buffer has already been drained or because the chunk was never
+    /// dictionary encoded.
+    pub(crate) fn abandon(&mut self) -> Option<&mut D> {
+        *self = match std::mem::replace(self, Self::Absent) {
+            Self::Active(encoder) | Self::Draining(encoder) => Self::Draining(encoder),
+            Self::Absent => Self::Absent,
+        };
+        match self {
+            Self::Draining(encoder) => Some(encoder),
+            Self::Active(_) | Self::Absent => None,
+        }
+    }
+
+    /// Drops the dictionary encoder, taking it if its dictionary page is still
+    /// to be written.
+    ///
+    /// An abandoned dictionary is referenced by nothing and is discarded along
+    /// with any ids that were never drained.
+    pub(crate) fn take_for_dict_page(&mut self) -> Option<D> {
+        match std::mem::replace(self, Self::Absent) {
+            Self::Active(encoder) => Some(encoder),
+            Self::Draining(_) | Self::Absent => None,
+        }
+    }
+}
+
 pub struct ColumnValueEncoderImpl<T: DataType> {
     encoder: Box<dyn Encoder<T>>,
-    dict_encoder: Option<DictEncoder<T>>,
-    /// Set by [`ColumnValueEncoder::fall_back_from_dictionary`] once this
-    /// chunk has abandoned dictionary encoding for good.
-    ///
-    /// While it is set, `dict_encoder` is no longer an encoder: it is only the
-    /// source of the buffered ids still to be re-encoded through `encoder`,
-    /// and is dropped as soon as they are drained. Everything that asks about
-    /// the dictionary goes through [`Self::active_dict_encoder`] so that the
-    /// chunk behaves from this point on as if it had never been dictionary
-    /// encoded.
-    dictionary_abandoned: bool,
+    dict_encoder: DictionaryState<DictEncoder<T>>,
     descr: ColumnDescPtr,
     num_values: usize,
     statistics_enabled: EnabledStatistics,
@@ -264,26 +323,10 @@ impl<T: DataType> ColumnValueEncoderImpl<T> {
             }
         }
 
-        match self.active_dict_encoder_mut() {
+        match self.dict_encoder.active_mut() {
             Some(encoder) => encoder.put(slice),
             _ => self.encoder.put(slice),
         }
-    }
-
-    /// The dictionary encoder, while it is still encoding values.
-    ///
-    /// Returns `None` once the chunk has fallen back, even though
-    /// `dict_encoder` may still hold ids waiting to be re-encoded.
-    fn active_dict_encoder(&self) -> Option<&DictEncoder<T>> {
-        self.dict_encoder
-            .as_ref()
-            .filter(|_| !self.dictionary_abandoned)
-    }
-
-    /// Mutable counterpart of [`Self::active_dict_encoder`].
-    fn active_dict_encoder_mut(&mut self) -> Option<&mut DictEncoder<T>> {
-        let abandoned = self.dictionary_abandoned;
-        self.dict_encoder.as_mut().filter(|_| !abandoned)
     }
 }
 
@@ -301,7 +344,10 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     fn try_new(descr: &ColumnDescPtr, props: &WriterProperties) -> Result<Self> {
         let dict_supported = props.dictionary_enabled(descr.path())
             && has_dictionary_support(T::get_physical_type(), props);
-        let dict_encoder = dict_supported.then(|| DictEncoder::new(descr.clone()));
+        let dict_encoder = match dict_supported {
+            true => DictionaryState::Active(DictEncoder::new(descr.clone())),
+            false => DictionaryState::Absent,
+        };
 
         // Set either main encoder or fallback encoder.
         let encoder = get_encoder(
@@ -320,7 +366,6 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
         Ok(Self {
             encoder,
             dict_encoder,
-            dictionary_abandoned: false,
             descr: descr.clone(),
             num_values: 0,
             statistics_enabled,
@@ -392,13 +437,13 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn has_dictionary(&self) -> bool {
-        self.active_dict_encoder().is_some()
+        self.dict_encoder.active().is_some()
     }
 
     fn compresses_against_previous_value(&self) -> bool {
         // While dictionary encoding is active `self.encoder` is unused: the
         // data page holds RLE indices, which carry no cross-value state.
-        self.active_dict_encoder().is_none()
+        self.dict_encoder.active().is_none()
             && self.encoder.encoding() == Encoding::DELTA_BYTE_ARRAY
     }
 
@@ -406,7 +451,8 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
         let encoder_size = self.encoder.estimated_memory_size();
 
         let dict_encoder_size = self
-            .active_dict_encoder()
+            .dict_encoder
+            .active()
             .map(|encoder| encoder.estimated_memory_size())
             .unwrap_or_default();
 
@@ -420,24 +466,20 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {
-        Some(self.active_dict_encoder()?.dict_encoded_size())
+        Some(self.dict_encoder.active()?.dict_encoded_size())
     }
 
     fn estimated_data_page_size(&self) -> usize {
-        match self.active_dict_encoder() {
+        match self.dict_encoder.active() {
             Some(encoder) => encoder.estimated_data_encoded_size(),
             _ => self.encoder.estimated_data_encoded_size(),
         }
     }
 
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>> {
-        if self.dictionary_abandoned {
-            // The chunk fell back before any data page referenced the
-            // dictionary, so there is no dictionary page to write.
-            self.dict_encoder = None;
-            return Ok(None);
-        }
-        let Some(encoder) = self.dict_encoder.take() else {
+        // An abandoned dictionary yields no page: the chunk fell back before any
+        // data page referenced it.
+        let Some(encoder) = self.dict_encoder.take_for_dict_page() else {
             return Ok(None);
         };
         if self.num_values != 0 {
@@ -456,8 +498,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn fall_back_from_dictionary(&mut self, max_values: usize) -> Result<usize> {
-        self.dictionary_abandoned = true;
-        let Some(dict_encoder) = self.dict_encoder.as_mut() else {
+        let Some(dict_encoder) = self.dict_encoder.abandon() else {
             return Ok(0);
         };
 
@@ -465,16 +506,17 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
         // when these values were first written, so the re-encoded values
         // deliberately bypass `write_slice`.
         let values = dict_encoder.drain_buffered_values(max_values);
+        let drained = dict_encoder.num_buffered_values() == 0;
         self.encoder.put(&values)?;
 
-        if dict_encoder.num_buffered_values() == 0 {
-            self.dict_encoder = None;
+        if drained {
+            self.dict_encoder = DictionaryState::Absent;
         }
         Ok(values.len())
     }
 
     fn flush_data_page(&mut self) -> Result<DataPageValues<T::T>> {
-        let (buf, encoding) = match self.active_dict_encoder_mut() {
+        let (buf, encoding) = match self.dict_encoder.active_mut() {
             Some(encoder) => (encoder.write_indices()?, Encoding::RLE_DICTIONARY),
             _ => (self.encoder.flush_buffer()?, self.encoder.encoding()),
         };

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -173,19 +173,23 @@ pub trait ColumnValueEncoder {
     /// are any pending page values
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>>;
 
-    /// Falls back from dictionary encoding to the fallback encoding for the
-    /// remainder of this column chunk: any values buffered for the in-progress
-    /// data page (currently held as dictionary ids) are re-encoded through the
-    /// fallback encoder, and subsequent writes will not be dictionary encoded.
+    /// Abandons dictionary encoding for the remainder of this column chunk,
+    /// re-encoding at most `max_values` of the values buffered for the
+    /// in-progress data page (currently held as dictionary ids) through the
+    /// fallback encoder.
     ///
-    /// If `retain_dictionary` is true the dictionary itself is kept, so that a
-    /// subsequent call to [`Self::flush_dict_page`] can produce the dictionary
-    /// page required by dictionary-encoded data pages that were already
-    /// flushed. Otherwise the dictionary is discarded and
-    /// [`Self::flush_dict_page`] will return `None`.
+    /// The dictionary is discarded, so from the first call onwards
+    /// [`Self::has_dictionary`] is false, further writes go to the fallback
+    /// encoder, and [`Self::flush_dict_page`] returns `None`. This is only
+    /// correct when no dictionary-encoded data page has been flushed for the
+    /// chunk; a caller with such pages must keep the dictionary and seal the
+    /// buffered ids as one more dictionary-encoded page instead.
     ///
-    /// Does nothing if no dictionary encoder is active.
-    fn fall_back_from_dictionary(&mut self, retain_dictionary: bool) -> Result<()>;
+    /// Returns the number of values re-encoded by this call, which is zero
+    /// once the buffer is drained. Re-encoding a page's worth of ids can
+    /// produce far more bytes than they occupied, so the caller drains the
+    /// buffer in increments and may seal a data page between them.
+    fn fall_back_from_dictionary(&mut self, max_values: usize) -> Result<usize>;
 
     /// Flush the next data page for this column chunk
     fn flush_data_page(&mut self) -> Result<DataPageValues<Self::T>>;
@@ -203,11 +207,16 @@ pub trait ColumnValueEncoder {
 pub struct ColumnValueEncoderImpl<T: DataType> {
     encoder: Box<dyn Encoder<T>>,
     dict_encoder: Option<DictEncoder<T>>,
-    /// A dictionary encoder retained by [`Self::fall_back_from_dictionary`] so
-    /// that [`Self::flush_dict_page`] can still produce the dictionary page
-    /// required by already flushed dictionary-encoded data pages. It no longer
-    /// receives values.
-    retired_dict_encoder: Option<DictEncoder<T>>,
+    /// Set by [`ColumnValueEncoder::fall_back_from_dictionary`] once this
+    /// chunk has abandoned dictionary encoding for good.
+    ///
+    /// While it is set, `dict_encoder` is no longer an encoder: it is only the
+    /// source of the buffered ids still to be re-encoded through `encoder`,
+    /// and is dropped as soon as they are drained. Everything that asks about
+    /// the dictionary goes through [`Self::active_dict_encoder`] so that the
+    /// chunk behaves from this point on as if it had never been dictionary
+    /// encoded.
+    dictionary_abandoned: bool,
     descr: ColumnDescPtr,
     num_values: usize,
     statistics_enabled: EnabledStatistics,
@@ -255,10 +264,26 @@ impl<T: DataType> ColumnValueEncoderImpl<T> {
             }
         }
 
-        match &mut self.dict_encoder {
+        match self.active_dict_encoder_mut() {
             Some(encoder) => encoder.put(slice),
             _ => self.encoder.put(slice),
         }
+    }
+
+    /// The dictionary encoder, while it is still encoding values.
+    ///
+    /// Returns `None` once the chunk has fallen back, even though
+    /// `dict_encoder` may still hold ids waiting to be re-encoded.
+    fn active_dict_encoder(&self) -> Option<&DictEncoder<T>> {
+        self.dict_encoder
+            .as_ref()
+            .filter(|_| !self.dictionary_abandoned)
+    }
+
+    /// Mutable counterpart of [`Self::active_dict_encoder`].
+    fn active_dict_encoder_mut(&mut self) -> Option<&mut DictEncoder<T>> {
+        let abandoned = self.dictionary_abandoned;
+        self.dict_encoder.as_mut().filter(|_| !abandoned)
     }
 }
 
@@ -295,7 +320,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
         Ok(Self {
             encoder,
             dict_encoder,
-            retired_dict_encoder: None,
+            dictionary_abandoned: false,
             descr: descr.clone(),
             num_values: 0,
             statistics_enabled,
@@ -367,21 +392,21 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn has_dictionary(&self) -> bool {
-        self.dict_encoder.is_some()
+        self.active_dict_encoder().is_some()
     }
 
     fn compresses_against_previous_value(&self) -> bool {
         // While dictionary encoding is active `self.encoder` is unused: the
         // data page holds RLE indices, which carry no cross-value state.
-        self.dict_encoder.is_none() && self.encoder.encoding() == Encoding::DELTA_BYTE_ARRAY
+        self.active_dict_encoder().is_none()
+            && self.encoder.encoding() == Encoding::DELTA_BYTE_ARRAY
     }
 
     fn estimated_memory_size(&self) -> usize {
         let encoder_size = self.encoder.estimated_memory_size();
 
         let dict_encoder_size = self
-            .dict_encoder
-            .as_ref()
+            .active_dict_encoder()
             .map(|encoder| encoder.estimated_memory_size())
             .unwrap_or_default();
 
@@ -395,34 +420,31 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn estimated_dict_page_size(&self) -> Option<usize> {
-        Some(self.dict_encoder.as_ref()?.dict_encoded_size())
+        Some(self.active_dict_encoder()?.dict_encoded_size())
     }
 
     fn estimated_data_page_size(&self) -> usize {
-        match &self.dict_encoder {
+        match self.active_dict_encoder() {
             Some(encoder) => encoder.estimated_data_encoded_size(),
             _ => self.encoder.estimated_data_encoded_size(),
         }
     }
 
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>> {
-        let encoder = match self.dict_encoder.take() {
-            Some(encoder) => {
-                if self.num_values != 0 {
-                    return Err(general_err!(
-                        "Must flush data pages before flushing dictionary"
-                    ));
-                }
-                encoder
-            }
-            // A dictionary retained by `fall_back_from_dictionary`: the values
-            // buffered when the fallback happened were re-encoded through the
-            // fallback encoder, so pending page values are fine here.
-            None => match self.retired_dict_encoder.take() {
-                Some(encoder) => encoder,
-                None => return Ok(None),
-            },
+        if self.dictionary_abandoned {
+            // The chunk fell back before any data page referenced the
+            // dictionary, so there is no dictionary page to write.
+            self.dict_encoder = None;
+            return Ok(None);
+        }
+        let Some(encoder) = self.dict_encoder.take() else {
+            return Ok(None);
         };
+        if self.num_values != 0 {
+            return Err(general_err!(
+                "Must flush data pages before flushing dictionary"
+            ));
+        }
 
         let buf = encoder.write_dict()?;
 
@@ -433,21 +455,26 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
         }))
     }
 
-    fn fall_back_from_dictionary(&mut self, retain_dictionary: bool) -> Result<()> {
-        if let Some(mut dict_encoder) = self.dict_encoder.take() {
-            // Statistics, bloom filter and variable length bytes were all
-            // updated when these values were first written, so the re-encoded
-            // values deliberately bypass `write_slice`.
-            self.encoder.put(&dict_encoder.take_buffered_values())?;
-            if retain_dictionary {
-                self.retired_dict_encoder = Some(dict_encoder);
-            }
+    fn fall_back_from_dictionary(&mut self, max_values: usize) -> Result<usize> {
+        self.dictionary_abandoned = true;
+        let Some(dict_encoder) = self.dict_encoder.as_mut() else {
+            return Ok(0);
+        };
+
+        // Statistics, bloom filter and variable length bytes were all updated
+        // when these values were first written, so the re-encoded values
+        // deliberately bypass `write_slice`.
+        let values = dict_encoder.drain_buffered_values(max_values);
+        self.encoder.put(&values)?;
+
+        if dict_encoder.num_buffered_values() == 0 {
+            self.dict_encoder = None;
         }
-        Ok(())
+        Ok(values.len())
     }
 
     fn flush_data_page(&mut self) -> Result<DataPageValues<T::T>> {
-        let (buf, encoding) = match &mut self.dict_encoder {
+        let (buf, encoding) = match self.active_dict_encoder_mut() {
             Some(encoder) => (encoder.write_indices()?, Encoding::RLE_DICTIONARY),
             _ => (self.encoder.flush_buffer()?, self.encoder.encoding()),
         };

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -452,6 +452,17 @@ impl LevelDataRef<'_> {
 /// Typed column writer for a primitive column.
 pub type ColumnWriterImpl<'a, T> = GenericColumnWriter<'a, ColumnValueEncoderImpl<T>>;
 
+/// Upper bound on the number of values re-encoded between data page size
+/// checks when falling back from dictionary encoding.
+///
+/// The buffered dictionary ids can expand by orders of magnitude once they are
+/// re-encoded, so the fallback drains them in increments rather than in one go,
+/// leaving the writer free to seal a page in between and keep the re-encoded
+/// pages within the configured data page size limit. Increments are sized from
+/// the bytes the previous one produced; this only caps that estimate, so that
+/// tiny values do not turn one page into a single enormous increment.
+const FALLBACK_REENCODE_BATCH_SIZE: usize = 1024;
+
 /// Generic column writer for a primitive Parquet column
 pub struct GenericColumnWriter<'a, E: ColumnValueEncoder> {
     // Column writer properties
@@ -1137,30 +1148,83 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
 
     /// Performs dictionary fallback.
     ///
-    /// The values buffered for the in-progress data page are dictionary ids;
-    /// they are re-encoded through the fallback encoder (together with the
-    /// dictionary they resolve to) rather than flushed as one more
-    /// dictionary-encoded page, and remain buffered. This matches
-    /// parquet-java's `FallbackValuesWriter`.
+    /// If any dictionary-encoded data page has already been produced for this
+    /// chunk then those pages reference the dictionary, so the dictionary page
+    /// is written and stays worth its bytes. The buffered ids are sealed as
+    /// one last dictionary-encoded page and the dictionary page is written
+    /// ahead of the data pages that were buffered awaiting it.
     ///
-    /// If dictionary-encoded data pages have already been produced for this
-    /// chunk they reference the dictionary, so the dictionary page must still
-    /// be written, ahead of any data pages buffered while awaiting it.
-    /// Otherwise no dictionary page is written at all and the whole chunk uses
-    /// the fallback encoding.
+    /// Otherwise nothing references the dictionary yet, and writing it would
+    /// only serve the ids still buffered for the in-progress page. Those
+    /// values are re-encoded through the fallback encoder instead and the
+    /// dictionary is dropped, so the whole chunk ends up in a single encoding
+    /// and pays for the values once. This matches parquet-java's
+    /// `FallbackValuesWriter`.
     fn dict_fallback(&mut self) -> Result<()> {
         // At this point we know that we need to fall back.
-        let retain_dictionary = self.has_dictionary_encoded_data_pages;
-        self.encoder.fall_back_from_dictionary(retain_dictionary)?;
-        if retain_dictionary {
+        if self.has_dictionary_encoded_data_pages {
+            if self.page_metrics.num_buffered_values > 0 {
+                self.add_data_page()?;
+            }
             self.write_dictionary_page()?;
-            while let Some(page) = self.data_pages.pop_front() {
-                self.write_data_page(page)?;
+            self.flush_data_pages()?;
+            return Ok(());
+        }
+
+        // Sealing a page part-way through the re-encode means splitting the
+        // levels already buffered for it, which the streaming level encoders
+        // cannot do. A column with no repetition or definition levels has no
+        // level buffer and exactly one row per value, so any value boundary is
+        // a valid page boundary; anything else has to re-encode the whole
+        // buffer into one page.
+        let splittable = self.descr.max_def_level() == 0 && self.descr.max_rep_level() == 0;
+        if !splittable {
+            self.encoder.fall_back_from_dictionary(usize::MAX)?;
+        } else {
+            // The buffered values are re-attributed to pages increment by
+            // increment below. With no levels there is one row per value and
+            // no nulls, so a page's counts are just how many it re-encoded.
+            self.page_metrics.num_buffered_values = 0;
+            self.page_metrics.num_buffered_rows = 0;
+
+            // Each increment is sized from the bytes the previous one
+            // produced, so that a page is sealed close to the limit whatever
+            // the values are worth: a fixed number of values would overshoot
+            // by a whole increment of large ones. The first increment is a
+            // single value, which is what makes an estimate available at all.
+            let page_size_limit = self.props.column_data_page_size_limit(self.descr.path());
+            // Bytes the re-encoded values have contributed to the page so far.
+            // Nothing reached the fallback encoder before now, so it starts at
+            // zero and returns there every time a page is sealed.
+            let mut page_size = 0;
+            let mut batch = 1;
+            loop {
+                let num_values = self.encoder.fall_back_from_dictionary(batch)?;
+                if num_values == 0 {
+                    break;
+                }
+                self.page_metrics.num_buffered_values += num_values as u32;
+                self.page_metrics.num_buffered_rows += num_values as u32;
+
+                let size = self.encoder.estimated_data_page_size();
+                let bytes_per_value = size.saturating_sub(page_size).div_ceil(num_values).max(1);
+                page_size = size;
+
+                if self.should_add_data_page() {
+                    self.add_data_page()?;
+                    page_size = self.encoder.estimated_data_page_size();
+                }
+
+                batch = page_size_limit
+                    .saturating_sub(page_size)
+                    .div_ceil(bytes_per_value)
+                    .clamp(1, FALLBACK_REENCODE_BATCH_SIZE);
             }
         }
-        // The dictionary ids held only a fraction of the page size budget; the
-        // same values re-encoded with the fallback encoding may already exceed
-        // it.
+
+        // The dictionary ids held only a fraction of the page size budget, so
+        // the values re-encoded into whatever is left buffered here may
+        // already exceed it.
         if self.should_add_data_page() {
             self.add_data_page()?;
         }

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -480,6 +480,10 @@ pub struct GenericColumnWriter<'a, E: ColumnValueEncoder> {
     def_levels_encoder: LevelEncoder,
     rep_levels_encoder: LevelEncoder,
     data_pages: VecDeque<CompressedPage>,
+    /// Whether any dictionary-encoded data page has been produced for this
+    /// column chunk. Once set, a dictionary fallback can no longer skip
+    /// writing the dictionary page, as the flushed pages reference it.
+    has_dictionary_encoded_data_pages: bool,
     // column index and offset index
     column_index_builder: ColumnIndexBuilder,
     offset_index_builder: Option<OffsetIndexBuilder>,
@@ -546,6 +550,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             compressor,
             encoder,
             data_pages: VecDeque::new(),
+            has_dictionary_encoded_data_pages: false,
             page_metrics,
             column_metrics,
             distinct_count_override: None,
@@ -1131,14 +1136,34 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     }
 
     /// Performs dictionary fallback.
-    /// Prepares and writes dictionary and all data pages into page writer.
+    ///
+    /// The values buffered for the in-progress data page are dictionary ids;
+    /// they are re-encoded through the fallback encoder (together with the
+    /// dictionary they resolve to) rather than flushed as one more
+    /// dictionary-encoded page, and remain buffered. This matches
+    /// parquet-java's `FallbackValuesWriter`.
+    ///
+    /// If dictionary-encoded data pages have already been produced for this
+    /// chunk they reference the dictionary, so the dictionary page must still
+    /// be written, ahead of any data pages buffered while awaiting it.
+    /// Otherwise no dictionary page is written at all and the whole chunk uses
+    /// the fallback encoding.
     fn dict_fallback(&mut self) -> Result<()> {
         // At this point we know that we need to fall back.
-        if self.page_metrics.num_buffered_values > 0 {
+        let retain_dictionary = self.has_dictionary_encoded_data_pages;
+        self.encoder.fall_back_from_dictionary(retain_dictionary)?;
+        if retain_dictionary {
+            self.write_dictionary_page()?;
+            while let Some(page) = self.data_pages.pop_front() {
+                self.write_data_page(page)?;
+            }
+        }
+        // The dictionary ids held only a fraction of the page size budget; the
+        // same values re-encoded with the fallback encoding may already exceed
+        // it.
+        if self.should_add_data_page() {
             self.add_data_page()?;
         }
-        self.write_dictionary_page()?;
-        self.flush_data_pages()?;
         Ok(())
     }
 
@@ -1551,8 +1576,13 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         // that defers final layout (the Arrow path) instead orders pages itself
         // at flush, so we stream the data pages straight through and never let
         // them accumulate in memory.
-        if self.encoder.has_dictionary() && !self.page_writer.defers_dictionary_ordering() {
-            self.data_pages.push_back(compressed_page);
+        if self.encoder.has_dictionary() {
+            self.has_dictionary_encoded_data_pages = true;
+            if self.page_writer.defers_dictionary_ordering() {
+                self.write_data_page(compressed_page)?;
+            } else {
+                self.data_pages.push_back(compressed_page);
+            }
         } else {
             self.write_data_page(compressed_page)?;
         }
@@ -2850,6 +2880,121 @@ mod tests {
     }
 
     #[test]
+    fn test_column_writer_dict_fallback_before_first_data_page() {
+        // All values distinct: the dictionary overflows its size limit long
+        // before the first data page is flushed, so the buffered values are
+        // re-encoded with the fallback encoding and the dictionary is
+        // discarded entirely: no dictionary page and no dictionary-encoded
+        // data page.
+        let values: Vec<i32> = (0..2048).collect();
+        let props = || {
+            WriterProperties::builder()
+                .set_writer_version(WriterVersion::PARQUET_1_0)
+                .set_dictionary_page_size_limit(512)
+                .build()
+        };
+
+        let meta = column_write_and_get_metadata::<Int32Type>(props(), &values);
+        assert_eq!(meta.dictionary_page_offset(), None);
+        assert_eq!(
+            meta.encodings().collect::<Vec<_>>(),
+            &[Encoding::PLAIN, Encoding::RLE]
+        );
+        assert_eq!(
+            meta.page_encoding_stats().unwrap(),
+            &[encoding_stats(PageType::DATA_PAGE, Encoding::PLAIN, 1)]
+        );
+        // The whole chunk is plain encoded: no dictionary page and no
+        // dictionary-encoded prefix duplicating the values it references.
+        assert!(
+            meta.compressed_size() <= (values.len() * 4 + 128) as i64,
+            "unexpected chunk size {}",
+            meta.compressed_size()
+        );
+
+        // Values on both sides of the fallback point roundtrip.
+        column_roundtrip::<Int32Type>(props(), &values, None, None);
+    }
+
+    #[test]
+    fn test_column_writer_dict_fallback_before_first_data_page_v2() {
+        // As `test_column_writer_dict_fallback_before_first_data_page`, with
+        // the V2 fallback encoding: a sorted column re-encoded with
+        // DELTA_BINARY_PACKED ends up considerably smaller than the plain
+        // values, let alone than an oversized dictionary page plus a
+        // dictionary-encoded prefix.
+        let values: Vec<i32> = (0..2048).collect();
+        let props = || {
+            WriterProperties::builder()
+                .set_writer_version(WriterVersion::PARQUET_2_0)
+                .set_dictionary_page_size_limit(512)
+                .build()
+        };
+
+        let meta = column_write_and_get_metadata::<Int32Type>(props(), &values);
+        assert_eq!(meta.dictionary_page_offset(), None);
+        assert_eq!(
+            meta.encodings().collect::<Vec<_>>(),
+            &[Encoding::RLE, Encoding::DELTA_BINARY_PACKED]
+        );
+        assert_eq!(
+            meta.page_encoding_stats().unwrap(),
+            &[encoding_stats(
+                PageType::DATA_PAGE_V2,
+                Encoding::DELTA_BINARY_PACKED,
+                1
+            )]
+        );
+        assert!(
+            meta.compressed_size() < (values.len() * 4 / 2) as i64,
+            "unexpected chunk size {}",
+            meta.compressed_size()
+        );
+
+        column_roundtrip::<Int32Type>(props(), &values, None, None);
+    }
+
+    #[test]
+    fn test_column_writer_dict_fallback_after_data_page_keeps_dictionary() {
+        // Flush dictionary-encoded data pages every 32 rows, so that when the
+        // dictionary overflows its size limit part-way through the chunk,
+        // pages referencing it have already been written. The dictionary page
+        // must then still be written, but the values buffered at the fallback
+        // point are re-encoded with the fallback encoding rather than flushed
+        // as one more dictionary-encoded page.
+        let values: Vec<i32> = (0..2048).collect();
+        let props = || {
+            WriterProperties::builder()
+                .set_writer_version(WriterVersion::PARQUET_1_0)
+                .set_dictionary_page_size_limit(512)
+                .set_data_page_row_count_limit(32)
+                .set_write_batch_size(32)
+                .build()
+        };
+
+        let meta = column_write_and_get_metadata::<Int32Type>(props(), &values);
+        assert!(meta.dictionary_page_offset().is_some());
+        let stats = meta.page_encoding_stats().unwrap();
+        let data_pages_with = |encoding| {
+            stats
+                .iter()
+                .filter(|s| s.page_type == PageType::DATA_PAGE && s.encoding == encoding)
+                .map(|s| s.count)
+                .sum::<i32>()
+        };
+        assert!(
+            data_pages_with(Encoding::RLE_DICTIONARY) > 0,
+            "expected dictionary-encoded pages before the fallback: {stats:?}"
+        );
+        assert!(
+            data_pages_with(Encoding::PLAIN) > 0,
+            "expected plain pages after the fallback: {stats:?}"
+        );
+
+        column_roundtrip::<Int32Type>(props(), &values, None, None);
+    }
+
+    #[test]
     #[cfg_attr(miri, ignore)] // Takes too long
     fn test_column_writer_small_write_batch_size() {
         for i in &[1usize, 2, 5, 10, 11, 1023] {
@@ -3408,6 +3553,11 @@ mod tests {
             .set_writer_version(WriterVersion::PARQUET_1_0)
             .set_dictionary_enabled(true)
             .set_dictionary_page_size_limit(dict_page_limit)
+            // Flush dictionary-encoded data pages before the dictionary
+            // spills: a fallback with no dictionary-encoded data pages
+            // discards the dictionary entirely, and this test needs a
+            // dictionary page in the output to measure.
+            .set_data_page_row_count_limit(4)
             .build();
 
         let data: Vec<_> = (0..num_rows)

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -149,6 +149,22 @@ impl<T: DataType> DictEncoder<T> {
         self.indices.push(self.interner.intern(value));
     }
 
+    /// Returns the values buffered for the in-progress data page, resolving
+    /// dictionary ids back to their values, and clears the buffer.
+    ///
+    /// Used on dictionary fallback to re-encode the buffered values with the
+    /// fallback encoder.
+    pub fn take_buffered_values(&mut self) -> Vec<T::T> {
+        let uniques = &self.interner.storage().uniques;
+        let values = self
+            .indices
+            .iter()
+            .map(|&i| uniques[i as usize].clone())
+            .collect();
+        self.indices.clear();
+        values
+    }
+
     #[inline]
     fn bit_width(&self) -> u8 {
         num_required_bits(self.num_entries().saturating_sub(1) as u64)

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -149,19 +149,25 @@ impl<T: DataType> DictEncoder<T> {
         self.indices.push(self.interner.intern(value));
     }
 
-    /// Returns the values buffered for the in-progress data page, resolving
-    /// dictionary ids back to their values, and clears the buffer.
+    /// Number of values buffered for the in-progress data page.
+    pub fn num_buffered_values(&self) -> usize {
+        self.indices.len()
+    }
+
+    /// Removes up to `max_values` of the values buffered for the in-progress
+    /// data page, resolving their dictionary ids back to values.
     ///
     /// Used on dictionary fallback to re-encode the buffered values with the
-    /// fallback encoder.
-    pub fn take_buffered_values(&mut self) -> Vec<T::T> {
+    /// fallback encoder, a bounded number at a time so that the caller can
+    /// keep the re-encoded data pages within the configured size limit.
+    pub fn drain_buffered_values(&mut self, max_values: usize) -> Vec<T::T> {
+        let num_values = max_values.min(self.indices.len());
         let uniques = &self.interner.storage().uniques;
-        let values = self
-            .indices
+        let values = self.indices[..num_values]
             .iter()
             .map(|&i| uniques[i as usize].clone())
             .collect();
-        self.indices.clear();
+        self.indices.drain(..num_values);
         values
     }
 

--- a/parquet/tests/arrow_writer/layout.rs
+++ b/parquet/tests/arrow_writer/layout.rs
@@ -216,6 +216,11 @@ fn test_primitive() {
     });
 
     // Test spill dictionary
+    //
+    // The dictionary overflows its size limit before the first data page is
+    // flushed, so the buffered values are re-encoded with the fallback
+    // encoding and the dictionary is discarded: the chunk contains no
+    // dictionary page and only PLAIN data pages.
     let props = WriterProperties::builder()
         .set_dictionary_enabled(true)
         .set_dictionary_page_size_limit(1000)
@@ -230,29 +235,14 @@ fn test_primitive() {
         layout: Layout {
             row_groups: vec![RowGroup {
                 columns: vec![ColumnChunk {
-                    pages: vec![
-                        Page {
-                            rows: 250,
-                            page_header_size: 38,
-                            compressed_size: 258,
-                            encoding: Encoding::RLE_DICTIONARY,
-                            page_type: PageType::DATA_PAGE,
-                        },
-                        Page {
-                            rows: 1750,
-                            page_header_size: 38,
-                            compressed_size: 7000,
-                            encoding: Encoding::PLAIN,
-                            page_type: PageType::DATA_PAGE,
-                        },
-                    ],
-                    dictionary_page: Some(Page {
-                        rows: 250,
+                    pages: vec![Page {
+                        rows: 2000,
                         page_header_size: 38,
-                        compressed_size: 1000,
+                        compressed_size: 8000,
                         encoding: Encoding::PLAIN,
-                        page_type: PageType::DICTIONARY_PAGE,
-                    }),
+                        page_type: PageType::DATA_PAGE,
+                    }],
+                    dictionary_page: None,
                 }],
             }],
         },
@@ -417,42 +407,29 @@ fn test_string() {
         layout: Layout {
             row_groups: vec![RowGroup {
                 columns: vec![ColumnChunk {
+                    // The dictionary overflows its size limit at 126 rows,
+                    // before the first data page is flushed, so those rows are
+                    // re-encoded with the fallback encoding and the dictionary
+                    // is discarded: no dictionary page, PLAIN pages only, with
+                    // the first page boundary determined by the data page size
+                    // limit rather than by the fallback.
                     pages: vec![
                         Page {
-                            rows: 126,
-                            page_header_size: 38,
-                            compressed_size: 114,
-                            encoding: Encoding::RLE_DICTIONARY,
-                            page_type: PageType::DATA_PAGE,
-                        },
-                        Page {
-                            rows: 1254,
+                            rows: 1250,
                             page_header_size: 40,
-                            compressed_size: 10032,
+                            compressed_size: 10000,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
-                            rows: 620,
+                            rows: 750,
                             page_header_size: 38,
-                            compressed_size: 4960,
+                            compressed_size: 6000,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
                         },
                     ],
-                    // The byte-budget chunker sub-batches the dictionary
-                    // phase. The mini-batch deliberately includes the value
-                    // that crosses the 1000-byte limit so the spill triggers
-                    // on this chunk rather than carrying a sliver into the
-                    // next page, giving a 126-row dictionary page at 1008
-                    // bytes.
-                    dictionary_page: Some(Page {
-                        rows: 126,
-                        page_header_size: 38,
-                        compressed_size: 1008,
-                        encoding: Encoding::PLAIN,
-                        page_type: PageType::DICTIONARY_PAGE,
-                    }),
+                    dictionary_page: None,
                 }],
             }],
         },
@@ -941,10 +918,10 @@ fn test_nullable_large_values() {
 fn test_dictionary_spill_large_values() {
     // Dictionary encoding is enabled, but each value is large (64 KiB) and
     // unique, so the dictionary spills almost immediately (1 KiB dict page
-    // limit). After the spill, plain encoding takes over and the byte-budget
-    // sub-batch bounds each page to a single value. The first value is
-    // interned into the dictionary page (one RLE_DICTIONARY data page
-    // referencing it); the remaining 31 fall back to PLAIN, one per page.
+    // limit). The first value is interned before the spill; the fallback
+    // re-encodes it as PLAIN and discards the dictionary, so no dictionary
+    // page (which would have been 64x the configured limit) is written and
+    // the byte-budget sub-batch bounds each page to a single PLAIN value.
     // Mirrors `test_column_writer_dict_enabled_large_values_post_spill`,
     // exercising the same dict→plain transition via the arrow path.
     let value_size = 64 * 1024;
@@ -969,30 +946,18 @@ fn test_dictionary_spill_large_values() {
         layout: Layout {
             row_groups: vec![RowGroup {
                 columns: vec![ColumnChunk {
-                    pages: std::iter::once(Page {
-                        // The single value interned before the dict spilled.
-                        rows: 1,
-                        page_header_size: 17,
-                        compressed_size: 2,
-                        encoding: Encoding::RLE_DICTIONARY,
-                        page_type: PageType::DATA_PAGE,
-                    })
-                    .chain((0..31).map(|_| Page {
-                        // Post-spill plain-encoded values, one per page.
-                        rows: 1,
-                        page_header_size: 21,
-                        compressed_size: 65540,
-                        encoding: Encoding::PLAIN,
-                        page_type: PageType::DATA_PAGE,
-                    }))
-                    .collect(),
-                    dictionary_page: Some(Page {
-                        rows: 1,
-                        page_header_size: 21,
-                        compressed_size: 65540,
-                        encoding: Encoding::PLAIN,
-                        page_type: PageType::DICTIONARY_PAGE,
-                    }),
+                    pages: (0..32)
+                        .map(|_| Page {
+                            // Plain-encoded values, one per page; the first
+                            // was re-encoded from the dictionary on fallback.
+                            rows: 1,
+                            page_header_size: 21,
+                            compressed_size: 65540,
+                            encoding: Encoding::PLAIN,
+                            page_type: PageType::DATA_PAGE,
+                        })
+                        .collect(),
+                    dictionary_page: None,
                 }],
             }],
         },


### PR DESCRIPTION
Closes #9739.

When the dictionary overflows its size limit, the writer currently flushes the buffered dictionary ids as one more dictionary-encoded page and writes the dictionary page. If no data page has been sealed yet, that dictionary page exists solely to serve the values still buffered, and the chunk pays for those values twice: once in the dictionary, once in the ids that index it.

This changes the fallback to re-encode the buffered ids through the fallback encoder and drop the dictionary, but only in that case. Once a dictionary-encoded data page has been sealed, the dictionary page has to be written whatever happens next and every value it covers is already paid for, so re-encoding would pay for them a second time. Measurements agree: re-encoding unconditionally makes common files whose dictionary overflows after several sealed pages 3 to 15 percent larger, while the narrow case is where the saving is, with a TPC-H orders column dropping a roughly 1 MB dictionary whose only reference was the re-encoded buffer, for a 0.8 percent smaller file.

While dictionary encoding is active a data page holds small RLE indices, so it can buffer far more bytes worth of values than the data page size limit before the limit is consulted, and re-encoding that buffer in one go could produce a single page many times the limit. The re-encode drains the buffer in increments sized from the bytes the previous increment produced, sealing a page whenever the limit is reached. Sealing a page part-way through means splitting the levels already buffered for it, which the streaming level encoders cannot do, so this applies to columns with no repetition or definition levels; other columns re-encode into a single page as before.

The dual `Option<DictEncoder>` bookkeeping is gone. A single `DictionaryState` enum holds the three states a chunk can be in — encoding, draining the ids buffered at the fallback point, or without a dictionary — so the encoder cannot be consulted as an encoder once it is only a source of values to re-encode.
