### PR TITLE
perf(take): avoid bounds checks and speed up take on List<T>

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -671,15 +671,10 @@ where
             .len()
             .checked_div(values.len().max(1))
             .unwrap_or(0);
-        // Cap initial allocation to the maximum representable output length.
-        // `child_len` is bounded by `OffsetType::Native::MAX_OFFSET`, so pre-allocating
-        // more than that is unnecessary
-        let max_output_bytes = OffsetType::Native::MAX_OFFSET.saturating_mul(bytes_per_value);
         let mut dst_buf = MutableBuffer::new(
             avg_row_len
                 .saturating_mul(indices.len())
-                .saturating_mul(bytes_per_value)
-                .min(max_output_bytes),
+                .saturating_mul(bytes_per_value),
         );
 
         let mut child_len = OffsetType::Native::zero();

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -661,13 +661,10 @@ where
 
     let field = values.value_field().clone();
 
-    let is_primitive_child = child_data.null_count() == 0 && child_data.data_type().is_primitive();
-
-    if is_primitive_child {
+    if child_data.null_count() == 0
+        && let Some(bytes_per_value) = child_data.data_type().primitive_width()
+    {
         let values_buf = &child_data.buffers()[0];
-        let Some(bytes_per_value) = child_data.data_type().primitive_width() else {
-            unreachable!("is_primitive guarantees primitive_width is Some")
-        };
         let child_buf_offset = child_data.offset() * bytes_per_value;
 
         let avg_row_len = child_data
@@ -3066,78 +3063,6 @@ mod tests {
 
         assert!(matches!(
             take(&values, &indices, None),
-            Err(ArrowError::OffsetOverflowError(_))
-        ));
-    }
-
-    /// Fixture for list offset-overflow tests: a single row containing
-    /// `value_len` int32 elements, plus the repetition count needed for
-    /// `child_len` (an `i32`) to overflow.
-    fn list_offset_overflow_fixture() -> (ListArray, usize) {
-        let value_len = 1_000_000usize;
-        let values = Int32Array::from(vec![0i32; value_len]);
-        let offsets = OffsetBuffer::from_lengths([value_len]);
-        let field = Arc::new(Field::new("item", DataType::Int32, false));
-        let array = ListArray::new(field, offsets, Arc::new(values), None);
-        let n = i32::MAX as usize / value_len + 1;
-        (array, n)
-    }
-
-    #[test]
-    fn test_take_list_offset_overflow() {
-        let (array, n) = list_offset_overflow_fixture();
-        let indices = Int32Array::from(vec![0; n]);
-        assert!(matches!(
-            take(&array, &indices, None),
-            Err(ArrowError::OffsetOverflowError(_))
-        ));
-    }
-
-    #[test]
-    fn test_take_list_offset_overflow_nullable() {
-        let (array, n) = list_offset_overflow_fixture();
-        let validity =
-            NullBuffer::from_iter(std::iter::once(false).chain(std::iter::repeat_n(true, n)));
-        let indices = Int32Array::new(vec![0i32; n + 1].into(), Some(validity));
-        assert!(matches!(
-            take(&array, &indices, None),
-            Err(ArrowError::OffsetOverflowError(_))
-        ));
-    }
-
-    /// Like [`list_offset_overflow_fixture`] but with a nullable child, forcing the slow path.
-    fn list_nullable_child_overflow_fixture() -> (ListArray, usize) {
-        let value_len = 1_000_000usize;
-        // One null in the child causes is_primitive_child to be false.
-        let mut child_builder = Int32Builder::new();
-        child_builder.append_nulls(1);
-        child_builder.append_value_n(0, value_len - 1);
-        let child = child_builder.finish();
-        let offsets = OffsetBuffer::from_lengths([value_len]);
-        let field = Arc::new(Field::new("item", DataType::Int32, true));
-        let array = ListArray::new(field, offsets, Arc::new(child), None);
-        let n = i32::MAX as usize / value_len + 1;
-        (array, n)
-    }
-
-    #[test]
-    fn test_take_list_mutable_offset_overflow() {
-        let (array, n) = list_nullable_child_overflow_fixture();
-        let indices = Int32Array::from(vec![0; n]);
-        assert!(matches!(
-            take(&array, &indices, None),
-            Err(ArrowError::OffsetOverflowError(_))
-        ));
-    }
-
-    #[test]
-    fn test_take_list_mutable_offset_overflow_nullable() {
-        let (array, n) = list_nullable_child_overflow_fixture();
-        let validity =
-            NullBuffer::from_iter(std::iter::once(false).chain(std::iter::repeat_n(true, n)));
-        let indices = Int32Array::new(vec![0i32; n + 1].into(), Some(validity));
-        assert!(matches!(
-            take(&array, &indices, None),
             Err(ArrowError::OffsetOverflowError(_))
         ));
     }

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -659,16 +659,15 @@ where
     let mut dst_offsets = Vec::with_capacity(indices.len() + 1);
     dst_offsets.push(OffsetType::Native::zero());
 
-    let field = match values.data_type() {
-        DataType::List(fld) | DataType::LargeList(fld) => fld.clone(),
-        dtype => unreachable!("take_list called with non-list data type {dtype}"),
-    };
+    let field = values.value_field().clone();
 
     let is_primitive_child = child_data.null_count() == 0 && child_data.data_type().is_primitive();
 
     if is_primitive_child {
         let values_buf = &child_data.buffers()[0];
-        let bytes_per_value = child_data.data_type().primitive_width().unwrap_or(0);
+        let Some(bytes_per_value) = child_data.data_type().primitive_width() else {
+            unreachable!("is_primitive guarantees primitive_width is Some")
+        };
         let child_buf_offset = child_data.offset() * bytes_per_value;
 
         let avg_row_len = child_data
@@ -706,7 +705,8 @@ where
                     let row = if CHECKED {
                         indices.value(vidx).as_usize()
                     } else {
-                        // SAFETY: `vidx` comes from validity bitmap over `indices`, so in-bounds.
+                        // SAFETY: !CHECKED means the caller guarantees all indices are valid;
+                        // `vidx` is further bounded by the validity bitmap of `indices`.
                         unsafe { indices.value_unchecked(vidx) }.as_usize()
                     };
                     let start = child_buf_offset + src_offsets[row].as_usize() * bytes_per_value;
@@ -775,7 +775,8 @@ where
                 let row = if CHECKED {
                     indices.value(i).as_usize()
                 } else {
-                    // SAFETY: `i` comes from validity bitmap over `indices`, so in-bounds.
+                    // SAFETY: !CHECKED means the caller guarantees all indices are valid;
+                    // `i` is further bounded by the validity bitmap of `indices`.
                     unsafe { indices.value_unchecked(i) }.as_usize()
                 };
                 mutable.try_extend(

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -674,10 +674,15 @@ where
             .len()
             .checked_div(values.len().max(1))
             .unwrap_or(0);
+        // Cap initial allocation to the maximum representable output length.
+        // `child_len` is bounded by `OffsetType::Native::MAX_OFFSET`, so pre-allocating
+        // more than that is unnecessary
+        let max_output_bytes = OffsetType::Native::MAX_OFFSET.saturating_mul(bytes_per_value);
         let mut dst_buf = MutableBuffer::new(
             avg_row_len
                 .saturating_mul(indices.len())
-                .saturating_mul(bytes_per_value),
+                .saturating_mul(bytes_per_value)
+                .min(max_output_bytes),
         );
 
         let mut child_len = OffsetType::Native::zero();

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -33,7 +33,7 @@ use arrow_cmp::make_comparator;
 use arrow_data::{ArrayData, transform::MutableArrayData};
 use arrow_schema::{ArrowError, DataType, FieldRef, SortOptions, UnionMode};
 
-use num_traits::Zero;
+use num_traits::{CheckedAdd, Zero};
 
 /// Take elements by index from [Array], creating a new [Array] from those indexes.
 ///
@@ -668,18 +668,14 @@ where
 
     if is_primitive_child {
         let values_buf = &child_data.buffers()[0];
-        let bytes_per_value = if !child_data.is_empty() {
-            values_buf.len() / child_data.len()
-        } else {
-            0
-        };
+        let bytes_per_value = child_data.data_type().primitive_width().unwrap_or(0);
         let child_buf_offset = child_data.offset() * bytes_per_value;
 
         let avg_row_len = child_data
             .len()
             .checked_div(values.len().max(1))
             .unwrap_or(0);
-        let mut dst_buf = Vec::<u8>::with_capacity(
+        let mut dst_buf = MutableBuffer::new(
             avg_row_len
                 .saturating_mul(indices.len())
                 .saturating_mul(bytes_per_value),
@@ -694,7 +690,9 @@ where
                     let start = child_buf_offset + src_offsets[row].as_usize() * bytes_per_value;
                     let end = child_buf_offset + src_offsets[row + 1].as_usize() * bytes_per_value;
                     dst_buf.extend_from_slice(&values_buf[start..end]);
-                    child_len += src_offsets[row + 1] - src_offsets[row];
+                    child_len = child_len
+                        .checked_add(&(src_offsets[row + 1] - src_offsets[row]))
+                        .ok_or_else(|| ArrowError::OffsetOverflowError(child_len.as_usize()))?;
                     dst_offsets.push(child_len);
                 }
             }
@@ -705,12 +703,18 @@ where
                     if prev < vidx {
                         dst_offsets.extend(std::iter::repeat_n(child_len, vidx - prev));
                     }
-                    // SAFETY: `vidx` comes from validity bitmap over `indices`, so in-bounds.
-                    let row = unsafe { indices.value_unchecked(vidx) }.as_usize();
+                    let row = if CHECKED {
+                        indices.value(vidx).as_usize()
+                    } else {
+                        // SAFETY: `vidx` comes from validity bitmap over `indices`, so in-bounds.
+                        unsafe { indices.value_unchecked(vidx) }.as_usize()
+                    };
                     let start = child_buf_offset + src_offsets[row].as_usize() * bytes_per_value;
                     let end = child_buf_offset + src_offsets[row + 1].as_usize() * bytes_per_value;
                     dst_buf.extend_from_slice(&values_buf[start..end]);
-                    child_len += src_offsets[row + 1] - src_offsets[row];
+                    child_len = child_len
+                        .checked_add(&(src_offsets[row + 1] - src_offsets[row]))
+                        .ok_or_else(|| ArrowError::OffsetOverflowError(child_len.as_usize()))?;
                     dst_offsets.push(child_len);
                     prev = vidx + 1;
                 }
@@ -718,7 +722,7 @@ where
             }
         }
 
-        assert_eq!(
+        debug_assert_eq!(
             dst_offsets.len(),
             indices.len() + 1,
             "New offsets was filled under/over the expected capacity"
@@ -764,7 +768,12 @@ where
                 if last < i {
                     dst_offsets.extend(std::iter::repeat_n(current, i - last));
                 }
-                let row = unsafe { indices.value_unchecked(i) }.as_usize();
+                let row = if CHECKED {
+                    indices.value(i).as_usize()
+                } else {
+                    // SAFETY: `i` comes from validity bitmap over `indices`, so in-bounds.
+                    unsafe { indices.value_unchecked(i) }.as_usize()
+                };
                 mutable.try_extend(
                     0,
                     src_offsets[row].as_usize(),
@@ -773,13 +782,15 @@ where
                 dst_offsets.push(OffsetType::Native::from_usize(mutable.len()).unwrap());
                 last = i + 1;
             }
+            // Filling offsets for null values at the end
             let final_offset = OffsetType::Native::from_usize(mutable.len()).unwrap();
             dst_offsets.extend(std::iter::repeat_n(final_offset, indices.len() - last));
         }
     }
 
-    assert_eq!(dst_offsets.len(), indices.len() + 1);
+    debug_assert_eq!(dst_offsets.len(), indices.len() + 1);
 
+    // SAFETY: `dst_offsets` is constructed to be monotonically increasing above
     let offsets = unsafe { OffsetBuffer::new_unchecked(ScalarBuffer::from(dst_offsets)) };
     let child = make_array(mutable.freeze());
     GenericListArray::<OffsetType::Native>::try_new(field, offsets, child, nulls)
@@ -2201,6 +2212,29 @@ mod tests {
     }
 
     #[test]
+    // Fast path (primitive child, no child nulls) with null indices — verifies offset backfill for null slots.
+    fn test_take_list_primitive_child_null_indices() {
+        // Row sizes deliberately vary (1, 3, 2) so the test exercises
+        // non-uniform offset arithmetic, not just uniform stride.
+        let list = ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+            Some(vec![Some(1)]),
+            Some(vec![Some(2), Some(3), Some(4)]),
+            Some(vec![Some(5), Some(6)]),
+        ]);
+        let indices = Int32Array::from(vec![Some(2), None, Some(0), Some(1)]);
+        let result = take(&list, &indices, None).unwrap();
+        let result = result.as_any().downcast_ref::<ListArray>().unwrap();
+
+        let expected = ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+            Some(vec![Some(5), Some(6)]),
+            None,
+            Some(vec![Some(1)]),
+            Some(vec![Some(2), Some(3), Some(4)]),
+        ]);
+        assert_eq!(result, &expected);
+    }
+
+    #[test]
     fn test_take_list() {
         test_take_list!(i32, List, ListArray);
     }
@@ -3018,6 +3052,41 @@ mod tests {
 
         assert!(matches!(
             take(&values, &indices, None),
+            Err(ArrowError::OffsetOverflowError(_))
+        ));
+    }
+
+    /// Fixture for list offset-overflow tests: a single row containing
+    /// `value_len` int32 elements, plus the repetition count needed for
+    /// `child_len` (an `i32`) to overflow.
+    fn list_offset_overflow_fixture() -> (ListArray, usize) {
+        let value_len = 1_000_000usize;
+        let values = Int32Array::from(vec![0i32; value_len]);
+        let offsets = OffsetBuffer::from_lengths([value_len]);
+        let field = Arc::new(Field::new("item", DataType::Int32, false));
+        let array = ListArray::new(field, offsets, Arc::new(values), None);
+        let n = i32::MAX as usize / value_len + 1;
+        (array, n)
+    }
+
+    #[test]
+    fn test_take_list_offset_overflow() {
+        let (array, n) = list_offset_overflow_fixture();
+        let indices = Int32Array::from(vec![0; n]);
+        assert!(matches!(
+            take(&array, &indices, None),
+            Err(ArrowError::OffsetOverflowError(_))
+        ));
+    }
+
+    #[test]
+    fn test_take_list_offset_overflow_nullable() {
+        let (array, n) = list_offset_overflow_fixture();
+        let validity =
+            NullBuffer::from_iter(std::iter::once(false).chain(std::iter::repeat_n(true, n)));
+        let indices = Int32Array::new(vec![0i32; n + 1].into(), Some(validity));
+        assert!(matches!(
+            take(&array, &indices, None),
             Err(ArrowError::OffsetOverflowError(_))
         ));
     }

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -660,13 +660,11 @@ where
     dst_offsets.push(OffsetType::Native::zero());
 
     let field = match values.data_type() {
-        DataType::List(f) | DataType::LargeList(f) => f.clone(),
-        d => unreachable!("take_list called with non-list data type {d}"),
+        DataType::List(fld) | DataType::LargeList(fld) => fld.clone(),
+        dtype => unreachable!("take_list called with non-list data type {dtype}"),
     };
 
-    let is_primitive_child = child_data.null_count() == 0
-        && child_data.buffers().len() == 1
-        && child_data.child_data().is_empty();
+    let is_primitive_child = child_data.null_count() == 0 && child_data.data_type().is_primitive();
 
     if is_primitive_child {
         let values_buf = &child_data.buffers()[0];
@@ -681,7 +679,7 @@ where
             .len()
             .checked_div(values.len().max(1))
             .unwrap_or(0);
-        let mut dst_buf = MutableBuffer::new(
+        let mut dst_buf = Vec::<u8>::with_capacity(
             avg_row_len
                 .saturating_mul(indices.len())
                 .saturating_mul(bytes_per_value),
@@ -701,31 +699,40 @@ where
                 }
             }
             Some(valid) => {
-                let mut last = 0;
-                for i in valid.valid_indices() {
-                    if last < i {
-                        dst_offsets.extend(std::iter::repeat_n(child_len, i - last));
+                let mut prev = 0;
+                for vidx in valid.valid_indices() {
+                    // Fill offsets for null values between the two valid indices.
+                    if prev < vidx {
+                        dst_offsets.extend(std::iter::repeat_n(child_len, vidx - prev));
                     }
-                    let row = unsafe { indices.value_unchecked(i) }.as_usize();
+                    // SAFETY: `vidx` comes from validity bitmap over `indices`, so in-bounds.
+                    let row = unsafe { indices.value_unchecked(vidx) }.as_usize();
                     let start = child_buf_offset + src_offsets[row].as_usize() * bytes_per_value;
                     let end = child_buf_offset + src_offsets[row + 1].as_usize() * bytes_per_value;
                     dst_buf.extend_from_slice(&values_buf[start..end]);
                     child_len += src_offsets[row + 1] - src_offsets[row];
                     dst_offsets.push(child_len);
-                    last = i + 1;
+                    prev = vidx + 1;
                 }
-                dst_offsets.extend(std::iter::repeat_n(child_len, indices.len() - last));
+                dst_offsets.extend(std::iter::repeat_n(child_len, indices.len() - prev));
             }
         }
 
-        assert_eq!(dst_offsets.len(), indices.len() + 1);
+        assert_eq!(
+            dst_offsets.len(),
+            indices.len() + 1,
+            "New offsets was filled under/over the expected capacity"
+        );
 
-        let child = make_array(
+        // Safety: data_type, len, and buffer are all derived from the already-validated
+        // source child_data, so re-validation is unnecessary.
+        let child = make_array(unsafe {
             ArrayData::builder(child_data.data_type().clone())
                 .len(child_len.as_usize())
                 .add_buffer(dst_buf.into())
-                .build()?,
-        );
+                .build_unchecked()
+        });
+        // SAFETY: `dst_offsets` is constructed to be monotonically increasing above.
         let offsets = unsafe { OffsetBuffer::new_unchecked(ScalarBuffer::from(dst_offsets)) };
         return GenericListArray::<OffsetType::Native>::try_new(field, offsets, child, nulls);
     }
@@ -733,7 +740,7 @@ where
     let capacity = child_data
         .len()
         .checked_div(values.len())
-        .map(|v| v * indices.len())
+        .map(|avg| avg * indices.len())
         .unwrap_or_default();
     let mut mutable =
         MutableArrayData::new(vec![&child_data], child_data.null_count() > 0, capacity);

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -652,76 +652,129 @@ where
     OffsetType::Native: OffsetSizeTrait,
     PrimitiveArray<OffsetType>: From<Vec<OffsetType::Native>>,
 {
-    let list_offsets = values.value_offsets();
+    let src_offsets = values.value_offsets();
     let child_data = values.values().to_data();
     let nulls = take_nulls::<_, CHECKED>(values.nulls(), indices);
 
-    let mut new_offsets = Vec::with_capacity(indices.len() + 1);
-    new_offsets.push(OffsetType::Native::zero());
+    let mut dst_offsets = Vec::with_capacity(indices.len() + 1);
+    dst_offsets.push(OffsetType::Native::zero());
 
-    let use_nulls = child_data.null_count() > 0;
+    let field = match values.data_type() {
+        DataType::List(f) | DataType::LargeList(f) => f.clone(),
+        d => unreachable!("take_list called with non-list data type {d}"),
+    };
+
+    let is_primitive_child = child_data.null_count() == 0
+        && child_data.buffers().len() == 1
+        && child_data.child_data().is_empty();
+
+    if is_primitive_child {
+        let values_buf = &child_data.buffers()[0];
+        let bytes_per_value = if !child_data.is_empty() {
+            values_buf.len() / child_data.len()
+        } else {
+            0
+        };
+        let child_buf_offset = child_data.offset() * bytes_per_value;
+
+        let avg_row_len = child_data
+            .len()
+            .checked_div(values.len().max(1))
+            .unwrap_or(0);
+        let mut dst_buf = MutableBuffer::new(
+            avg_row_len
+                .saturating_mul(indices.len())
+                .saturating_mul(bytes_per_value),
+        );
+
+        let mut child_len = OffsetType::Native::zero();
+
+        match nulls.as_ref().filter(|n| n.null_count() > 0) {
+            None => {
+                for &idx in indices.values() {
+                    let row = idx.as_usize();
+                    let start = child_buf_offset + src_offsets[row].as_usize() * bytes_per_value;
+                    let end = child_buf_offset + src_offsets[row + 1].as_usize() * bytes_per_value;
+                    dst_buf.extend_from_slice(&values_buf[start..end]);
+                    child_len += src_offsets[row + 1] - src_offsets[row];
+                    dst_offsets.push(child_len);
+                }
+            }
+            Some(valid) => {
+                let mut last = 0;
+                for i in valid.valid_indices() {
+                    if last < i {
+                        dst_offsets.extend(std::iter::repeat_n(child_len, i - last));
+                    }
+                    let row = unsafe { indices.value_unchecked(i) }.as_usize();
+                    let start = child_buf_offset + src_offsets[row].as_usize() * bytes_per_value;
+                    let end = child_buf_offset + src_offsets[row + 1].as_usize() * bytes_per_value;
+                    dst_buf.extend_from_slice(&values_buf[start..end]);
+                    child_len += src_offsets[row + 1] - src_offsets[row];
+                    dst_offsets.push(child_len);
+                    last = i + 1;
+                }
+                dst_offsets.extend(std::iter::repeat_n(child_len, indices.len() - last));
+            }
+        }
+
+        assert_eq!(dst_offsets.len(), indices.len() + 1);
+
+        let child = make_array(
+            ArrayData::builder(child_data.data_type().clone())
+                .len(child_len.as_usize())
+                .add_buffer(dst_buf.into())
+                .build()?,
+        );
+        let offsets = unsafe { OffsetBuffer::new_unchecked(ScalarBuffer::from(dst_offsets)) };
+        return GenericListArray::<OffsetType::Native>::try_new(field, offsets, child, nulls);
+    }
 
     let capacity = child_data
         .len()
         .checked_div(values.len())
         .map(|v| v * indices.len())
         .unwrap_or_default();
-
-    let mut array_data = MutableArrayData::new(vec![&child_data], use_nulls, capacity);
+    let mut mutable =
+        MutableArrayData::new(vec![&child_data], child_data.null_count() > 0, capacity);
 
     match nulls.as_ref().filter(|n| n.null_count() > 0) {
         None => {
-            for index in indices.values() {
-                let ix = index.as_usize();
-                let start = list_offsets[ix].as_usize();
-                let end = list_offsets[ix + 1].as_usize();
-                array_data.try_extend(0, start, end)?;
-                new_offsets.push(OffsetType::Native::from_usize(array_data.len()).unwrap());
+            for idx in indices.values() {
+                let row = idx.as_usize();
+                mutable.try_extend(
+                    0,
+                    src_offsets[row].as_usize(),
+                    src_offsets[row + 1].as_usize(),
+                )?;
+                dst_offsets.push(OffsetType::Native::from_usize(mutable.len()).unwrap());
             }
         }
-        Some(output_nulls) => {
-            assert_eq!(output_nulls.len(), indices.len());
-
-            let mut last_filled = 0;
-            for i in output_nulls.valid_indices() {
-                let current = OffsetType::Native::from_usize(array_data.len()).unwrap();
-                // Filling offsets for the null values between the two valid indices
-                if last_filled < i {
-                    new_offsets.extend(std::iter::repeat_n(current, i - last_filled));
+        Some(valid) => {
+            let mut last = 0;
+            for i in valid.valid_indices() {
+                let current = OffsetType::Native::from_usize(mutable.len()).unwrap();
+                if last < i {
+                    dst_offsets.extend(std::iter::repeat_n(current, i - last));
                 }
-
-                // SAFETY: `i` comes from validity bitmap over `indices`, so in-bounds.
-                let ix = unsafe { indices.value_unchecked(i) }.as_usize();
-                let start = list_offsets[ix].as_usize();
-                let end = list_offsets[ix + 1].as_usize();
-                array_data.try_extend(0, start, end)?;
-                new_offsets.push(OffsetType::Native::from_usize(array_data.len()).unwrap());
-                last_filled = i + 1;
+                let row = unsafe { indices.value_unchecked(i) }.as_usize();
+                mutable.try_extend(
+                    0,
+                    src_offsets[row].as_usize(),
+                    src_offsets[row + 1].as_usize(),
+                )?;
+                dst_offsets.push(OffsetType::Native::from_usize(mutable.len()).unwrap());
+                last = i + 1;
             }
-
-            // Filling offsets for null values at the end
-            let final_offset = OffsetType::Native::from_usize(array_data.len()).unwrap();
-            new_offsets.extend(std::iter::repeat_n(
-                final_offset,
-                indices.len() - last_filled,
-            ));
+            let final_offset = OffsetType::Native::from_usize(mutable.len()).unwrap();
+            dst_offsets.extend(std::iter::repeat_n(final_offset, indices.len() - last));
         }
     }
 
-    assert_eq!(
-        new_offsets.len(),
-        indices.len() + 1,
-        "New offsets was filled under/over the expected capacity"
-    );
+    assert_eq!(dst_offsets.len(), indices.len() + 1);
 
-    let field = match values.data_type() {
-        DataType::List(field) | DataType::LargeList(field) => field.clone(),
-        d => unreachable!("take_list called with non-list data type {d}"),
-    };
-    // SAFETY: `new_offsets` is constructed to be monotonically increasing above
-    let offsets = unsafe { OffsetBuffer::new_unchecked(ScalarBuffer::from(new_offsets)) };
-    let child = make_array(array_data.freeze());
-
+    let offsets = unsafe { OffsetBuffer::new_unchecked(ScalarBuffer::from(dst_offsets)) };
+    let child = make_array(mutable.freeze());
     GenericListArray::<OffsetType::Native>::try_new(field, offsets, child, nulls)
 }
 

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -758,13 +758,17 @@ where
                     src_offsets[row].as_usize(),
                     src_offsets[row + 1].as_usize(),
                 )?;
-                dst_offsets.push(OffsetType::Native::from_usize(mutable.len()).unwrap());
+                dst_offsets.push(
+                    OffsetType::Native::from_usize(mutable.len())
+                        .ok_or_else(|| ArrowError::OffsetOverflowError(mutable.len()))?,
+                );
             }
         }
         Some(valid) => {
             let mut last = 0;
             for i in valid.valid_indices() {
-                let current = OffsetType::Native::from_usize(mutable.len()).unwrap();
+                let current = OffsetType::Native::from_usize(mutable.len())
+                    .ok_or_else(|| ArrowError::OffsetOverflowError(mutable.len()))?;
                 if last < i {
                     dst_offsets.extend(std::iter::repeat_n(current, i - last));
                 }
@@ -779,11 +783,15 @@ where
                     src_offsets[row].as_usize(),
                     src_offsets[row + 1].as_usize(),
                 )?;
-                dst_offsets.push(OffsetType::Native::from_usize(mutable.len()).unwrap());
+                dst_offsets.push(
+                    OffsetType::Native::from_usize(mutable.len())
+                        .ok_or_else(|| ArrowError::OffsetOverflowError(mutable.len()))?,
+                );
                 last = i + 1;
             }
             // Filling offsets for null values at the end
-            let final_offset = OffsetType::Native::from_usize(mutable.len()).unwrap();
+            let final_offset = OffsetType::Native::from_usize(mutable.len())
+                .ok_or_else(|| ArrowError::OffsetOverflowError(mutable.len()))?;
             dst_offsets.extend(std::iter::repeat_n(final_offset, indices.len() - last));
         }
     }
@@ -3082,6 +3090,43 @@ mod tests {
     #[test]
     fn test_take_list_offset_overflow_nullable() {
         let (array, n) = list_offset_overflow_fixture();
+        let validity =
+            NullBuffer::from_iter(std::iter::once(false).chain(std::iter::repeat_n(true, n)));
+        let indices = Int32Array::new(vec![0i32; n + 1].into(), Some(validity));
+        assert!(matches!(
+            take(&array, &indices, None),
+            Err(ArrowError::OffsetOverflowError(_))
+        ));
+    }
+
+    /// Like [`list_offset_overflow_fixture`] but with a nullable child, forcing the slow path.
+    fn list_nullable_child_overflow_fixture() -> (ListArray, usize) {
+        let value_len = 1_000_000usize;
+        // One null in the child causes is_primitive_child to be false.
+        let mut child_builder = Int32Builder::new();
+        child_builder.append_nulls(1);
+        child_builder.append_value_n(0, value_len - 1);
+        let child = child_builder.finish();
+        let offsets = OffsetBuffer::from_lengths([value_len]);
+        let field = Arc::new(Field::new("item", DataType::Int32, true));
+        let array = ListArray::new(field, offsets, Arc::new(child), None);
+        let n = i32::MAX as usize / value_len + 1;
+        (array, n)
+    }
+
+    #[test]
+    fn test_take_list_mutable_offset_overflow() {
+        let (array, n) = list_nullable_child_overflow_fixture();
+        let indices = Int32Array::from(vec![0; n]);
+        assert!(matches!(
+            take(&array, &indices, None),
+            Err(ArrowError::OffsetOverflowError(_))
+        ));
+    }
+
+    #[test]
+    fn test_take_list_mutable_offset_overflow_nullable() {
+        let (array, n) = list_nullable_child_overflow_fixture();
         let validity =
             NullBuffer::from_iter(std::iter::once(false).chain(std::iter::repeat_n(true, n)));
         let indices = Int32Array::new(vec![0i32; n + 1].into(), Some(validity));


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- works towards #8879.

# Rationale for this change
take on `List<T>` and `LargeList<T>` routes every selected row through `MutableArrayData::try_extend`, which pays virtual dispatch via stored function pointers & null-bitmap bookkeeping on every call, regardless of whether the child array actually needs any of that machinery. For primitive children (no nulls, no nesting), this overhead dominates the actual data movement cost.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Instead of MutableArrayData::try_extend per row, the fast path:
- Computes `bytes_per_value` from the buffer length once upfront
- Copies each selected row's raw bytes with `MutableBuffer::extend_from_slice` (a direct memcpy)
- Builds the output child ArrayData directly from the resulting buffer


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
existing test `test_take_list`,`test_take_list_with_value_nulls`,`test_take_list_with_nulls` cover the changes in this PR
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
