### PR TITLE
feat(parquet): `DictionaryFallback::Adaptive` — measured, checkpointed dictionary fallback decision

### DIFF
--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -335,6 +335,11 @@ struct DictEncoder {
     interner: Interner<ByteArrayStorage>,
     indices: Vec<u64>,
     variable_length_bytes: i64,
+    /// Total bytes the values appended to this column chunk would occupy
+    /// PLAIN-encoded (4-byte length prefix + payload per value), accumulated
+    /// over all appended values (not just the dictionary's unique values);
+    /// never reset per page
+    plain_encoded_bytes: u64,
 }
 
 impl DictEncoder {
@@ -351,6 +356,7 @@ impl DictEncoder {
             let interned = self.interner.intern(value.as_ref());
             self.indices.push(interned);
             self.variable_length_bytes += value.as_ref().len() as i64;
+            self.plain_encoded_bytes += 4 + value.as_ref().len() as u64;
         }
     }
 
@@ -589,6 +595,10 @@ impl ColumnValueEncoder for ByteArrayEncoder {
 
     fn estimated_dict_page_size(&self) -> Option<usize> {
         Some(self.dict_encoder.as_ref()?.estimated_dict_page_size())
+    }
+
+    fn estimated_plain_encoded_bytes(&self) -> Option<u64> {
+        Some(self.dict_encoder.as_ref()?.plain_encoded_bytes)
     }
 
     /// Returns an estimate of the data page size in bytes

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -18,7 +18,7 @@
 use crate::basic::Encoding;
 use crate::bloom_filter::Sbbf;
 use crate::column::writer::encoder::{
-    ColumnValueEncoder, DataPageValues, DictionaryPage, create_bloom_filter,
+    ColumnValueEncoder, DataPageValues, DictionaryCostSample, DictionaryPage, create_bloom_filter,
 };
 use crate::data_type::{AsBytes, ByteArray, Int32Type};
 use crate::encodings::encoding::{DeltaBitPackEncoder, Encoder};
@@ -38,6 +38,7 @@ use arrow_array::{
 };
 use arrow_buffer::{ArrowNativeType, Buffer};
 use arrow_schema::DataType;
+use bytes::Bytes;
 
 macro_rules! downcast_dict_impl {
     ($array:ident, $key:ident, $val:ident, $op:expr $(, $arg:expr)*) => {{
@@ -140,6 +141,12 @@ impl FallbackEncoder {
                     WriterVersion::PARQUET_2_0 => Encoding::DELTA_BYTE_ARRAY,
                 });
 
+        Self::new_from_encoding(encoding)
+    }
+
+    /// Create a fallback encoder producing the given (already validated)
+    /// fallback `encoding`
+    fn new_from_encoding(encoding: Encoding) -> Result<Self> {
         let encoder = match encoding {
             Encoding::PLAIN => FallbackEncoderImpl::Plain { buffer: vec![] },
             Encoding::DELTA_LENGTH_BYTE_ARRAY => FallbackEncoderImpl::DeltaLength {
@@ -165,6 +172,15 @@ impl FallbackEncoder {
             num_values: 0,
             variable_length_bytes: 0,
         })
+    }
+
+    /// Returns the encoding this fallback encoder produces
+    fn encoding(&self) -> Encoding {
+        match &self.encoder {
+            FallbackEncoderImpl::Plain { .. } => Encoding::PLAIN,
+            FallbackEncoderImpl::DeltaLength { .. } => Encoding::DELTA_LENGTH_BYTE_ARRAY,
+            FallbackEncoderImpl::Delta { .. } => Encoding::DELTA_BYTE_ARRAY,
+        }
     }
 
     /// Encode `values` to the in-progress page
@@ -344,6 +360,10 @@ struct DictEncoder {
     /// over all appended values (not just the dictionary's unique values);
     /// never reset per page
     plain_encoded_bytes: u64,
+    /// Total number of values appended to this column chunk, over all pages;
+    /// never reset per page (unlike `indices`, which is cleared on each page
+    /// flush)
+    num_appended_values: u64,
 }
 
 impl DictEncoder {
@@ -361,6 +381,7 @@ impl DictEncoder {
             self.indices.push(interned);
             self.variable_length_bytes += value.as_ref().len() as i64;
             self.plain_encoded_bytes += 4 + value.as_ref().len() as u64;
+            self.num_appended_values += 1;
         }
     }
 
@@ -610,6 +631,54 @@ impl ColumnValueEncoder for ByteArrayEncoder {
 
     fn estimated_plain_encoded_bytes(&self) -> Option<u64> {
         Some(self.dict_encoder.as_ref()?.plain_encoded_bytes)
+    }
+
+    fn sample_dictionary_cost(&self, max_sample_bytes: usize) -> Option<DictionaryCostSample> {
+        let dict_encoder = self.dict_encoder.as_ref()?;
+        let storage = dict_encoder.interner.storage();
+
+        // Resolve up to `max_sample_bytes` worth of the values buffered for
+        // the in-progress page (dictionary ids) and measure their size in the
+        // fallback encoding. `self.fallback` is the live encoder awaiting a
+        // potential fallback, so measure with a scratch encoder of the same
+        // encoding.
+        let mut sample_plain_bytes = 0u64;
+        let mut num_sampled = 0usize;
+        for &idx in &dict_encoder.indices {
+            sample_plain_bytes += 4 + storage.get(idx).len() as u64;
+            num_sampled += 1;
+            if sample_plain_bytes >= max_sample_bytes as u64 {
+                break;
+            }
+        }
+        let sample_fallback = if num_sampled == 0 {
+            Bytes::new()
+        } else {
+            let mut scratch = FallbackEncoder::new_from_encoding(self.fallback.encoding()).ok()?;
+            scratch.encode_all(
+                dict_encoder.indices[..num_sampled]
+                    .iter()
+                    .map(|&idx| storage.get(idx)),
+            );
+            scratch.flush_data_page(None, None).ok()?.buf
+        };
+        let dict_page_prefix = if num_sampled == 0 {
+            Bytes::new()
+        } else {
+            let prefix_len = storage.page.len().min(max_sample_bytes);
+            Bytes::copy_from_slice(&storage.page[..prefix_len])
+        };
+
+        let num_appended = usize::try_from(dict_encoder.num_appended_values).unwrap_or(usize::MAX);
+        Some(DictionaryCostSample {
+            plain_bytes: dict_encoder.plain_encoded_bytes,
+            dict_page_bytes: storage.page.len() as u64,
+            indices_bytes: 1 + RleEncoder::max_buffer_size(dict_encoder.bit_width(), num_appended)
+                as u64,
+            sample_plain_bytes,
+            sample_fallback,
+            dict_page_prefix,
+        })
     }
 
     /// Returns an estimate of the data page size in bytes

--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -173,24 +173,28 @@ impl FallbackEncoder {
         T: ArrayAccessor + Copy,
         T::Item: AsRef<[u8]>,
     {
-        self.num_values += indices.len();
+        self.encode_all(indices.map(|idx| values.value(idx)))
+    }
+
+    /// Encode each value yielded by `values` to the in-progress page
+    fn encode_all(&mut self, values: impl Iterator<Item = impl AsRef<[u8]>>) {
         match &mut self.encoder {
             FallbackEncoderImpl::Plain { buffer } => {
-                for idx in indices {
-                    let value = values.value(idx);
+                for value in values {
                     let value = value.as_ref();
                     buffer.extend_from_slice((value.len() as u32).as_bytes());
                     buffer.extend_from_slice(value);
                     self.variable_length_bytes += value.len() as i64;
+                    self.num_values += 1;
                 }
             }
             FallbackEncoderImpl::DeltaLength { buffer, lengths } => {
-                for idx in indices {
-                    let value = values.value(idx);
+                for value in values {
                     let value = value.as_ref();
                     lengths.put(&[value.len() as i32]).unwrap();
                     buffer.extend_from_slice(value);
                     self.variable_length_bytes += value.len() as i64;
+                    self.num_values += 1;
                 }
             }
             FallbackEncoderImpl::Delta {
@@ -199,8 +203,7 @@ impl FallbackEncoder {
                 prefix_lengths,
                 suffix_lengths,
             } => {
-                for idx in indices {
-                    let value = values.value(idx);
+                for value in values {
                     let value = value.as_ref();
 
                     let prefix_length = common_prefix_length(last_value, value);
@@ -213,6 +216,7 @@ impl FallbackEncoder {
                     prefix_lengths.put(&[prefix_length as i32]).unwrap();
                     suffix_lengths.put(&[suffix_length as i32]).unwrap();
                     self.variable_length_bytes += value.len() as i64;
+                    self.num_values += 1;
                 }
             }
         }
@@ -418,6 +422,12 @@ impl DictEncoder {
 pub struct ByteArrayEncoder {
     fallback: FallbackEncoder,
     dict_encoder: Option<DictEncoder>,
+    /// A dictionary encoder retained by
+    /// [`ColumnValueEncoder::fall_back_from_dictionary`] so that
+    /// [`ColumnValueEncoder::flush_dict_page`] can still produce the dictionary
+    /// page required by already flushed dictionary-encoded data pages. It no
+    /// longer receives values.
+    retired_dict_encoder: Option<DictEncoder>,
     statistics_enabled: EnabledStatistics,
     min_value: Option<ByteArray>,
     max_value: Option<ByteArray>,
@@ -457,6 +467,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
             bloom_filter,
             bloom_filter_target_fpp,
             dict_encoder: dictionary,
+            retired_dict_encoder: None,
             min_value: None,
             max_value: None,
             geo_stats_accumulator,
@@ -603,18 +614,43 @@ impl ColumnValueEncoder for ByteArrayEncoder {
     }
 
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>> {
-        match self.dict_encoder.take() {
+        let encoder = match self.dict_encoder.take() {
             Some(encoder) => {
                 if !encoder.indices.is_empty() {
                     return Err(general_err!(
                         "Must flush data pages before flushing dictionary"
                     ));
                 }
-
-                Ok(Some(encoder.flush_dict_page()))
+                encoder
             }
-            _ => Ok(None),
+            // A dictionary retained by `fall_back_from_dictionary`: its
+            // buffered indices were re-encoded through the fallback encoder
+            // when the fallback happened.
+            None => match self.retired_dict_encoder.take() {
+                Some(encoder) => encoder,
+                None => return Ok(None),
+            },
+        };
+
+        Ok(Some(encoder.flush_dict_page()))
+    }
+
+    fn fall_back_from_dictionary(&mut self, retain_dictionary: bool) -> Result<()> {
+        if let Some(mut dict_encoder) = self.dict_encoder.take() {
+            // Statistics, bloom filter and variable length bytes were all
+            // updated when these values were first written; `encode_all`
+            // re-counts `variable_length_bytes` in the fallback encoder, so
+            // reset the dictionary's per-page count to match.
+            let storage = dict_encoder.interner.storage();
+            self.fallback
+                .encode_all(dict_encoder.indices.iter().map(|&idx| storage.get(idx)));
+            dict_encoder.indices.clear();
+            dict_encoder.variable_length_bytes = 0;
+            if retain_dictionary {
+                self.retired_dict_encoder = Some(dict_encoder);
+            }
         }
+        Ok(())
     }
 
     fn flush_data_page(&mut self) -> Result<DataPageValues<ByteArray>> {

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -4205,6 +4205,75 @@ mod tests {
     }
 
     #[test]
+    fn arrow_writer_dict_fallback_before_first_data_page() {
+        // All values distinct: the dictionary overflows its 1 KiB size limit
+        // long before the first data page is flushed. The buffered values are
+        // re-encoded with the fallback encoding and the dictionary discarded:
+        // no dictionary page is written and no data page is dictionary
+        // encoded, and in particular no dictionary page exceeding the
+        // configured limit reaches the reader.
+        let values: Vec<String> = (0..1024).map(|i| format!("value-{i:04}")).collect();
+        let array = Arc::new(StringArray::from_iter_values(&values)) as ArrayRef;
+        let batch = RecordBatch::try_from_iter([("col", array)]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_writer_version(WriterVersion::PARQUET_1_0)
+            .set_dictionary_page_size_limit(1024)
+            .build();
+
+        // Validates the values roundtrip, across the fallback point included.
+        let file = roundtrip_opts(&batch, props);
+
+        let reader = SerializedFileReader::new(file).unwrap();
+        let column = reader.metadata().row_group(0).column(0);
+        assert_eq!(column.dictionary_page_offset(), None);
+        let encodings: Vec<_> = column.encodings().collect();
+        assert!(
+            !encodings.contains(&Encoding::RLE_DICTIONARY),
+            "unexpected dictionary encoding: {encodings:?}"
+        );
+        let mask = column.page_encoding_stats_mask().unwrap();
+        assert!(
+            mask.is_only(Encoding::PLAIN),
+            "expected only plain-encoded data pages: {mask:?}"
+        );
+    }
+
+    #[test]
+    fn arrow_writer_dict_fallback_after_data_page_keeps_dictionary() {
+        // Flush dictionary-encoded data pages every 32 rows, so that when the
+        // dictionary overflows its size limit part-way through the chunk,
+        // pages referencing it have already been written: the dictionary page
+        // must then still be written, while the remainder of the chunk uses
+        // the fallback encoding.
+        let values: Vec<String> = (0..1024).map(|i| format!("value-{i:04}")).collect();
+        let array = Arc::new(StringArray::from_iter_values(&values)) as ArrayRef;
+        let batch = RecordBatch::try_from_iter([("col", array)]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_writer_version(WriterVersion::PARQUET_1_0)
+            .set_dictionary_page_size_limit(4096)
+            .set_data_page_row_count_limit(32)
+            .set_write_batch_size(32)
+            .build();
+
+        let file = roundtrip_opts(&batch, props);
+
+        let reader = SerializedFileReader::new(file).unwrap();
+        let column = reader.metadata().row_group(0).column(0);
+        assert!(column.dictionary_page_offset().is_some());
+        let mask = column.page_encoding_stats_mask().unwrap();
+        assert!(
+            mask.is_set(Encoding::RLE_DICTIONARY),
+            "expected dictionary-encoded pages before the fallback: {mask:?}"
+        );
+        assert!(
+            mask.is_set(Encoding::PLAIN),
+            "expected plain pages after the fallback: {mask:?}"
+        );
+    }
+
+    #[test]
     fn arrow_writer_string_dictionary() {
         // define schema
         #[expect(deprecated)]

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2076,15 +2076,16 @@ mod tests {
     use arrow::{array::*, buffer::Buffer};
     use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano, NullBuffer, OffsetBuffer, i256};
     use arrow_schema::Fields;
+    use arrow_select::concat::concat_batches;
     use half::f16;
     use num_traits::{FromPrimitive, ToPrimitive};
     use tempfile::tempfile;
 
-    use crate::basic::Encoding;
+    use crate::basic::{Encoding, PageType};
     use crate::data_type::AsBytes;
     use crate::file::metadata::{ColumnChunkMetaData, ParquetMetaData, ParquetMetaDataReader};
     use crate::file::properties::{
-        BloomFilterPosition, EnabledStatistics, ReaderProperties, WriterVersion,
+        BloomFilterPosition, DictionaryFallback, EnabledStatistics, ReaderProperties, WriterVersion,
     };
     use crate::file::serialized_reader::ReadOptionsBuilder;
     use crate::file::{
@@ -5587,6 +5588,237 @@ mod tests {
 
         assert_eq!(get_dict_page_size(col0_meta), 1024 * 1024);
         assert_eq!(get_dict_page_size(col1_meta), 1024 * 1024 * 4);
+    }
+
+    /// A single-column batch of `pool_size * repeats` strings, each of the
+    /// `pool_size` distinct `value_len` byte values repeated `repeats` times
+    /// consecutively. The consecutive runs keep the ratio of distinct to total
+    /// values seen so far at `1 / repeats`, independent of how the writer
+    /// slices the batch internally
+    fn repetitive_string_batch(pool_size: usize, value_len: usize, repeats: usize) -> RecordBatch {
+        let pool: Vec<String> = (0..pool_size)
+            .map(|i| {
+                let mut v = format!("value-{i:06}-").repeat(value_len / 8 + 1);
+                v.truncate(value_len);
+                v
+            })
+            .collect();
+        let array =
+            StringArray::from_iter_values((0..pool_size * repeats).map(|i| &pool[i / repeats]));
+        let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, false)]));
+        RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
+    }
+
+    /// Writes `batch` with `props`, returning the encoded bytes and the metadata
+    fn write_batch_with_props(
+        batch: &RecordBatch,
+        props: WriterProperties,
+    ) -> (Bytes, ParquetMetaData) {
+        let mut writer = ArrowWriter::try_new(Vec::new(), batch.schema(), Some(props)).unwrap();
+        writer.write(batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+        let options = ReadOptionsBuilder::new()
+            .with_encoding_stats_as_mask(false)
+            .build();
+        let reader = SerializedFileReader::new_with_options(data.clone(), options).unwrap();
+        let metadata = reader.metadata().clone();
+        (data, metadata)
+    }
+
+    /// Returns the number of data pages in the first column chunk of the first
+    /// row group encoded with the dictionary, and the number encoded otherwise
+    /// (i.e. with the fallback encoding)
+    fn count_dict_and_fallback_pages(metadata: &ParquetMetaData) -> (i32, i32) {
+        let stats = metadata
+            .row_group(0)
+            .column(0)
+            .page_encoding_stats()
+            .unwrap();
+        let mut num_dict = 0;
+        let mut num_fallback = 0;
+        for s in stats {
+            if s.page_type == PageType::DATA_PAGE || s.page_type == PageType::DATA_PAGE_V2 {
+                match s.encoding {
+                    Encoding::RLE_DICTIONARY | Encoding::PLAIN_DICTIONARY => num_dict += s.count,
+                    _ => num_fallback += s.count,
+                }
+            }
+        }
+        (num_dict, num_fallback)
+    }
+
+    #[test]
+    fn test_dictionary_fallback_explicit_default_policy_unchanged() {
+        // Explicitly configuring `DictionaryFallback::OnPageSizeLimit` must be
+        // byte-identical to the default properties, on data that does overflow
+        // the dictionary page size limit and trigger the fallback
+        let batch = repetitive_string_batch(64, 2048, 32);
+
+        let default_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .build();
+        let explicit_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_dictionary_fallback(DictionaryFallback::OnPageSizeLimit)
+            .build();
+
+        let (default_data, default_metadata) = write_batch_with_props(&batch, default_props);
+        let (explicit_data, _) = write_batch_with_props(&batch, explicit_props);
+
+        assert_eq!(default_data, explicit_data);
+
+        // the dictionary overflowed the 64 KiB limit, so the writer fell back
+        let (num_dict, num_fallback) = count_dict_and_fallback_pages(&default_metadata);
+        assert!(num_dict > 0, "expected dictionary encoded pages");
+        assert!(num_fallback > 0, "expected fallback encoded pages");
+    }
+
+    #[test]
+    fn test_dictionary_fallback_when_profitable_keeps_dictionary() {
+        // 64 distinct 2 KiB values (~131 KiB dictionary) overflow a 64 KiB
+        // dictionary page size limit, but each value recurs 32 times: the
+        // dictionary is profitable, so `WhenProfitable` must keep it while
+        // `OnPageSizeLimit` falls back
+        let batch = repetitive_string_batch(64, 2048, 32);
+
+        let default_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .build();
+        let profitable_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_dictionary_fallback(DictionaryFallback::WhenProfitable {
+                worth_ratio: 0.1,
+                max_dictionary_page_size: 64 * 1024 * 1024,
+            })
+            .build();
+
+        let (default_data, _) = write_batch_with_props(&batch, default_props);
+        let (profitable_data, profitable_metadata) =
+            write_batch_with_props(&batch, profitable_props);
+
+        // no fallback: all data pages are dictionary encoded and the
+        // dictionary page is present
+        let (num_dict, num_fallback) = count_dict_and_fallback_pages(&profitable_metadata);
+        assert!(num_dict > 0, "expected dictionary encoded pages");
+        assert_eq!(num_fallback, 0, "expected no fallback encoded pages");
+        let column = profitable_metadata.row_group(0).column(0);
+        assert!(column.dictionary_page_offset().is_some());
+
+        // deduplicating the repeated values must beat writing them out in full
+        assert!(
+            profitable_data.len() < default_data.len() / 2,
+            "expected dictionary encoded file to be much smaller, got {} vs {}",
+            profitable_data.len(),
+            default_data.len()
+        );
+
+        // roundtrip: the data must read back identically
+        let read = ParquetRecordBatchReader::try_new(profitable_data, 2048)
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+        let read = concat_batches(&batch.schema(), &read).unwrap();
+        assert_eq!(read, batch);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_when_profitable_hard_cap() {
+        // 80 distinct 2 KiB values (~164 KiB dictionary) are profitable at a
+        // worth_ratio of 0.5, but the 128 KiB `max_dictionary_page_size` cap
+        // must force the fallback regardless
+        let batch = repetitive_string_batch(80, 2048, 16);
+
+        let props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_dictionary_fallback(DictionaryFallback::WhenProfitable {
+                worth_ratio: 0.5,
+                max_dictionary_page_size: 128 * 1024,
+            })
+            .build();
+
+        let (_, metadata) = write_batch_with_props(&batch, props);
+
+        let (_, num_fallback) = count_dict_and_fallback_pages(&metadata);
+        assert!(num_fallback > 0, "expected fallback encoded pages");
+    }
+
+    #[test]
+    fn test_dictionary_fallback_when_profitable_high_cardinality_matches_default() {
+        // On a column of unique values the dictionary is never profitable: the
+        // profitability test fails right at the dictionary page size limit, so
+        // `WhenProfitable` must produce output byte-identical to the default
+        // policy. This uses an Int64 column to also exercise the non-byte-array
+        // dictionary encoder
+        let array = Arc::new(Int64Array::from_iter(0..1024 * 1024));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "col",
+            arrow_schema::DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let default_props = WriterProperties::builder().build();
+        let profitable_props = WriterProperties::builder()
+            .set_dictionary_fallback(DictionaryFallback::WhenProfitable {
+                worth_ratio: 0.1,
+                max_dictionary_page_size: 64 * 1024 * 1024,
+            })
+            .build();
+
+        let (default_data, default_metadata) = write_batch_with_props(&batch, default_props);
+        let (profitable_data, _) = write_batch_with_props(&batch, profitable_props);
+
+        // both fall back at the dictionary page size limit
+        let (_, num_fallback) = count_dict_and_fallback_pages(&default_metadata);
+        assert!(num_fallback > 0, "expected fallback encoded pages");
+        assert_eq!(default_data, profitable_data);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_when_profitable_int64_keeps_dictionary() {
+        // Exercise the non-byte-array dictionary encoder's profitability
+        // accounting: 16 Ki distinct Int64 values (128 KiB dictionary), each
+        // repeated 16 times, against a 64 KiB dictionary page size limit
+        let array = Arc::new(Int64Array::from_iter(
+            (0..16 * 1024i64).flat_map(|i| std::iter::repeat_n(i, 16)),
+        ));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "col",
+            arrow_schema::DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_column_dictionary_fallback(
+                ColumnPath::from("col"),
+                DictionaryFallback::WhenProfitable {
+                    worth_ratio: 0.1,
+                    max_dictionary_page_size: 64 * 1024 * 1024,
+                },
+            )
+            .build();
+
+        let (data, metadata) = write_batch_with_props(&batch, props);
+
+        let (num_dict, num_fallback) = count_dict_and_fallback_pages(&metadata);
+        assert!(num_dict > 0, "expected dictionary encoded pages");
+        assert_eq!(num_fallback, 0, "expected no fallback encoded pages");
+        assert!(
+            metadata
+                .row_group(0)
+                .column(0)
+                .dictionary_page_offset()
+                .is_some()
+        );
+
+        let read = ParquetRecordBatchReader::try_new(data, 8192)
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+        let read = concat_batches(&batch.schema(), &read).unwrap();
+        assert_eq!(read, batch);
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -5894,6 +5894,322 @@ mod tests {
         assert_eq!(read, batch);
     }
 
+    /// Roundtrips `data` and asserts it equals `batch`
+    fn assert_roundtrip_equal(data: Bytes, batch: &RecordBatch) {
+        let read = ParquetRecordBatchReader::try_new(data, 8192)
+            .unwrap()
+            .collect::<ArrowResult<Vec<_>>>()
+            .unwrap();
+        let read = concat_batches(&batch.schema(), &read).unwrap();
+        assert_eq!(&read, batch);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_adaptive_sorted_keys_fall_back_like_stock() {
+        // A sorted key column where each value repeats a few times: the
+        // dictionary looks nominally profitable (a quarter of the PLAIN
+        // size), but DELTA_BINARY_PACKED encodes the sorted values far
+        // smaller than dictionary page + indices. `Adaptive` measures the
+        // fallback and must fall back exactly like the default policy —
+        // byte-identical output — where `WhenProfitable` at a 0.5 ratio
+        // keeps the dictionary and produces a much larger file
+        let array = Arc::new(Int64Array::from_iter(
+            (0..32 * 1024i64).flat_map(|i| std::iter::repeat_n(i, 4)),
+        ));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "col",
+            arrow_schema::DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let base = || {
+            WriterProperties::builder()
+                .set_writer_version(WriterVersion::PARQUET_2_0)
+                .set_dictionary_page_size_limit(64 * 1024)
+        };
+        let (stock_data, stock_metadata) = write_batch_with_props(&batch, base().build());
+        let (adaptive_data, _) = write_batch_with_props(
+            &batch,
+            base()
+                .set_dictionary_fallback(DictionaryFallback::Adaptive {
+                    max_dictionary_page_size: 64 * 1024 * 1024,
+                })
+                .build(),
+        );
+        let (profitable_data, profitable_metadata) = write_batch_with_props(
+            &batch,
+            base()
+                .set_dictionary_fallback(DictionaryFallback::WhenProfitable {
+                    worth_ratio: 0.5,
+                    max_dictionary_page_size: 64 * 1024 * 1024,
+                })
+                .build(),
+        );
+
+        // stock fell back at the dictionary page size limit; the measured
+        // comparison reaches the same decision at the same point
+        let (_, num_fallback) = count_dict_and_fallback_pages(&stock_metadata);
+        assert!(num_fallback > 0, "expected fallback encoded pages");
+        assert_eq!(adaptive_data, stock_data);
+
+        // ... while the PLAIN-bound ratio heuristic keeps the dictionary and
+        // pays for it
+        let (_, num_fallback) = count_dict_and_fallback_pages(&profitable_metadata);
+        assert_eq!(num_fallback, 0, "expected WhenProfitable to keep the dict");
+        assert!(
+            profitable_data.len() > 2 * stock_data.len(),
+            "expected the kept dictionary to lose to the delta fallback, got {} vs {}",
+            profitable_data.len(),
+            stock_data.len()
+        );
+
+        assert_roundtrip_equal(adaptive_data, &batch);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_adaptive_keeps_repetitive_dictionary() {
+        // 64 distinct 2 KiB values (~131 KiB dictionary) overflow a 64 KiB
+        // dictionary page size limit, but each value recurs 32 times: the
+        // measured comparison keeps the dictionary, with no ratio to tune
+        let batch = repetitive_string_batch(64, 2048, 32);
+
+        let default_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .build();
+        let adaptive_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_dictionary_fallback(DictionaryFallback::Adaptive {
+                max_dictionary_page_size: 64 * 1024 * 1024,
+            })
+            .build();
+
+        let (default_data, _) = write_batch_with_props(&batch, default_props);
+        let (adaptive_data, adaptive_metadata) = write_batch_with_props(&batch, adaptive_props);
+
+        let (num_dict, num_fallback) = count_dict_and_fallback_pages(&adaptive_metadata);
+        assert!(num_dict > 0, "expected dictionary encoded pages");
+        assert_eq!(num_fallback, 0, "expected no fallback encoded pages");
+        let column = adaptive_metadata.row_group(0).column(0);
+        assert!(column.dictionary_page_offset().is_some());
+
+        assert!(
+            adaptive_data.len() < default_data.len() / 2,
+            "expected dictionary encoded file to be much smaller, got {} vs {}",
+            adaptive_data.len(),
+            default_data.len()
+        );
+
+        assert_roundtrip_equal(adaptive_data, &batch);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_adaptive_shuffled_pool_keeps_dictionary() {
+        // A bounded pool of 300 distinct 1 KiB values sampled in uniformly
+        // shuffled order: when the dictionary crosses the 64 KiB grace floor
+        // (~64 distinct values seen) only a handful of repeats are visible,
+        // so any up-front decision falls back — both `OnPageSizeLimit` and
+        // the `WhenProfitable` ratio heuristic write every repeat out in
+        // full. The measured near-tie plus visible repeats defers the
+        // decision; by later checkpoints the accumulated repeats have the
+        // dictionary measurably winning, and the pool exhausts well below the
+        // hard cap
+        let pool: Vec<String> = (0..300)
+            .map(|i| {
+                let mut v = format!("value-{i:06}-").repeat(1024 / 8 + 1);
+                v.truncate(1024);
+                v
+            })
+            .collect();
+        // Deterministic uniform sampling (LCG), so repeats occur by the
+        // birthday bound rather than by construction
+        let mut lcg: u64 = 42;
+        let array = StringArray::from_iter_values((0..8192).map(|_| {
+            lcg = lcg
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            &pool[(lcg >> 33) as usize % 300]
+        }));
+        let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap();
+
+        let default_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .build();
+        let adaptive_props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_dictionary_fallback(DictionaryFallback::Adaptive {
+                max_dictionary_page_size: 64 * 1024 * 1024,
+            })
+            .build();
+
+        let (default_data, default_metadata) = write_batch_with_props(&batch, default_props);
+        let (adaptive_data, adaptive_metadata) = write_batch_with_props(&batch, adaptive_props);
+
+        // stock gives up on the shuffled pool ...
+        let (_, num_fallback) = count_dict_and_fallback_pages(&default_metadata);
+        assert!(num_fallback > 0, "expected stock to fall back");
+
+        // ... the measured deferral captures it
+        let (num_dict, num_fallback) = count_dict_and_fallback_pages(&adaptive_metadata);
+        assert!(num_dict > 0, "expected dictionary encoded pages");
+        assert_eq!(num_fallback, 0, "expected no fallback encoded pages");
+        assert!(
+            adaptive_metadata
+                .row_group(0)
+                .column(0)
+                .dictionary_page_offset()
+                .is_some()
+        );
+        assert!(
+            adaptive_data.len() < default_data.len() / 2,
+            "expected dictionary encoded file to be much smaller, got {} vs {}",
+            adaptive_data.len(),
+            default_data.len()
+        );
+
+        assert_roundtrip_equal(adaptive_data, &batch);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_adaptive_unique_values_match_stock() {
+        // On a column of unique values no repeat is ever seen: the measured
+        // comparison fails right at the grace floor with nothing to defer
+        // for, so `Adaptive` must produce output byte-identical to the
+        // default policy
+        let batch = repetitive_string_batch(2048, 256, 1);
+
+        let base = || WriterProperties::builder().set_dictionary_page_size_limit(64 * 1024);
+        let (stock_data, stock_metadata) = write_batch_with_props(&batch, base().build());
+        let (adaptive_data, _) = write_batch_with_props(
+            &batch,
+            base()
+                .set_dictionary_fallback(DictionaryFallback::Adaptive {
+                    max_dictionary_page_size: 64 * 1024 * 1024,
+                })
+                .build(),
+        );
+
+        let (_, num_fallback) = count_dict_and_fallback_pages(&stock_metadata);
+        assert!(num_fallback > 0, "expected fallback encoded pages");
+        assert_eq!(adaptive_data, stock_data);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_adaptive_unbounded_cardinality_bounded_deferral() {
+        // Effectively unbounded cardinality with a trickle of repeats (one
+        // value in ~83 repeats, just above the minimum repeat fraction): at
+        // the first checkpoint the comparison is a near-tie (the dictionary
+        // is behind by only the indices overhead), so the decision is
+        // deferred; by the second checkpoint the hit rate is flat and low, so
+        // the writer falls back — with a dictionary bounded to twice the
+        // grace floor, not the cap — and the chunk stays about the size stock
+        // produces
+        let pool: Vec<String> = (0..8192)
+            .map(|i| {
+                let mut v = format!("value-{i:06}-").repeat(64 / 8 + 1);
+                v.truncate(64);
+                v
+            })
+            .collect();
+        let array = StringArray::from_iter_values(
+            (0..8192).map(|i| &pool[if i % 83 == 1 { i - 1 } else { i }]),
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap();
+
+        let base = || WriterProperties::builder().set_dictionary_page_size_limit(64 * 1024);
+        let (stock_data, _) = write_batch_with_props(&batch, base().build());
+        let (adaptive_data, adaptive_metadata) = write_batch_with_props(
+            &batch,
+            base()
+                .set_dictionary_fallback(DictionaryFallback::Adaptive {
+                    max_dictionary_page_size: 64 * 1024 * 1024,
+                })
+                .build(),
+        );
+
+        let (_, num_fallback) = count_dict_and_fallback_pages(&adaptive_metadata);
+        assert!(
+            num_fallback > 0,
+            "expected the deferred decision to fall back"
+        );
+
+        // the brief deferral must not cost more than a few percent vs stock
+        let (stock_len, adaptive_len) = (stock_data.len() as f64, adaptive_data.len() as f64);
+        assert!(
+            (adaptive_len - stock_len).abs() / stock_len < 0.1,
+            "expected chunk size close to stock, got {} vs {}",
+            adaptive_data.len(),
+            stock_data.len()
+        );
+
+        assert_roundtrip_equal(adaptive_data, &batch);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_adaptive_hard_cap() {
+        // 80 distinct 2 KiB values (~164 KiB dictionary), each repeated 16
+        // times, measure as clearly worth keeping — but the 128 KiB
+        // `max_dictionary_page_size` cap must force the fallback regardless
+        let batch = repetitive_string_batch(80, 2048, 16);
+
+        let props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_dictionary_fallback(DictionaryFallback::Adaptive {
+                max_dictionary_page_size: 128 * 1024,
+            })
+            .build();
+
+        let (data, metadata) = write_batch_with_props(&batch, props);
+
+        let (_, num_fallback) = count_dict_and_fallback_pages(&metadata);
+        assert!(num_fallback > 0, "expected fallback encoded pages");
+
+        assert_roundtrip_equal(data, &batch);
+    }
+
+    #[test]
+    fn test_dictionary_fallback_adaptive_int64_keeps_dictionary() {
+        // Exercise the non-byte-array dictionary encoder's measurement path:
+        // 16 Ki distinct Int64 values (128 KiB dictionary), each repeated 16
+        // times, against a 64 KiB dictionary page size limit
+        let array = Arc::new(Int64Array::from_iter(
+            (0..16 * 1024i64).flat_map(|i| std::iter::repeat_n(i, 16)),
+        ));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "col",
+            arrow_schema::DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let props = WriterProperties::builder()
+            .set_dictionary_page_size_limit(64 * 1024)
+            .set_column_dictionary_fallback(
+                ColumnPath::from("col"),
+                DictionaryFallback::Adaptive {
+                    max_dictionary_page_size: 64 * 1024 * 1024,
+                },
+            )
+            .build();
+
+        let (data, metadata) = write_batch_with_props(&batch, props);
+
+        let (num_dict, num_fallback) = count_dict_and_fallback_pages(&metadata);
+        assert!(num_dict > 0, "expected dictionary encoded pages");
+        assert_eq!(num_fallback, 0, "expected no fallback encoded pages");
+        assert!(
+            metadata
+                .row_group(0)
+                .column(0)
+                .dictionary_page_offset()
+                .is_some()
+        );
+
+        assert_roundtrip_equal(data, &batch);
+    }
+
     #[test]
     fn test_arrow_writer_granular_mode_roundtrip() {
         // Granular mode subdivides chunks and writes more pages than the

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -139,6 +139,18 @@ pub trait ColumnValueEncoder {
     /// Returns an estimate of the encoded size of dictionary page size in bytes, or `None` if no dictionary
     fn estimated_dict_page_size(&self) -> Option<usize>;
 
+    /// Returns an estimate of the total bytes the values appended to this column
+    /// chunk so far would occupy PLAIN-encoded, or `None` if unknown
+    ///
+    /// Used together with [`Self::estimated_dict_page_size`] to decide whether
+    /// dictionary encoding is still paying for itself relative to the fallback
+    /// encoding, see [`DictionaryFallback::WhenProfitable`]
+    ///
+    /// [`DictionaryFallback::WhenProfitable`]: crate::file::properties::DictionaryFallback::WhenProfitable
+    fn estimated_plain_encoded_bytes(&self) -> Option<u64> {
+        None
+    }
+
     /// Returns an estimate of the encoded data page size in bytes
     ///
     /// This should include:
@@ -349,6 +361,10 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
 
     fn estimated_dict_page_size(&self) -> Option<usize> {
         Some(self.dict_encoder.as_ref()?.dict_encoded_size())
+    }
+
+    fn estimated_plain_encoded_bytes(&self) -> Option<u64> {
+        Some(self.dict_encoder.as_ref()?.plain_encoded_bytes())
     }
 
     fn estimated_data_page_size(&self) -> usize {

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -152,6 +152,20 @@ pub trait ColumnValueEncoder {
     /// are any pending page values
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>>;
 
+    /// Falls back from dictionary encoding to the fallback encoding for the
+    /// remainder of this column chunk: any values buffered for the in-progress
+    /// data page (currently held as dictionary ids) are re-encoded through the
+    /// fallback encoder, and subsequent writes will not be dictionary encoded.
+    ///
+    /// If `retain_dictionary` is true the dictionary itself is kept, so that a
+    /// subsequent call to [`Self::flush_dict_page`] can produce the dictionary
+    /// page required by dictionary-encoded data pages that were already
+    /// flushed. Otherwise the dictionary is discarded and
+    /// [`Self::flush_dict_page`] will return `None`.
+    ///
+    /// Does nothing if no dictionary encoder is active.
+    fn fall_back_from_dictionary(&mut self, retain_dictionary: bool) -> Result<()>;
+
     /// Flush the next data page for this column chunk
     fn flush_data_page(&mut self) -> Result<DataPageValues<Self::T>>;
 
@@ -168,6 +182,11 @@ pub trait ColumnValueEncoder {
 pub struct ColumnValueEncoderImpl<T: DataType> {
     encoder: Box<dyn Encoder<T>>,
     dict_encoder: Option<DictEncoder<T>>,
+    /// A dictionary encoder retained by [`Self::fall_back_from_dictionary`] so
+    /// that [`Self::flush_dict_page`] can still produce the dictionary page
+    /// required by already flushed dictionary-encoded data pages. It no longer
+    /// receives values.
+    retired_dict_encoder: Option<DictEncoder<T>>,
     descr: ColumnDescPtr,
     num_values: usize,
     statistics_enabled: EnabledStatistics,
@@ -255,6 +274,7 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
         Ok(Self {
             encoder,
             dict_encoder,
+            retired_dict_encoder: None,
             descr: descr.clone(),
             num_values: 0,
             statistics_enabled,
@@ -359,24 +379,44 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
     }
 
     fn flush_dict_page(&mut self) -> Result<Option<DictionaryPage>> {
-        match self.dict_encoder.take() {
+        let encoder = match self.dict_encoder.take() {
             Some(encoder) => {
                 if self.num_values != 0 {
                     return Err(general_err!(
                         "Must flush data pages before flushing dictionary"
                     ));
                 }
-
-                let buf = encoder.write_dict()?;
-
-                Ok(Some(DictionaryPage {
-                    buf,
-                    num_values: encoder.num_entries(),
-                    is_sorted: encoder.is_sorted(),
-                }))
+                encoder
             }
-            _ => Ok(None),
+            // A dictionary retained by `fall_back_from_dictionary`: the values
+            // buffered when the fallback happened were re-encoded through the
+            // fallback encoder, so pending page values are fine here.
+            None => match self.retired_dict_encoder.take() {
+                Some(encoder) => encoder,
+                None => return Ok(None),
+            },
+        };
+
+        let buf = encoder.write_dict()?;
+
+        Ok(Some(DictionaryPage {
+            buf,
+            num_values: encoder.num_entries(),
+            is_sorted: encoder.is_sorted(),
+        }))
+    }
+
+    fn fall_back_from_dictionary(&mut self, retain_dictionary: bool) -> Result<()> {
+        if let Some(mut dict_encoder) = self.dict_encoder.take() {
+            // Statistics, bloom filter and variable length bytes were all
+            // updated when these values were first written, so the re-encoded
+            // values deliberately bypass `write_slice`.
+            self.encoder.put(&dict_encoder.take_buffered_values())?;
+            if retain_dictionary {
+                self.retired_dict_encoder = Some(dict_encoder);
+            }
         }
+        Ok(())
     }
 
     fn flush_data_page(&mut self) -> Result<DataPageValues<T::T>> {

--- a/parquet/src/column/writer/encoder.rs
+++ b/parquet/src/column/writer/encoder.rs
@@ -57,6 +57,30 @@ pub struct DictionaryPage {
     pub is_sorted: bool,
 }
 
+/// Measured cost inputs for the `Adaptive` dictionary fallback policy, see
+/// [`ColumnValueEncoder::sample_dictionary_cost`]
+///
+/// [`DictionaryFallback::Adaptive`]: crate::file::properties::DictionaryFallback::Adaptive
+pub struct DictionaryCostSample {
+    /// Total bytes the values appended to this column chunk so far would
+    /// occupy PLAIN-encoded
+    pub plain_bytes: u64,
+    /// Current size of the dictionary page, in bytes
+    pub dict_page_bytes: u64,
+    /// Upper-bound estimate of the RLE/bit-packed size of the dictionary
+    /// indices for every value appended to this column chunk so far
+    pub indices_bytes: u64,
+    /// PLAIN-encoded size of the sampled values; `0` if no values are
+    /// currently buffered (in which case `sample_fallback` is empty)
+    pub sample_plain_bytes: u64,
+    /// A bounded sample of the currently-buffered values (resolved through the
+    /// dictionary), encoded with the column's fallback encoding
+    pub sample_fallback: Bytes,
+    /// A bounded prefix of the dictionary page bytes, for estimating the
+    /// dictionary page's compressibility
+    pub dict_page_prefix: Bytes,
+}
+
 /// The encoded values for a data page, with optional statistics
 pub struct DataPageValues<T> {
     pub buf: Bytes,
@@ -148,6 +172,23 @@ pub trait ColumnValueEncoder {
     ///
     /// [`DictionaryFallback::WhenProfitable`]: crate::file::properties::DictionaryFallback::WhenProfitable
     fn estimated_plain_encoded_bytes(&self) -> Option<u64> {
+        None
+    }
+
+    /// Measures the cost inputs for the `Adaptive` dictionary fallback policy,
+    /// or `None` if no dictionary encoder is active (or the encoder does not
+    /// support measurement, in which case the policy preserves the
+    /// absolute-limit fallback behavior).
+    ///
+    /// The measured sample is bounded: at most `max_sample_bytes` of buffered
+    /// values (PLAIN-encoded size) are resolved through the dictionary and
+    /// re-encoded through a scratch fallback encoder, and at most
+    /// `max_sample_bytes` of the dictionary page is copied as a
+    /// compressibility sample, so a single measurement costs no more than
+    /// encoding one data page's worth of values.
+    ///
+    /// [`DictionaryFallback::Adaptive`]: crate::file::properties::DictionaryFallback::Adaptive
+    fn sample_dictionary_cost(&self, _max_sample_bytes: usize) -> Option<DictionaryCostSample> {
         None
     }
 
@@ -385,6 +426,37 @@ impl<T: DataType> ColumnValueEncoder for ColumnValueEncoderImpl<T> {
 
     fn estimated_plain_encoded_bytes(&self) -> Option<u64> {
         Some(self.dict_encoder.as_ref()?.plain_encoded_bytes())
+    }
+
+    fn sample_dictionary_cost(&self, max_sample_bytes: usize) -> Option<DictionaryCostSample> {
+        let dict_encoder = self.dict_encoder.as_ref()?;
+
+        let (sample_values, sample_plain_bytes) =
+            dict_encoder.sample_buffered_values(max_sample_bytes);
+        let sample_fallback = if sample_values.is_empty() {
+            Bytes::new()
+        } else {
+            // `self.encoder` is the live fallback encoder awaiting a potential
+            // fallback; measure with a scratch encoder of the same encoding so
+            // its state is not disturbed.
+            let mut scratch = get_encoder::<T>(self.encoder.encoding(), &self.descr).ok()?;
+            scratch.put(&sample_values).ok()?;
+            scratch.flush_buffer().ok()?
+        };
+        let dict_page_prefix = if sample_plain_bytes == 0 {
+            Bytes::new()
+        } else {
+            dict_encoder.write_dict_prefix(max_sample_bytes).ok()?
+        };
+
+        Some(DictionaryCostSample {
+            plain_bytes: dict_encoder.plain_encoded_bytes(),
+            dict_page_bytes: dict_encoder.dict_encoded_size() as u64,
+            indices_bytes: dict_encoder.estimated_total_indices_bytes(),
+            sample_plain_bytes,
+            sample_fallback,
+            dict_page_prefix,
+        })
     }
 
     fn estimated_data_page_size(&self) -> usize {

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -473,6 +473,10 @@ pub struct GenericColumnWriter<'a, E: ColumnValueEncoder> {
     def_levels_encoder: LevelEncoder,
     rep_levels_encoder: LevelEncoder,
     data_pages: VecDeque<CompressedPage>,
+    /// Whether any dictionary-encoded data page has been produced for this
+    /// column chunk. Once set, a dictionary fallback can no longer skip
+    /// writing the dictionary page, as the flushed pages reference it.
+    has_dictionary_encoded_data_pages: bool,
     // column index and offset index
     column_index_builder: ColumnIndexBuilder,
     offset_index_builder: Option<OffsetIndexBuilder>,
@@ -539,6 +543,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             compressor,
             encoder,
             data_pages: VecDeque::new(),
+            has_dictionary_encoded_data_pages: false,
             page_metrics,
             column_metrics,
             distinct_count_override: None,
@@ -1079,14 +1084,34 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     }
 
     /// Performs dictionary fallback.
-    /// Prepares and writes dictionary and all data pages into page writer.
+    ///
+    /// The values buffered for the in-progress data page are dictionary ids;
+    /// they are re-encoded through the fallback encoder (together with the
+    /// dictionary they resolve to) rather than flushed as one more
+    /// dictionary-encoded page, and remain buffered. This matches
+    /// parquet-java's `FallbackValuesWriter`.
+    ///
+    /// If dictionary-encoded data pages have already been produced for this
+    /// chunk they reference the dictionary, so the dictionary page must still
+    /// be written, ahead of any data pages buffered while awaiting it.
+    /// Otherwise no dictionary page is written at all and the whole chunk uses
+    /// the fallback encoding.
     fn dict_fallback(&mut self) -> Result<()> {
         // At this point we know that we need to fall back.
-        if self.page_metrics.num_buffered_values > 0 {
+        let retain_dictionary = self.has_dictionary_encoded_data_pages;
+        self.encoder.fall_back_from_dictionary(retain_dictionary)?;
+        if retain_dictionary {
+            self.write_dictionary_page()?;
+            while let Some(page) = self.data_pages.pop_front() {
+                self.write_data_page(page)?;
+            }
+        }
+        // The dictionary ids held only a fraction of the page size budget; the
+        // same values re-encoded with the fallback encoding may already exceed
+        // it.
+        if self.should_add_data_page() {
             self.add_data_page()?;
         }
-        self.write_dictionary_page()?;
-        self.flush_data_pages()?;
         Ok(())
     }
 
@@ -1499,8 +1524,13 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         // that defers final layout (the Arrow path) instead orders pages itself
         // at flush, so we stream the data pages straight through and never let
         // them accumulate in memory.
-        if self.encoder.has_dictionary() && !self.page_writer.defers_dictionary_ordering() {
-            self.data_pages.push_back(compressed_page);
+        if self.encoder.has_dictionary() {
+            self.has_dictionary_encoded_data_pages = true;
+            if self.page_writer.defers_dictionary_ordering() {
+                self.write_data_page(compressed_page)?;
+            } else {
+                self.data_pages.push_back(compressed_page);
+            }
         } else {
             self.write_data_page(compressed_page)?;
         }
@@ -2760,6 +2790,121 @@ mod tests {
     }
 
     #[test]
+    fn test_column_writer_dict_fallback_before_first_data_page() {
+        // All values distinct: the dictionary overflows its size limit long
+        // before the first data page is flushed, so the buffered values are
+        // re-encoded with the fallback encoding and the dictionary is
+        // discarded entirely: no dictionary page and no dictionary-encoded
+        // data page.
+        let values: Vec<i32> = (0..2048).collect();
+        let props = || {
+            WriterProperties::builder()
+                .set_writer_version(WriterVersion::PARQUET_1_0)
+                .set_dictionary_page_size_limit(512)
+                .build()
+        };
+
+        let meta = column_write_and_get_metadata::<Int32Type>(props(), &values);
+        assert_eq!(meta.dictionary_page_offset(), None);
+        assert_eq!(
+            meta.encodings().collect::<Vec<_>>(),
+            &[Encoding::PLAIN, Encoding::RLE]
+        );
+        assert_eq!(
+            meta.page_encoding_stats().unwrap(),
+            &[encoding_stats(PageType::DATA_PAGE, Encoding::PLAIN, 1)]
+        );
+        // The whole chunk is plain encoded: no dictionary page and no
+        // dictionary-encoded prefix duplicating the values it references.
+        assert!(
+            meta.compressed_size() <= (values.len() * 4 + 128) as i64,
+            "unexpected chunk size {}",
+            meta.compressed_size()
+        );
+
+        // Values on both sides of the fallback point roundtrip.
+        column_roundtrip::<Int32Type>(props(), &values, None, None);
+    }
+
+    #[test]
+    fn test_column_writer_dict_fallback_before_first_data_page_v2() {
+        // As `test_column_writer_dict_fallback_before_first_data_page`, with
+        // the V2 fallback encoding: a sorted column re-encoded with
+        // DELTA_BINARY_PACKED ends up considerably smaller than the plain
+        // values, let alone than an oversized dictionary page plus a
+        // dictionary-encoded prefix.
+        let values: Vec<i32> = (0..2048).collect();
+        let props = || {
+            WriterProperties::builder()
+                .set_writer_version(WriterVersion::PARQUET_2_0)
+                .set_dictionary_page_size_limit(512)
+                .build()
+        };
+
+        let meta = column_write_and_get_metadata::<Int32Type>(props(), &values);
+        assert_eq!(meta.dictionary_page_offset(), None);
+        assert_eq!(
+            meta.encodings().collect::<Vec<_>>(),
+            &[Encoding::RLE, Encoding::DELTA_BINARY_PACKED]
+        );
+        assert_eq!(
+            meta.page_encoding_stats().unwrap(),
+            &[encoding_stats(
+                PageType::DATA_PAGE_V2,
+                Encoding::DELTA_BINARY_PACKED,
+                1
+            )]
+        );
+        assert!(
+            meta.compressed_size() < (values.len() * 4 / 2) as i64,
+            "unexpected chunk size {}",
+            meta.compressed_size()
+        );
+
+        column_roundtrip::<Int32Type>(props(), &values, None, None);
+    }
+
+    #[test]
+    fn test_column_writer_dict_fallback_after_data_page_keeps_dictionary() {
+        // Flush dictionary-encoded data pages every 32 rows, so that when the
+        // dictionary overflows its size limit part-way through the chunk,
+        // pages referencing it have already been written. The dictionary page
+        // must then still be written, but the values buffered at the fallback
+        // point are re-encoded with the fallback encoding rather than flushed
+        // as one more dictionary-encoded page.
+        let values: Vec<i32> = (0..2048).collect();
+        let props = || {
+            WriterProperties::builder()
+                .set_writer_version(WriterVersion::PARQUET_1_0)
+                .set_dictionary_page_size_limit(512)
+                .set_data_page_row_count_limit(32)
+                .set_write_batch_size(32)
+                .build()
+        };
+
+        let meta = column_write_and_get_metadata::<Int32Type>(props(), &values);
+        assert!(meta.dictionary_page_offset().is_some());
+        let stats = meta.page_encoding_stats().unwrap();
+        let data_pages_with = |encoding| {
+            stats
+                .iter()
+                .filter(|s| s.page_type == PageType::DATA_PAGE && s.encoding == encoding)
+                .map(|s| s.count)
+                .sum::<i32>()
+        };
+        assert!(
+            data_pages_with(Encoding::RLE_DICTIONARY) > 0,
+            "expected dictionary-encoded pages before the fallback: {stats:?}"
+        );
+        assert!(
+            data_pages_with(Encoding::PLAIN) > 0,
+            "expected plain pages after the fallback: {stats:?}"
+        );
+
+        column_roundtrip::<Int32Type>(props(), &values, None, None);
+    }
+
+    #[test]
     fn test_column_writer_small_write_batch_size() {
         for i in &[1usize, 2, 5, 10, 11, 1023] {
             let props = WriterProperties::builder().set_write_batch_size(*i).build();
@@ -3173,6 +3318,11 @@ mod tests {
             .set_writer_version(WriterVersion::PARQUET_1_0)
             .set_dictionary_enabled(true)
             .set_dictionary_page_size_limit(dict_page_limit)
+            // Flush dictionary-encoded data pages before the dictionary
+            // spills: a fallback with no dictionary-encoded data pages
+            // discards the dictionary entirely, and this test needs a
+            // dictionary page in the output to measure.
+            .set_data_page_row_count_limit(4)
             .build();
 
         let data: Vec<_> = (0..num_rows)

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -445,6 +445,60 @@ impl LevelDataRef<'_> {
 /// Typed column writer for a primitive column.
 pub type ColumnWriterImpl<'a, T> = GenericColumnWriter<'a, ColumnValueEncoderImpl<T>>;
 
+/// Byte budget for each measurement taken by [`DictionaryFallback::Adaptive`]:
+/// at most this many bytes (PLAIN-encoded) of buffered values are re-encoded
+/// through a scratch fallback encoder, and at most this many bytes of the
+/// dictionary page are sampled for compressibility, per checkpoint. Together
+/// with the geometric checkpoint spacing this bounds the total measurement
+/// cost per column chunk to `log2(cap / floor) + 1` single-page encodes.
+const ADAPTIVE_SAMPLE_BYTES: usize = 1024 * 1024;
+
+/// A dictionary whose measured cost is within this factor of the measured
+/// fallback cost at the *first* checkpoint is considered too close to call:
+/// the decision is deferred to the next checkpoint to observe a trend.
+const ADAPTIVE_TIE_RATIO: f64 = 1.02;
+
+/// Minimum fraction of the chunk's PLAIN bytes so far that must have been
+/// repeats of values already in the dictionary for the dictionary to be kept
+/// past a checkpoint. The repeat fraction bounds the dictionary's possible
+/// win over the fallback (every non-repeated byte is stored once either
+/// way), so below this floor a measured win is indistinguishable from
+/// sampling noise and the writer falls back exactly like
+/// [`DictionaryFallback::OnPageSizeLimit`] — in particular, a column with no
+/// repeats at all produces output identical to the default policy.
+const ADAPTIVE_MIN_REPEAT_FRACTION: f64 = 0.01;
+
+/// A dictionary measured worse than the fallback may still be deferred (repeat
+/// trend rising, or break-even hit rate) while its measured cost is within
+/// this factor of the fallback cost; measured worse than this, the writer
+/// always falls back.
+const ADAPTIVE_DEFER_RATIO: f64 = 1.5;
+
+/// Minimum increase of the windowed dictionary hit rate between checkpoints to
+/// count as "repeats are (still) arriving" for deferral.
+const ADAPTIVE_HIT_RATE_RISE: f64 = 0.05;
+
+/// Windowed dictionary hit rate (fraction of appended PLAIN bytes since the
+/// previous checkpoint that were already in the dictionary) at which the
+/// dictionary is at worst break-even on incoming values, warranting deferral
+/// even when the whole-chunk measurement is (boundedly) behind.
+const ADAPTIVE_HIT_RATE_BREAK_EVEN: f64 = 0.5;
+
+/// Per-column-chunk state for the [`DictionaryFallback::Adaptive`] policy,
+/// tracking the geometric measurement checkpoints and the repeat trend
+/// between them. See [`GenericColumnWriter::adaptive_should_fallback`].
+struct AdaptiveFallbackState {
+    /// Dictionary page size at which the next measured evaluation runs.
+    next_checkpoint: usize,
+    /// Dictionary page size at the previously evaluated checkpoint.
+    last_dict_page_bytes: u64,
+    /// PLAIN-encoded bytes appended at the previously evaluated checkpoint.
+    last_plain_bytes: u64,
+    /// Windowed dictionary hit rate observed at the previously evaluated
+    /// checkpoint.
+    last_hit_rate: f64,
+}
+
 /// Generic column writer for a primitive Parquet column
 pub struct GenericColumnWriter<'a, E: ColumnValueEncoder> {
     // Column writer properties
@@ -477,6 +531,10 @@ pub struct GenericColumnWriter<'a, E: ColumnValueEncoder> {
     /// column chunk. Once set, a dictionary fallback can no longer skip
     /// writing the dictionary page, as the flushed pages reference it.
     has_dictionary_encoded_data_pages: bool,
+    /// Measurement checkpoints for the [`DictionaryFallback::Adaptive`]
+    /// policy; `None` until the dictionary first crosses the grace floor
+    /// (and always `None` under other policies).
+    adaptive_fallback: Option<AdaptiveFallbackState>,
     // column index and offset index
     column_index_builder: ColumnIndexBuilder,
     offset_index_builder: Option<OffsetIndexBuilder>,
@@ -544,6 +602,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             encoder,
             data_pages: VecDeque::new(),
             has_dictionary_encoded_data_pages: false,
+            adaptive_fallback: None,
             page_metrics,
             column_metrics,
             distinct_count_override: None,
@@ -1057,7 +1116,7 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     /// dictionary is abandoned is controlled by the column's [`DictionaryFallback`]
     /// policy.
     #[inline]
-    fn should_dict_fallback(&self) -> bool {
+    fn should_dict_fallback(&mut self) -> bool {
         let Some(dict_page_size) = self.encoder.estimated_dict_page_size() else {
             return false;
         };
@@ -1087,7 +1146,161 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                     None => true,
                 }
             }
+            DictionaryFallback::Adaptive {
+                max_dictionary_page_size,
+            } => {
+                if dict_page_size >= max_dictionary_page_size {
+                    return true;
+                }
+
+                if dict_page_size < limit {
+                    return false;
+                }
+
+                self.adaptive_should_fallback(dict_page_size, limit)
+            }
         }
+    }
+
+    /// Measured fallback decision for [`DictionaryFallback::Adaptive`].
+    ///
+    /// Called once the dictionary page size has crossed the grace floor (the
+    /// configured `dictionary_page_size_limit`) but not the policy's hard cap.
+    /// Evaluations run at geometric checkpoints of the dictionary page size
+    /// (the floor, then 2x, 4x, ... the floor); between checkpoints this
+    /// returns `false` without doing any work.
+    ///
+    /// At each checkpoint the measured cost of keeping the dictionary — the
+    /// dictionary page (scaled by the compressibility of a sampled prefix)
+    /// plus an upper-bound estimate of the RLE-encoded indices — is compared
+    /// against the measured cost of the fallback encoding — a bounded sample
+    /// of the buffered values resolved through the dictionary, re-encoded with
+    /// the fallback encoder, compressed with the chunk's codec, and scaled to
+    /// the PLAIN-encoded bytes appended so far. Each measurement is bounded by
+    /// [`ADAPTIVE_SAMPLE_BYTES`].
+    ///
+    /// A column whose repeat fraction is below
+    /// [`ADAPTIVE_MIN_REPEAT_FRACTION`] always falls back: the repeat
+    /// fraction bounds what the dictionary can possibly win, so below it a
+    /// measured win is sampling noise. Otherwise a dictionary measured to be
+    /// winning is kept (until the next checkpoint), and one measured to be
+    /// losing falls back, unless the repeat trend warrants deferring the
+    /// decision to the next checkpoint: at the first checkpoint, a near-tie
+    /// ([`ADAPTIVE_TIE_RATIO`]) — the floor is typically crossed after too
+    /// few values to judge a shuffled distribution; at later checkpoints, a
+    /// windowed hit rate that is rising ([`ADAPTIVE_HIT_RATE_RISE`]) or at
+    /// break-even ([`ADAPTIVE_HIT_RATE_BREAK_EVEN`]), within
+    /// [`ADAPTIVE_DEFER_RATIO`]. A column that keeps producing fresh values
+    /// therefore falls back within a bounded number of checkpoints, while a
+    /// column drawing from a bounded pool of repeating values converges to a
+    /// kept dictionary.
+    fn adaptive_should_fallback(&mut self, dict_page_size: usize, grace_floor: usize) -> bool {
+        if let Some(state) = &self.adaptive_fallback
+            && dict_page_size < state.next_checkpoint
+        {
+            return false;
+        }
+
+        let Some(sample) = self.encoder.sample_dictionary_cost(ADAPTIVE_SAMPLE_BYTES) else {
+            // The encoder cannot measure the fallback encoding: preserve the
+            // absolute-limit behavior
+            return true;
+        };
+        if sample.sample_plain_bytes == 0 {
+            // No values are buffered to measure (the page was just flushed):
+            // hold the checkpoint and re-evaluate on the next write
+            return false;
+        }
+
+        // Compressed size of `buf` under the chunk's codec (identity when
+        // uncompressed); an incompressible buffer never counts for more than
+        // its input, matching how pages are stored
+        let mut compressed_len = |buf: &[u8]| -> usize {
+            match &mut self.compressor {
+                Some(compressor) => {
+                    let mut compressed = Vec::new();
+                    match compressor.compress(buf, &mut compressed) {
+                        Ok(()) => compressed.len().min(buf.len()),
+                        Err(_) => buf.len(),
+                    }
+                }
+                None => buf.len(),
+            }
+        };
+
+        let fallback_ratio =
+            compressed_len(&sample.sample_fallback) as f64 / sample.sample_plain_bytes as f64;
+        // Compressor efficiency varies strongly with input size, so measure
+        // the dictionary's compressibility on a prefix of about the same size
+        // as the fallback buffer: a checkpoint can land right after a page
+        // flush with only a few values buffered, and compressing a small
+        // fallback sample against the full dictionary prefix would bias the
+        // comparison toward the dictionary.
+        let matched_prefix_len = sample
+            .dict_page_prefix
+            .len()
+            .min(sample.sample_fallback.len());
+        let dict_ratio = match matched_prefix_len {
+            0 => 1.0,
+            prefix_len => {
+                compressed_len(&sample.dict_page_prefix[..prefix_len]) as f64 / prefix_len as f64
+            }
+        };
+
+        let fallback_cost = fallback_ratio * sample.plain_bytes as f64;
+        let dict_cost = dict_ratio * sample.dict_page_bytes as f64 + sample.indices_bytes as f64;
+        let cost_ratio = dict_cost / fallback_cost.max(1.0);
+
+        let last = self.adaptive_fallback.as_ref();
+        let last_plain_bytes = last.map(|s| s.last_plain_bytes).unwrap_or(0);
+        let last_dict_page_bytes = last.map(|s| s.last_dict_page_bytes).unwrap_or(0);
+        let last_hit_rate = last.map(|s| s.last_hit_rate);
+
+        // Fraction of the PLAIN bytes appended since the previous checkpoint
+        // (or, at the first checkpoint, since the chunk began) that were
+        // repeats of values already in the dictionary
+        let window_plain = sample.plain_bytes.saturating_sub(last_plain_bytes) as f64;
+        let window_dict = sample.dict_page_bytes.saturating_sub(last_dict_page_bytes) as f64;
+        let hit_rate = if window_plain > 0.0 {
+            (1.0 - window_dict / window_plain).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        // Fraction of the whole chunk's PLAIN bytes that were repeats: the
+        // PLAIN accounting of the dictionary entries matches the appended
+        // values exactly, so this is 0 iff no value has ever repeated
+        let repeat_fraction = if sample.plain_bytes > 0 {
+            1.0 - sample.dict_page_bytes as f64 / sample.plain_bytes as f64
+        } else {
+            0.0
+        };
+
+        let keep = repeat_fraction >= ADAPTIVE_MIN_REPEAT_FRACTION
+            && (cost_ratio <= 1.0
+                || (cost_ratio <= ADAPTIVE_DEFER_RATIO
+                    && hit_rate >= ADAPTIVE_HIT_RATE_BREAK_EVEN)
+                || (cost_ratio <= ADAPTIVE_DEFER_RATIO
+                    && last_hit_rate
+                        .is_some_and(|prev| hit_rate >= prev + ADAPTIVE_HIT_RATE_RISE))
+                || (cost_ratio <= ADAPTIVE_TIE_RATIO && last_hit_rate.is_none()));
+        if !keep {
+            return true;
+        }
+
+        let mut next_checkpoint = match &self.adaptive_fallback {
+            Some(state) => state.next_checkpoint,
+            None => grace_floor.max(1),
+        };
+        while next_checkpoint <= dict_page_size {
+            next_checkpoint = next_checkpoint.saturating_mul(2);
+        }
+        self.adaptive_fallback = Some(AdaptiveFallbackState {
+            next_checkpoint,
+            last_dict_page_bytes: sample.dict_page_bytes,
+            last_plain_bytes: sample.plain_bytes,
+            last_hit_rate: hit_rate,
+        });
+        false
     }
 
     /// Returns true if there is enough data for a data page, false otherwise.

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -45,7 +45,7 @@ use crate::file::metadata::{
     OffsetIndexBuilder, PageEncodingStats,
 };
 use crate::file::properties::{
-    EnabledStatistics, WriterProperties, WriterPropertiesPtr, WriterVersion,
+    DictionaryFallback, EnabledStatistics, WriterProperties, WriterPropertiesPtr, WriterVersion,
 };
 use crate::file::statistics::{Statistics, ValueStatistics};
 use crate::schema::types::{BasicTypeInfo, ColumnDescPtr, ColumnDescriptor};
@@ -1048,17 +1048,40 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
 
     /// Returns true if we need to fall back to non-dictionary encoding.
     ///
-    /// We can only fall back if dictionary encoder is set and we have exceeded dictionary
-    /// size.
+    /// We can only fall back if a dictionary encoder is set. When and whether the
+    /// dictionary is abandoned is controlled by the column's [`DictionaryFallback`]
+    /// policy.
     #[inline]
     fn should_dict_fallback(&self) -> bool {
-        match self.encoder.estimated_dict_page_size() {
-            Some(size) => {
-                size >= self
-                    .props
-                    .column_dictionary_page_size_limit(self.descr.path())
+        let Some(dict_page_size) = self.encoder.estimated_dict_page_size() else {
+            return false;
+        };
+
+        let limit = self
+            .props
+            .column_dictionary_page_size_limit(self.descr.path());
+
+        match self.props.column_dictionary_fallback(self.descr.path()) {
+            DictionaryFallback::OnPageSizeLimit => dict_page_size >= limit,
+            DictionaryFallback::WhenProfitable {
+                worth_ratio,
+                max_dictionary_page_size,
+            } => {
+                if dict_page_size >= max_dictionary_page_size {
+                    return true;
+                }
+
+                if dict_page_size < limit {
+                    return false;
+                }
+
+                match self.encoder.estimated_plain_encoded_bytes() {
+                    Some(plain_bytes) => dict_page_size as f64 > worth_ratio * plain_bytes as f64,
+                    // No estimate of the plain-encoded size is available:
+                    // preserve the absolute-limit behavior
+                    None => true,
+                }
             }
-            None => false,
         }
     }
 

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -93,6 +93,11 @@ pub struct DictEncoder<T: DataType> {
     /// PLAIN-encoded, accumulated over all appended values (not just the
     /// dictionary's unique values); never reset per page
     plain_encoded_bytes: u64,
+
+    /// Total number of values appended to this column chunk, over all pages;
+    /// never reset per page (unlike `indices`, which is cleared on each page
+    /// flush)
+    num_appended_values: u64,
 }
 
 impl<T: DataType> DictEncoder<T> {
@@ -108,6 +113,7 @@ impl<T: DataType> DictEncoder<T> {
             interner: Interner::new(storage),
             indices: vec![],
             plain_encoded_bytes: 0,
+            num_appended_values: 0,
         }
     }
 
@@ -157,6 +163,67 @@ impl<T: DataType> DictEncoder<T> {
         self.plain_encoded_bytes
     }
 
+    /// Returns an upper bound on the RLE/bit-packed encoded size of the
+    /// dictionary indices for every value appended to this encoder so far
+    /// (including values already flushed to data pages), at the current
+    /// bit width.
+    pub fn estimated_total_indices_bytes(&self) -> u64 {
+        let num_appended = usize::try_from(self.num_appended_values).unwrap_or(usize::MAX);
+        1 + RleEncoder::max_buffer_size(self.bit_width(), num_appended) as u64
+    }
+
+    /// Returns up to `max_plain_bytes` worth (and always at least one, if any
+    /// are buffered) of the values buffered for the in-progress data page,
+    /// resolved through the dictionary, together with their PLAIN-encoded
+    /// size. Unlike [`Self::take_buffered_values`] the buffer is left intact.
+    ///
+    /// Used by the `Adaptive` dictionary fallback policy to measure the size
+    /// of the fallback encoding on a bounded sample of real values.
+    pub fn sample_buffered_values(&self, max_plain_bytes: usize) -> (Vec<T::T>, u64) {
+        let storage = self.interner.storage();
+        let mut plain_bytes = 0u64;
+        let mut values = Vec::new();
+        for &idx in &self.indices {
+            let value = &storage.uniques[idx as usize];
+            let (base_size, num_elements) = value.dict_encoding_size();
+            let plain_size = match T::get_physical_type() {
+                Type::BYTE_ARRAY => base_size + num_elements,
+                Type::FIXED_LEN_BYTE_ARRAY => storage.type_length,
+                _ => base_size,
+            };
+            plain_bytes += plain_size as u64;
+            values.push(value.clone());
+            if plain_bytes >= max_plain_bytes as u64 {
+                break;
+            }
+        }
+        (values, plain_bytes)
+    }
+
+    /// PLAIN-encodes a prefix of the dictionary entries of up to `max_bytes`
+    /// bytes (always at least one entry, if any exist), as a sample of the
+    /// dictionary page's contents.
+    pub fn write_dict_prefix(&self, max_bytes: usize) -> Result<Bytes> {
+        let storage = self.interner.storage();
+        let mut prefix_bytes = 0usize;
+        let mut num_entries = 0usize;
+        for value in &storage.uniques {
+            let (base_size, num_elements) = value.dict_encoding_size();
+            prefix_bytes += match T::get_physical_type() {
+                Type::BYTE_ARRAY => base_size + num_elements,
+                Type::FIXED_LEN_BYTE_ARRAY => storage.type_length,
+                _ => base_size,
+            };
+            num_entries += 1;
+            if prefix_bytes >= max_bytes {
+                break;
+            }
+        }
+        let mut plain_encoder = PlainEncoder::<T>::new();
+        plain_encoder.put(&storage.uniques[..num_entries])?;
+        plain_encoder.flush_buffer()
+    }
+
     fn put_one(&mut self, value: &T::T) {
         let (base_size, num_elements) = value.dict_encoding_size();
         let plain_size = match T::get_physical_type() {
@@ -165,6 +232,7 @@ impl<T: DataType> DictEncoder<T> {
             _ => base_size,
         };
         self.plain_encoded_bytes += plain_size as u64;
+        self.num_appended_values += 1;
         self.indices.push(self.interner.intern(value));
     }
 

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -88,6 +88,11 @@ pub struct DictEncoder<T: DataType> {
 
     /// The buffered indices
     indices: Vec<u64>,
+
+    /// Total bytes the values appended to this column chunk would occupy
+    /// PLAIN-encoded, accumulated over all appended values (not just the
+    /// dictionary's unique values); never reset per page
+    plain_encoded_bytes: u64,
 }
 
 impl<T: DataType> DictEncoder<T> {
@@ -102,6 +107,7 @@ impl<T: DataType> DictEncoder<T> {
         Self {
             interner: Interner::new(storage),
             indices: vec![],
+            plain_encoded_bytes: 0,
         }
     }
 
@@ -145,7 +151,20 @@ impl<T: DataType> DictEncoder<T> {
         Ok(encoder.consume().into())
     }
 
+    /// Returns the total bytes the values appended to this encoder would occupy
+    /// PLAIN-encoded.
+    pub fn plain_encoded_bytes(&self) -> u64 {
+        self.plain_encoded_bytes
+    }
+
     fn put_one(&mut self, value: &T::T) {
+        let (base_size, num_elements) = value.dict_encoding_size();
+        let plain_size = match T::get_physical_type() {
+            Type::BYTE_ARRAY => base_size + num_elements,
+            Type::FIXED_LEN_BYTE_ARRAY => self.interner.storage().type_length,
+            _ => base_size,
+        };
+        self.plain_encoded_bytes += plain_size as u64;
         self.indices.push(self.interner.intern(value));
     }
 

--- a/parquet/src/encodings/encoding/dict_encoder.rs
+++ b/parquet/src/encodings/encoding/dict_encoder.rs
@@ -149,6 +149,22 @@ impl<T: DataType> DictEncoder<T> {
         self.indices.push(self.interner.intern(value));
     }
 
+    /// Returns the values buffered for the in-progress data page, resolving
+    /// dictionary ids back to their values, and clears the buffer.
+    ///
+    /// Used on dictionary fallback to re-encode the buffered values with the
+    /// fallback encoder.
+    pub fn take_buffered_values(&mut self) -> Vec<T::T> {
+        let uniques = &self.interner.storage().uniques;
+        let values = self
+            .indices
+            .iter()
+            .map(|&i| uniques[i as usize].clone())
+            .collect();
+        self.indices.clear();
+        values
+    }
+
     #[inline]
     fn bit_width(&self) -> u8 {
         num_required_bits(self.num_entries().saturating_sub(1) as u64)

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -38,6 +38,8 @@ pub const DEFAULT_COMPRESSION: Compression = Compression::UNCOMPRESSED;
 pub const DEFAULT_DICTIONARY_ENABLED: bool = true;
 /// Default value for [`WriterProperties::dictionary_page_size_limit`]
 pub const DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT: usize = DEFAULT_PAGE_SIZE;
+/// Default value for [`WriterProperties::dictionary_fallback`]
+pub const DEFAULT_DICTIONARY_FALLBACK: DictionaryFallback = DictionaryFallback::OnPageSizeLimit;
 /// Default value for [`WriterProperties::data_page_row_count_limit`]
 pub const DEFAULT_DATA_PAGE_ROW_COUNT_LIMIT: usize = 20_000;
 /// Default value for [`WriterProperties::statistics_enabled`]
@@ -331,6 +333,26 @@ impl WriterProperties {
             .and_then(|c| c.dictionary_page_size_limit())
             .or_else(|| self.default_column_properties.dictionary_page_size_limit())
             .unwrap_or(DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT)
+    }
+
+    /// Returns the default dictionary fallback policy.
+    ///
+    /// For more details see [`WriterPropertiesBuilder::set_dictionary_fallback`]
+    pub fn dictionary_fallback(&self) -> DictionaryFallback {
+        self.default_column_properties
+            .dictionary_fallback()
+            .unwrap_or(DEFAULT_DICTIONARY_FALLBACK)
+    }
+
+    /// Returns the dictionary fallback policy for a specific column.
+    ///
+    /// Takes precedence over [`Self::dictionary_fallback`].
+    pub fn column_dictionary_fallback(&self, col: &ColumnPath) -> DictionaryFallback {
+        self.column_properties
+            .get(col)
+            .and_then(|c| c.dictionary_fallback())
+            .or_else(|| self.default_column_properties.dictionary_fallback())
+            .unwrap_or(DEFAULT_DICTIONARY_FALLBACK)
     }
 
     /// Returns the maximum page row count
@@ -1099,6 +1121,22 @@ impl WriterPropertiesBuilder {
         self
     }
 
+    /// Sets the default [`DictionaryFallback`] policy for all columns (defaults to
+    /// [`DictionaryFallback::OnPageSizeLimit`] via [`DEFAULT_DICTIONARY_FALLBACK`]).
+    ///
+    /// This controls when the writer gives up on dictionary encoding for a
+    /// column chunk and switches to the column's fallback encoding.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the policy is [`DictionaryFallback::WhenProfitable`] with a
+    /// `worth_ratio` that is not finite or is not strictly positive.
+    pub fn set_dictionary_fallback(mut self, value: DictionaryFallback) -> Self {
+        self.default_column_properties
+            .set_dictionary_fallback(value);
+        self
+    }
+
     /// Sets best effort maximum size of a data page in bytes (defaults to `1024 * 1024`
     /// via [`DEFAULT_PAGE_SIZE`]).
     ///
@@ -1252,6 +1290,23 @@ impl WriterPropertiesBuilder {
     pub fn set_column_dictionary_page_size_limit(mut self, col: ColumnPath, value: usize) -> Self {
         self.get_mut_props(col)
             .set_dictionary_page_size_limit(value);
+        self
+    }
+
+    /// Sets the [`DictionaryFallback`] policy for a specific column.
+    ///
+    /// Takes precedence over [`Self::set_dictionary_fallback`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the policy is [`DictionaryFallback::WhenProfitable`] with a
+    /// `worth_ratio` that is not finite or is not strictly positive.
+    pub fn set_column_dictionary_fallback(
+        mut self,
+        col: ColumnPath,
+        value: DictionaryFallback,
+    ) -> Self {
+        self.get_mut_props(col).set_dictionary_fallback(value);
         self
     }
 
@@ -1443,6 +1498,73 @@ impl Default for EnabledStatistics {
     }
 }
 
+/// Controls when dictionary encoding falls back to the column's fallback encoding.
+///
+/// While dictionary encoding is enabled for a column, the writer buffers a
+/// dictionary of the distinct values seen so far. This policy decides when the
+/// writer gives up on dictionary encoding for the remainder of the column chunk
+/// and switches to the fallback encoding (e.g. `PLAIN`, or a delta encoding
+/// with [`WriterVersion::PARQUET_2_0`]).
+///
+/// This enum is `#[non_exhaustive]`: additional policies may be added in the
+/// future.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub enum DictionaryFallback {
+    /// Fall back as soon as the dictionary page exceeds
+    /// [`WriterProperties::dictionary_page_size_limit`].
+    ///
+    /// This is the default, and the historical behavior of this crate.
+    OnPageSizeLimit,
+    /// Keep the dictionary past [`WriterProperties::dictionary_page_size_limit`]
+    /// (which acts as a grace floor) for as long as it stays profitable,
+    /// falling back unconditionally at `max_dictionary_page_size`.
+    ///
+    /// The dictionary is considered profitable while the dictionary page is
+    /// smaller than `worth_ratio` times the total size the values appended so
+    /// far would occupy PLAIN-encoded. For example, with a `worth_ratio` of
+    /// `0.1` the dictionary is kept (past the grace floor) only while it is at
+    /// least 10x smaller than the PLAIN encoding of the data.
+    ///
+    /// This helps columns whose values are large but highly repetitive: with
+    /// [`Self::OnPageSizeLimit`], a handful of distinct multi-kilobyte values
+    /// overflows the (default 1 MiB) dictionary page size limit and each
+    /// repeated value is written out in full by the fallback encoding, even
+    /// though a slightly larger dictionary would have deduplicated them.
+    ///
+    /// `max_dictionary_page_size` is a memory guard: readers must decompress
+    /// and materialize the entire dictionary page (the format allows at most
+    /// one dictionary page per column chunk, so it cannot be split), so an
+    /// unboundedly profitable dictionary must still be capped. A value of
+    /// `64 * 1024 * 1024` (64 MiB) is a reasonable upper bound; a
+    /// `worth_ratio` of `0.1` is a conservative choice that avoids regressions
+    /// on columns where a delta fallback encoding would beat a nominally
+    /// "profitable" dictionary (e.g. sorted numeric keys).
+    ///
+    /// The PLAIN-encoded size is used as a pessimistic upper bound for the
+    /// fallback encoding's size: the Parquet specification requires the delta
+    /// encodings to never exceed the PLAIN encoding of the same values. The
+    /// exact profitability estimate is an implementation detail and may be
+    /// refined in the future (for example, by measuring the actual fallback
+    /// encoding) without changing this API.
+    WhenProfitable {
+        /// Maximum ratio of the dictionary page size to the PLAIN-encoded size
+        /// of the values appended so far for the dictionary to be considered
+        /// profitable. Must be finite and greater than zero.
+        worth_ratio: f64,
+        /// Hard cap on the dictionary page size, in bytes: the writer always
+        /// falls back once the dictionary page reaches this size, regardless
+        /// of profitability.
+        max_dictionary_page_size: usize,
+    },
+}
+
+impl Default for DictionaryFallback {
+    fn default() -> Self {
+        DEFAULT_DICTIONARY_FALLBACK
+    }
+}
+
 /// Controls the bloom filter to be computed by the writer.
 ///
 /// The bloom filter is initially sized for `ndv` distinct values at the given `fpp`, then
@@ -1629,6 +1751,7 @@ struct ColumnProperties {
     data_page_size_limit: Option<usize>,
     dictionary_page_size_limit: Option<usize>,
     dictionary_enabled: Option<bool>,
+    dictionary_fallback: Option<DictionaryFallback>,
     statistics_enabled: Option<EnabledStatistics>,
     write_page_header_statistics: Option<bool>,
     /// bloom filter related properties
@@ -1673,6 +1796,22 @@ impl ColumnProperties {
     /// Sets dictionary page size limit for this column.
     fn set_dictionary_page_size_limit(&mut self, value: usize) {
         self.dictionary_page_size_limit = Some(value);
+    }
+
+    /// Sets the dictionary fallback policy for this column.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the policy is [`DictionaryFallback::WhenProfitable`] with a
+    /// `worth_ratio` that is not finite or is not strictly positive.
+    fn set_dictionary_fallback(&mut self, value: DictionaryFallback) {
+        if let DictionaryFallback::WhenProfitable { worth_ratio, .. } = value {
+            assert!(
+                worth_ratio.is_finite() && worth_ratio > 0.0,
+                "worth_ratio must be a positive finite number, got {worth_ratio}"
+            );
+        }
+        self.dictionary_fallback = Some(value);
     }
 
     /// Sets the statistics level for this column.
@@ -1763,6 +1902,11 @@ impl ColumnProperties {
     /// Returns optional dictionary page size limit for this column.
     fn dictionary_page_size_limit(&self) -> Option<usize> {
         self.dictionary_page_size_limit
+    }
+
+    /// Returns optional dictionary fallback policy for this column.
+    fn dictionary_fallback(&self) -> Option<DictionaryFallback> {
+        self.dictionary_fallback
     }
 
     /// Returns optional data page size limit for this column.
@@ -1963,6 +2107,11 @@ mod tests {
             props.dictionary_enabled(&ColumnPath::from("col")),
             DEFAULT_DICTIONARY_ENABLED
         );
+        assert_eq!(props.dictionary_fallback(), DEFAULT_DICTIONARY_FALLBACK);
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("col")),
+            DEFAULT_DICTIONARY_FALLBACK
+        );
         assert_eq!(
             props.statistics_enabled(&ColumnPath::from("col")),
             DEFAULT_STATISTICS_ENABLED
@@ -1972,6 +2121,50 @@ mod tests {
                 .bloom_filter_properties(&ColumnPath::from("col"))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_writer_properties_dictionary_fallback() {
+        let when_profitable = DictionaryFallback::WhenProfitable {
+            worth_ratio: 0.1,
+            max_dictionary_page_size: 64 * 1024 * 1024,
+        };
+        let props = WriterProperties::builder()
+            .set_dictionary_fallback(when_profitable)
+            .set_column_dictionary_fallback(
+                ColumnPath::from("col"),
+                DictionaryFallback::OnPageSizeLimit,
+            )
+            .build();
+        assert_eq!(props.dictionary_fallback(), when_profitable);
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("other")),
+            when_profitable
+        );
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("col")),
+            DictionaryFallback::OnPageSizeLimit
+        );
+
+        // survives the round trip through into_builder
+        let props = props.into_builder().build();
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("col")),
+            DictionaryFallback::OnPageSizeLimit
+        );
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("other")),
+            when_profitable
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "worth_ratio must be a positive finite number")]
+    fn test_writer_properties_dictionary_fallback_invalid_ratio() {
+        WriterProperties::builder().set_dictionary_fallback(DictionaryFallback::WhenProfitable {
+            worth_ratio: 0.0,
+            max_dictionary_page_size: 64 * 1024 * 1024,
+        });
     }
 
     #[test]

--- a/parquet/src/file/properties.rs
+++ b/parquet/src/file/properties.rs
@@ -1557,6 +1557,53 @@ pub enum DictionaryFallback {
         /// of profitability.
         max_dictionary_page_size: usize,
     },
+    /// Keep the dictionary past [`WriterProperties::dictionary_page_size_limit`]
+    /// (which acts as a grace floor) while a *measured* comparison shows it
+    /// beating the column's fallback encoding, falling back unconditionally at
+    /// `max_dictionary_page_size`.
+    ///
+    /// Unlike [`Self::WhenProfitable`], there is no ratio to tune: whenever the
+    /// dictionary page size crosses a checkpoint (the grace floor, then
+    /// geometrically — 2x, 4x, ... the floor, up to the hard cap), the writer
+    /// compares the measured cost of the dictionary (the dictionary page plus
+    /// an estimate of the RLE-encoded indices) against the measured cost of the
+    /// fallback encoding, obtained by re-encoding a bounded sample of the
+    /// buffered values through the fallback encoder. When the column chunk is
+    /// compressed, both sides of the comparison are compressed with the chunk's
+    /// codec, so a dictionary that only looks smaller before compression (e.g.
+    /// sorted numeric keys, where the fallback compresses extremely well but a
+    /// dictionary of distinct keys does not) is correctly rejected.
+    ///
+    /// The decision is not final at the first crossing: when the comparison is
+    /// too close to call, and repeated values are still arriving (so the
+    /// dictionary may simply not have seen enough data yet — e.g. a bounded
+    /// pool of values in shuffled order, where hardly any repeats are visible
+    /// by the time the floor is crossed), the writer defers to the next
+    /// checkpoint instead. A column whose values keep repeating converges to a
+    /// kept dictionary; a column that keeps producing new values falls back
+    /// within a bounded number of checkpoints.
+    ///
+    /// The measurement cost is bounded: each checkpoint encodes (and, if the
+    /// chunk is compressed, compresses) at most a fixed byte budget of sampled
+    /// values — see `GenericColumnWriter` — and the geometric spacing bounds
+    /// the number of checkpoints per column chunk by
+    /// `log2(max_dictionary_page_size / dictionary_page_size_limit) + 1`.
+    ///
+    /// `max_dictionary_page_size` is a memory guard, exactly as in
+    /// [`Self::WhenProfitable`]: readers must decompress and materialize the
+    /// entire dictionary page, so an unboundedly winning dictionary must still
+    /// be capped. A value of `64 * 1024 * 1024` (64 MiB) is a reasonable upper
+    /// bound.
+    ///
+    /// The exact decision procedure (checkpoint spacing, sample budget, tie
+    /// margins) is an implementation detail and may be refined without
+    /// changing this API.
+    Adaptive {
+        /// Hard cap on the dictionary page size, in bytes: the writer always
+        /// falls back once the dictionary page reaches this size, regardless
+        /// of the measured comparison.
+        max_dictionary_page_size: usize,
+    },
 }
 
 impl Default for DictionaryFallback {
@@ -2155,6 +2202,40 @@ mod tests {
         assert_eq!(
             props.column_dictionary_fallback(&ColumnPath::from("other")),
             when_profitable
+        );
+    }
+
+    #[test]
+    fn test_writer_properties_dictionary_fallback_adaptive() {
+        let adaptive = DictionaryFallback::Adaptive {
+            max_dictionary_page_size: 64 * 1024 * 1024,
+        };
+        let props = WriterProperties::builder()
+            .set_dictionary_fallback(adaptive)
+            .set_column_dictionary_fallback(
+                ColumnPath::from("col"),
+                DictionaryFallback::OnPageSizeLimit,
+            )
+            .build();
+        assert_eq!(props.dictionary_fallback(), adaptive);
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("other")),
+            adaptive
+        );
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("col")),
+            DictionaryFallback::OnPageSizeLimit
+        );
+
+        // survives the round trip through into_builder
+        let props = props.into_builder().build();
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("col")),
+            DictionaryFallback::OnPageSizeLimit
+        );
+        assert_eq!(
+            props.column_dictionary_fallback(&ColumnPath::from("other")),
+            adaptive
         );
     }
 

--- a/parquet/tests/arrow_writer/layout.rs
+++ b/parquet/tests/arrow_writer/layout.rs
@@ -208,6 +208,11 @@ fn test_primitive() {
     });
 
     // Test spill dictionary
+    //
+    // The dictionary overflows its size limit before the first data page is
+    // flushed, so the buffered values are re-encoded with the fallback
+    // encoding and the dictionary is discarded: the chunk contains no
+    // dictionary page and only PLAIN data pages.
     let props = WriterProperties::builder()
         .set_dictionary_enabled(true)
         .set_dictionary_page_size_limit(1000)
@@ -222,29 +227,14 @@ fn test_primitive() {
         layout: Layout {
             row_groups: vec![RowGroup {
                 columns: vec![ColumnChunk {
-                    pages: vec![
-                        Page {
-                            rows: 250,
-                            page_header_size: 38,
-                            compressed_size: 258,
-                            encoding: Encoding::RLE_DICTIONARY,
-                            page_type: PageType::DATA_PAGE,
-                        },
-                        Page {
-                            rows: 1750,
-                            page_header_size: 38,
-                            compressed_size: 7000,
-                            encoding: Encoding::PLAIN,
-                            page_type: PageType::DATA_PAGE,
-                        },
-                    ],
-                    dictionary_page: Some(Page {
-                        rows: 250,
+                    pages: vec![Page {
+                        rows: 2000,
                         page_header_size: 38,
-                        compressed_size: 1000,
+                        compressed_size: 8000,
                         encoding: Encoding::PLAIN,
-                        page_type: PageType::DICTIONARY_PAGE,
-                    }),
+                        page_type: PageType::DATA_PAGE,
+                    }],
+                    dictionary_page: None,
                 }],
             }],
         },
@@ -408,42 +398,29 @@ fn test_string() {
         layout: Layout {
             row_groups: vec![RowGroup {
                 columns: vec![ColumnChunk {
+                    // The dictionary overflows its size limit at 126 rows,
+                    // before the first data page is flushed, so those rows are
+                    // re-encoded with the fallback encoding and the dictionary
+                    // is discarded: no dictionary page, PLAIN pages only, with
+                    // the first page boundary determined by the data page size
+                    // limit rather than by the fallback.
                     pages: vec![
                         Page {
-                            rows: 126,
-                            page_header_size: 38,
-                            compressed_size: 114,
-                            encoding: Encoding::RLE_DICTIONARY,
-                            page_type: PageType::DATA_PAGE,
-                        },
-                        Page {
-                            rows: 1254,
+                            rows: 1250,
                             page_header_size: 40,
-                            compressed_size: 10032,
+                            compressed_size: 10000,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
                         },
                         Page {
-                            rows: 620,
+                            rows: 750,
                             page_header_size: 38,
-                            compressed_size: 4960,
+                            compressed_size: 6000,
                             encoding: Encoding::PLAIN,
                             page_type: PageType::DATA_PAGE,
                         },
                     ],
-                    // The byte-budget chunker sub-batches the dictionary
-                    // phase. The mini-batch deliberately includes the value
-                    // that crosses the 1000-byte limit so the spill triggers
-                    // on this chunk rather than carrying a sliver into the
-                    // next page, giving a 126-row dictionary page at 1008
-                    // bytes.
-                    dictionary_page: Some(Page {
-                        rows: 126,
-                        page_header_size: 38,
-                        compressed_size: 1008,
-                        encoding: Encoding::PLAIN,
-                        page_type: PageType::DICTIONARY_PAGE,
-                    }),
+                    dictionary_page: None,
                 }],
             }],
         },
@@ -891,10 +868,10 @@ fn test_nullable_large_values() {
 fn test_dictionary_spill_large_values() {
     // Dictionary encoding is enabled, but each value is large (64 KiB) and
     // unique, so the dictionary spills almost immediately (1 KiB dict page
-    // limit). After the spill, plain encoding takes over and the byte-budget
-    // sub-batch bounds each page to a single value. The first value is
-    // interned into the dictionary page (one RLE_DICTIONARY data page
-    // referencing it); the remaining 31 fall back to PLAIN, one per page.
+    // limit). The first value is interned before the spill; the fallback
+    // re-encodes it as PLAIN and discards the dictionary, so no dictionary
+    // page (which would have been 64x the configured limit) is written and
+    // the byte-budget sub-batch bounds each page to a single PLAIN value.
     // Mirrors `test_column_writer_dict_enabled_large_values_post_spill`,
     // exercising the same dict→plain transition via the arrow path.
     let value_size = 64 * 1024;
@@ -919,30 +896,18 @@ fn test_dictionary_spill_large_values() {
         layout: Layout {
             row_groups: vec![RowGroup {
                 columns: vec![ColumnChunk {
-                    pages: std::iter::once(Page {
-                        // The single value interned before the dict spilled.
-                        rows: 1,
-                        page_header_size: 17,
-                        compressed_size: 2,
-                        encoding: Encoding::RLE_DICTIONARY,
-                        page_type: PageType::DATA_PAGE,
-                    })
-                    .chain((0..31).map(|_| Page {
-                        // Post-spill plain-encoded values, one per page.
-                        rows: 1,
-                        page_header_size: 21,
-                        compressed_size: 65540,
-                        encoding: Encoding::PLAIN,
-                        page_type: PageType::DATA_PAGE,
-                    }))
-                    .collect(),
-                    dictionary_page: Some(Page {
-                        rows: 1,
-                        page_header_size: 21,
-                        compressed_size: 65540,
-                        encoding: Encoding::PLAIN,
-                        page_type: PageType::DICTIONARY_PAGE,
-                    }),
+                    pages: (0..32)
+                        .map(|_| Page {
+                            // Plain-encoded values, one per page; the first
+                            // was re-encoded from the dictionary on fallback.
+                            rows: 1,
+                            page_header_size: 21,
+                            compressed_size: 65540,
+                            encoding: Encoding::PLAIN,
+                            page_type: PageType::DATA_PAGE,
+                        })
+                        .collect(),
+                    dictionary_page: None,
                 }],
             }],
         },


### PR DESCRIPTION
# Which issue does this PR close?

- Part of #9699.
- Related to #8378: implements measured sampling for the dictionary-fallback decision specifically.

> [!IMPORTANT]
> **Stacked PR (draft)**: this builds on #10775 (`DictionaryFallback` policy) and #10777 (re-encode on fallback) and includes both as its base. Please review only the top commits (the merge of the two branches plus one feature commit); this PR will be rebased as those merge.

# Rationale for this change

#10775 added an opt-in `DictionaryFallback::WhenProfitable { worth_ratio, .. }` policy that keeps a dictionary past `dictionary_page_size_limit` while the dictionary page stays below `worth_ratio` × the PLAIN-encoded size of the appended values. That PR disclosed two structural weaknesses of the ratio heuristic, both reproduced in its benchmarks:

1. **The ratio has to be tuned timidly.** PLAIN size is a pessimistic bound for the fallback encoding, so a "profitable" dictionary can still lose to the real fallback — most visibly on sorted/high-cardinality keys where `DELTA_BINARY_PACKED` (or PLAIN + compression) crushes a dictionary of distinct keys. At `worth_ratio: 0.5` ClickBench gained 8.5% overall but paid +13.2 MB on `UserID` and +8.3 MB on `FUniqID`, and TPC-H regressed +2.1% on `l_orderkey`/`ps_partkey`; the suggested default had to be a conservative 0.1, which captures only a fraction of the available wins.
2. **The decision is blind to shuffled data.** The decision is made when the dictionary crosses the grace floor, after only ~`floor / value_size` values — e.g. 64 samples of 16 KiB values — before repeats are even visible. On the disclosed uniformly-shuffled reproducer every policy behaved exactly like stock.

This PR adds the measured variant that #10775's API documentation anticipated: no ratio to tune, decisions based on measuring the actual encodings (including compression), and deferral with a trend signal instead of a one-shot decision.

```rust
#[non_exhaustive]
pub enum DictionaryFallback {
    OnPageSizeLimit,                                                  // default, unchanged
    WhenProfitable { worth_ratio: f64, max_dictionary_page_size: usize },
    /// Keep the dictionary past the grace floor while a *measured*
    /// comparison shows it beating the fallback encoding, re-evaluated at
    /// geometric checkpoints; fall back unconditionally at the hard cap.
    Adaptive { max_dictionary_page_size: usize },
}
```

# How the decision works

Whenever the dictionary page size crosses a checkpoint — the grace floor (`dictionary_page_size_limit`), then 2×, 4×, … the floor, up to the hard cap — the writer compares:

- **dictionary cost**: the dictionary page, scaled by the measured compressibility of a sampled prefix, plus an upper-bound estimate of the RLE/bit-packed indices for every value appended so far;
- **fallback cost**: a bounded sample of the values buffered for the in-progress page, resolved through the in-memory dictionary (the machinery from #10777) and re-encoded through a scratch fallback encoder, compressed with the chunk's codec, and scaled to the PLAIN bytes appended so far.

Compressing both sides with the chunk's codec is what fixes the sorted-key class: a dictionary of distinct keys barely compresses, while the PLAIN/delta encoding of sorted-with-repeats keys compresses extremely well, so the dictionary correctly loses even when it is nominally 2–4× smaller before compression. The two compression samples use matched input sizes, since codec efficiency varies strongly with input size.

The decision is not final at the first crossing:

- A column whose repeat fraction (share of appended PLAIN bytes that were already in the dictionary — measured exactly, at zero cost, from two counters #10775 already maintains) is **below 1% always falls back**: the repeat fraction bounds what a dictionary can possibly win, so below it a measured win is sampling noise. In particular, a column with no repeats at all produces output **identical to stock**.
- A measured near-tie at the first checkpoint defers to the next checkpoint: the floor is typically crossed after too few values to judge a shuffled distribution.
- At later checkpoints, a losing-but-close dictionary keeps deferring while the windowed hit rate is rising (repeats are arriving) or at break-even; otherwise it falls back. Thanks to #10777 the buffered values re-encode cleanly, and the dictionary page is only written if already-flushed pages reference it.

**Bounded cost**: each checkpoint re-encodes and compresses at most 1 MiB (PLAIN size) of sampled values plus a ≤1 MiB dictionary prefix — about one extra data-page encode — and the geometric spacing bounds the number of checkpoints per column chunk by `log2(cap / floor) + 1` (7 for the 1 MiB floor / 64 MiB cap defaults). Between checkpoints the policy does no work. There is no continuously-running parallel encoder.

# Benchmarks

Methodology as in #10775: every file rewritten with `ArrowWriter`, ZSTD level 1, defaults otherwise, only the fallback policy differing; totals are summed output bytes. "Stock" is the default policy **on this branch** (i.e. including #10777's fallback improvements, which is why totals differ slightly from the numbers in #10775). `WhenProfitable` arms use the cap 64 MiB; `Adaptive { max_dictionary_page_size: 64 MiB }`.

| Dataset | Stock | `WhenProfitable` 0.1 | `WhenProfitable` 0.5 | `Adaptive` |
|---|---:|---:|---:|---:|
| Repetitive 16 KiB blobs, short runs (seed 42) | 51,015,911 | −38.9% | −38.9% | **−38.9%** |
| Same pool, uniformly **shuffled** | 794,807,940 | ±0 | ±0 | **−46.9%** |
| Same pool, sorted | 61,447,608 | −19.9% | −19.9% | **−19.9%** |
| ClickBench (hits_0..29, ~4.1 GB) | 2,666,195,053 | −0.35% | −8.69% | **−12.09%** |
| TPC-H SF1 | 242,833,808 | — | +2.12% | **+0.01%** |
| TPC-DS SF1 | 301,005,084 | — | — | **+0.01%** |
| large_values (unique 16 KiB values) | 803,839,649 | — | — | **byte-identical** |

- **Shuffled reproducer** (the case disclosed as a miss in #10775): 2 of the 4 seeded files flip from 198.7 MB to 12.3 MB each — the dictionary is deferred at the floor, wins once repeats accumulate, and the 1000-value pool exhausts at a 16.4 MB dictionary, far below the cap. The other 2 files happen to cross the grace floor with *zero* repeats among the first ~64 samples and fall back exactly like stock — that is the deliberate price of keeping unique-value columns byte-identical to stock, and it is a missed win, never a regression.
- **ClickBench**: total −322.4 MB (−12.09%), beating both ratio arms while *also* removing their regression class. Top wins `Title` −183.9 MB, `URL` −92.2 MB, `Referer` −54.4 MB; the `WhenProfitable{0.5}` regressions `UserID` +13.0 MB → +1.1 MB and `FUniqID` +8.2 MB → +2.4 MB. Aggregate: −334.0 MB of wins vs +11.7 MB of regressions (largest single: `RefererHash` +2.9 MB).
- **TPC-H / TPC-DS**: +0.01% each (no per-column mover above 0.15 MB) — the sorted-key columns (`l_orderkey`, `ps_partkey`) that cost the ratio heuristic +2.1% now measure as losing post-compression and fall back exactly like stock.
- **Wall time**: ClickBench 53.6 s (stock) → 58.3 s (+8.8%, the measurement bound in action); TPC-H 4.0 s → 3.8 s; the shuffled reproducer is *faster* than stock (1.7 s → 1.6 s) since far fewer bytes get compressed.

Generator for the shuffled reproducer (pyarrow, seed 42; the runs/sorted variants from #10775 differ only in the `idx` line):

```python
import numpy as np, pyarrow as pa, pyarrow.parquet as pq, os, string
OUT = "repetitive_large_values"
os.makedirs(OUT, exist_ok=True)
rng = np.random.default_rng(42)
alphabet = np.frombuffer(bytes(string.ascii_letters + string.digits, "ascii"), dtype=np.uint8)
pool = ["".join(map(chr, rng.choice(alphabet, size=16384))) for _ in range(1000)]
for f in range(4):
    idx = rng.integers(0, 1000, size=16384)          # runs: np.repeat(rng.integers(0, 1000, 1024), 16); sorted: np.sort(...)
    t = pa.table({
        "id": pa.array(np.arange(f * 16384, (f + 1) * 16384), pa.int64()),
        "key": pa.array(idx, pa.int64()),
        "val": pa.array([pool[i] for i in idx], pa.string()),
    })
    pq.write_table(t, f"{OUT}/part-{f}.parquet", compression="zstd")
```

# What changes are included in this PR?

- `DictionaryFallback::Adaptive { max_dictionary_page_size }` in `file/properties.rs` (the enum is `#[non_exhaustive]`; plumbing was added by #10775).
- A defaulted crate-private `ColumnValueEncoder::sample_dictionary_cost`, implemented by both dictionary encoders (generic typed and arrow byte-array): resolves a bounded sample of the buffered ids through the dictionary, measures it through a scratch fallback encoder, and returns the dictionary/indices/PLAIN byte counts plus a dictionary-prefix compressibility sample. Encoders without measurement support keep the absolute-limit behavior.
- The checkpoint state machine and decision procedure in `GenericColumnWriter` (`adaptive_should_fallback`), with the thresholds documented as implementation details.
- Tests: sorted keys with repeats fall back byte-identically to stock while `WhenProfitable{0.5}` keeps the dictionary and produces a 2×+ larger file; repetitive large values keep the dictionary (no fallback pages, less than half the stock size); a uniformly-shuffled bounded pool keeps the dictionary where stock falls back (deterministic LCG sampling, less than half the stock size); unique values are byte-identical to stock; a trickle-of-repeats column defers exactly one checkpoint and then falls back with a chunk ≈ stock; the hard cap forces fallback on a clearly-winning dictionary; the non-byte-array encoder path; property plumbing incl. `into_builder()` roundtrip; roundtrip equality in every scenario.

# Are these changes tested?

Yes, as above; `cargo test -p parquet --all-features` passes (1791 tests), fmt and clippy clean.

# Are there any user-facing changes?

New opt-in `DictionaryFallback::Adaptive` variant. Default behavior is unchanged (`OnPageSizeLimit` remains the default; with the policy enabled, columns with no repeated values still produce byte-identical output to the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
