### PR TITLE
perf: optimize take bool & take null buffers

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -569,7 +569,8 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
                     if (value_byte >> ((src_idx + value_bit_offset) & 7)) & 1 != 0 {
                         bit_util::set_bit_raw(value_out_ptr, out_pos);
                     }
-                    let validity_byte = *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3); // byte containing validity bit
+                    let validity_byte =
+                        *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3); // byte containing validity bit
                     if (validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1 != 0 {
                         bit_util::set_bit_raw(validity_out_ptr, out_pos);
                     }
@@ -597,12 +598,15 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
                 let mut packed_validity = 0u8;
                 for bit_pos in 0..8usize {
                     // SAFETY: bit_base + bit_pos < len
-                    let src_idx =
-                        unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
-                    let value_byte = unsafe { *value_data_ptr.add((src_idx + value_bit_offset) >> 3) }; // byte containing value bit
-                    let validity_byte = unsafe { *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3) }; // byte containing validity bit
-                    packed_values |= ((value_byte >> ((src_idx + value_bit_offset) & 7)) & 1) << bit_pos; // extract value bit, place at position `bit_pos`
-                    packed_validity |= ((validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1) << bit_pos; // extract validity bit, place at position `bit_pos`
+                    let src_idx = unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
+                    let value_byte =
+                        unsafe { *value_data_ptr.add((src_idx + value_bit_offset) >> 3) }; // byte containing value bit
+                    let validity_byte =
+                        unsafe { *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3) }; // byte containing validity bit
+                    packed_values |=
+                        ((value_byte >> ((src_idx + value_bit_offset) & 7)) & 1) << bit_pos; // extract value bit, place at position `bit_pos`
+                    packed_validity |=
+                        ((validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1) << bit_pos; // extract validity bit, place at position `bit_pos`
                 }
                 *value_out_byte = packed_values;
                 *validity_out_byte = packed_validity;
@@ -613,12 +617,15 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
                 let mut packed_validity = 0u8;
                 for bit_pos in 0..(len - bit_base) {
                     // SAFETY: bit_base + bit_pos < len
-                    let src_idx =
-                        unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
-                    let value_byte = unsafe { *value_data_ptr.add((src_idx + value_bit_offset) >> 3) }; // byte containing value bit
-                    let validity_byte = unsafe { *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3) }; // byte containing validity bit
-                    packed_values |= ((value_byte >> ((src_idx + value_bit_offset) & 7)) & 1) << bit_pos; // extract value bit, place at position `bit_pos`
-                    packed_validity |= ((validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1) << bit_pos; // extract validity bit, place at position `bit_pos`
+                    let src_idx = unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
+                    let value_byte =
+                        unsafe { *value_data_ptr.add((src_idx + value_bit_offset) >> 3) }; // byte containing value bit
+                    let validity_byte =
+                        unsafe { *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3) }; // byte containing validity bit
+                    packed_values |=
+                        ((value_byte >> ((src_idx + value_bit_offset) & 7)) & 1) << bit_pos; // extract value bit, place at position `bit_pos`
+                    packed_validity |=
+                        ((validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1) << bit_pos; // extract validity bit, place at position `bit_pos`
                 }
                 value_out_slice[full_bytes] = packed_values;
                 validity_out_slice[full_bytes] = packed_validity;
@@ -1279,12 +1286,7 @@ pub fn take_record_batch(
     record_batch: &RecordBatch,
     indices: &dyn Array,
 ) -> Result<RecordBatch, ArrowError> {
-    let columns = record_batch
-        .columns()
-        .iter()
-        .map(|c| take(c, indices, None))
-        .collect::<Result<Vec<_>, _>>()?;
-    RecordBatch::try_new(record_batch.schema(), columns)
+    unsafe { take_record_batch_unchecked(record_batch, indices) }
 }
 
 /// Take rows by index from [`RecordBatch`], returning a new [`RecordBatch`], without bounds

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -495,7 +495,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
             let out_slice = output.as_slice_mut();
             let full_bytes = len / 8;
 
-            for byte_idx in 0..full_bytes {
+            for (byte_idx, out_byte) in out_slice.iter_mut().enumerate().take(full_bytes) {
                 let base = byte_idx * 8;
                 let mut byte = 0u8;
                 for bit in 0..8usize {
@@ -506,10 +506,10 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
                     // SAFETY: src_idx bounded by take's prior bounds check
-                    let raw = unsafe { *src_ptr.add(src_idx >> 3) };
-                    byte |= ((raw >> (src_idx & 7)) & 1) << bit;
+                    let raw = unsafe { *src_ptr.add(src_idx >> 3) }; // byte containing bit src_idx
+                    byte |= ((raw >> (src_idx & 7)) & 1) << bit; // extract that bit, place it at position `bit`
                 }
-                out_slice[byte_idx] = byte;
+                *out_byte = byte;
             }
             if full_bytes < out_bytes {
                 let base = full_bytes * 8;
@@ -522,8 +522,8 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
                     // SAFETY: src_idx bounded by take's prior bounds check
-                    let raw = unsafe { *src_ptr.add(src_idx >> 3) };
-                    byte |= ((raw >> (src_idx & 7)) & 1) << bit;
+                    let raw = unsafe { *src_ptr.add(src_idx >> 3) }; // byte containing bit src_idx
+                    byte |= ((raw >> (src_idx & 7)) & 1) << bit; // extract that bit, place it at position `bit`
                 }
                 out_slice[full_bytes] = byte;
             }
@@ -541,36 +541,37 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
     indices: &PrimitiveArray<I>,
 ) -> (BooleanBuffer, Option<NullBuffer>) {
     let len = indices.len();
-    let val_offset = values.offset();
-    let null_offset = validity.offset();
-    let val_ptr = values.values().as_ptr();
-    let null_ptr = validity.values().as_ptr();
+    let value_bit_offset = values.offset();
+    let validity_bit_offset = validity.offset();
+    let value_data_ptr = values.values().as_ptr();
+    let validity_data_ptr = validity.values().as_ptr();
     let out_bytes = len.div_ceil(8);
 
-    let mut val_buf = MutableBuffer::with_capacity(out_bytes);
-    let mut null_buf = MutableBuffer::with_capacity(out_bytes);
+    let mut value_out = MutableBuffer::with_capacity(out_bytes);
+    let mut validity_out = MutableBuffer::with_capacity(out_bytes);
 
     match indices.nulls().filter(|n| n.null_count() > 0) {
         Some(index_nulls) => {
             // SAFETY: every byte is written (fill) before reading
             unsafe {
-                val_buf.set_len(out_bytes);
-                null_buf.set_len(out_bytes)
+                value_out.set_len(out_bytes);
+                validity_out.set_len(out_bytes)
             };
-            val_buf.as_slice_mut().fill(0);
-            null_buf.as_slice_mut().fill(0);
-            let vp = val_buf.as_mut_ptr();
-            let np = null_buf.as_mut_ptr();
-            for i in index_nulls.valid_indices() {
-                let src_idx = unsafe { indices.value_unchecked(i) }.as_usize();
+            value_out.as_slice_mut().fill(0);
+            validity_out.as_slice_mut().fill(0);
+            let value_out_ptr = value_out.as_mut_ptr();
+            let validity_out_ptr = validity_out.as_mut_ptr();
+            for out_pos in index_nulls.valid_indices() {
+                // SAFETY: out_pos < len from the validity bitmap
+                let src_idx = unsafe { indices.value_unchecked(out_pos) }.as_usize();
                 unsafe {
-                    let v = *val_ptr.add((src_idx + val_offset) >> 3);
-                    if (v >> ((src_idx + val_offset) & 7)) & 1 != 0 {
-                        bit_util::set_bit_raw(vp, i);
+                    let value_byte = *value_data_ptr.add((src_idx + value_bit_offset) >> 3); // byte containing value bit
+                    if (value_byte >> ((src_idx + value_bit_offset) & 7)) & 1 != 0 {
+                        bit_util::set_bit_raw(value_out_ptr, out_pos);
                     }
-                    let n = *null_ptr.add((src_idx + null_offset) >> 3);
-                    if (n >> ((src_idx + null_offset) & 7)) & 1 != 0 {
-                        bit_util::set_bit_raw(np, i);
+                    let validity_byte = *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3); // byte containing validity bit
+                    if (validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1 != 0 {
+                        bit_util::set_bit_raw(validity_out_ptr, out_pos);
                     }
                 }
             }
@@ -578,47 +579,56 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
         None => {
             // SAFETY: every byte is written below before BooleanBuffer reads it
             unsafe {
-                val_buf.set_len(out_bytes);
-                null_buf.set_len(out_bytes)
+                value_out.set_len(out_bytes);
+                validity_out.set_len(out_bytes)
             };
-            let val_slice = val_buf.as_slice_mut();
-            let null_slice = null_buf.as_slice_mut();
+            let value_out_slice = value_out.as_slice_mut();
+            let validity_out_slice = validity_out.as_slice_mut();
             let full_bytes = len / 8;
 
-            for byte_idx in 0..full_bytes {
-                let base = byte_idx * 8;
-                let mut v_byte = 0u8;
-                let mut n_byte = 0u8;
-                for bit in 0..8usize {
-                    let src_idx = unsafe { indices.value_unchecked(base + bit) }.as_usize();
-                    let v = unsafe { *val_ptr.add((src_idx + val_offset) >> 3) };
-                    let n = unsafe { *null_ptr.add((src_idx + null_offset) >> 3) };
-                    v_byte |= ((v >> ((src_idx + val_offset) & 7)) & 1) << bit;
-                    n_byte |= ((n >> ((src_idx + null_offset) & 7)) & 1) << bit;
+            for (byte_idx, (value_out_byte, validity_out_byte)) in value_out_slice
+                .iter_mut()
+                .zip(validity_out_slice.iter_mut())
+                .enumerate()
+                .take(full_bytes)
+            {
+                let bit_base = byte_idx * 8;
+                let mut packed_values = 0u8;
+                let mut packed_validity = 0u8;
+                for bit_pos in 0..8usize {
+                    // SAFETY: bit_base + bit_pos < len
+                    let src_idx =
+                        unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
+                    let value_byte = unsafe { *value_data_ptr.add((src_idx + value_bit_offset) >> 3) }; // byte containing value bit
+                    let validity_byte = unsafe { *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3) }; // byte containing validity bit
+                    packed_values |= ((value_byte >> ((src_idx + value_bit_offset) & 7)) & 1) << bit_pos; // extract value bit, place at position `bit_pos`
+                    packed_validity |= ((validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1) << bit_pos; // extract validity bit, place at position `bit_pos`
                 }
-                val_slice[byte_idx] = v_byte;
-                null_slice[byte_idx] = n_byte;
+                *value_out_byte = packed_values;
+                *validity_out_byte = packed_validity;
             }
             if full_bytes < out_bytes {
-                let base = full_bytes * 8;
-                let mut v_byte = 0u8;
-                let mut n_byte = 0u8;
-                for bit in 0..(len - base) {
-                    let src_idx = unsafe { indices.value_unchecked(base + bit) }.as_usize();
-                    let v = unsafe { *val_ptr.add((src_idx + val_offset) >> 3) };
-                    let n = unsafe { *null_ptr.add((src_idx + null_offset) >> 3) };
-                    v_byte |= ((v >> ((src_idx + val_offset) & 7)) & 1) << bit;
-                    n_byte |= ((n >> ((src_idx + null_offset) & 7)) & 1) << bit;
+                let bit_base = full_bytes * 8;
+                let mut packed_values = 0u8;
+                let mut packed_validity = 0u8;
+                for bit_pos in 0..(len - bit_base) {
+                    // SAFETY: bit_base + bit_pos < len
+                    let src_idx =
+                        unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
+                    let value_byte = unsafe { *value_data_ptr.add((src_idx + value_bit_offset) >> 3) }; // byte containing value bit
+                    let validity_byte = unsafe { *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3) }; // byte containing validity bit
+                    packed_values |= ((value_byte >> ((src_idx + value_bit_offset) & 7)) & 1) << bit_pos; // extract value bit, place at position `bit_pos`
+                    packed_validity |= ((validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1) << bit_pos; // extract validity bit, place at position `bit_pos`
                 }
-                val_slice[full_bytes] = v_byte;
-                null_slice[full_bytes] = n_byte;
+                value_out_slice[full_bytes] = packed_values;
+                validity_out_slice[full_bytes] = packed_validity;
             }
         }
     }
 
-    let val_out = BooleanBuffer::new(val_buf.into(), 0, len);
-    let null_out = NullBuffer::from_unsliced_buffer(null_buf, len);
-    (val_out, null_out)
+    let value_buf_out = BooleanBuffer::new(value_out.into(), 0, len);
+    let validity_buf_out = NullBuffer::from_unsliced_buffer(validity_out, len);
+    (value_buf_out, validity_buf_out)
 }
 
 /// `take` implementation for boolean arrays
@@ -629,8 +639,7 @@ fn take_boolean<IndexType: ArrowPrimitiveType, const CHECKED: bool>(
     let bits = array.values();
     match array.nulls().filter(|n| n.null_count() > 0) {
         Some(array_nulls) => {
-            let (val_buf, null_buf) =
-                take_bits_with_validity(bits, array_nulls.inner(), indices);
+            let (val_buf, null_buf) = take_bits_with_validity(bits, array_nulls.inner(), indices);
             BooleanArray::new(val_buf, null_buf)
         }
         None => {

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -456,6 +456,42 @@ fn take_native<T: ArrowNativeType, I: ArrowPrimitiveType>(
     }
 }
 
+/// Read the bit at `src_bit_idx` from `src` and, if it is set, write a `1` to `dst_bit_idx`
+/// in `dst`. Leaves `dst_bit_idx` unchanged (zero) when the source bit is unset.
+///
+/// ```text
+/// src = 0b00100000  (bit 5 is set)
+/// copy_bit_if_set(src, 5, dst, 2)  →  dst bit 2 becomes 1
+/// ```
+///
+/// # Safety
+/// - `src` must be valid for reads up to byte `src_bit_idx / 8`.
+/// - `dst` must be valid for writes up to byte `dst_bit_idx / 8`.
+#[inline(always)]
+unsafe fn copy_bit_if_set(src: *const u8, src_bit_idx: usize, dst: *mut u8, dst_bit_idx: usize) {
+    unsafe {
+        if bit_util::get_bit_raw(src, src_bit_idx) {
+            bit_util::set_bit_raw(dst, dst_bit_idx);
+        }
+    }
+}
+
+/// Read the bit at `bit_idx` from `src` and return it shifted to `out_pos`, ready to be
+/// OR'd into an output byte accumulator.
+///
+/// ```text
+/// src = 0b10100000  (bit 5 is set)
+/// pack_bit(src, 5, 2)  →  0b00000100   (bit from position 5, placed at position 2)
+/// ```
+///
+/// # Safety
+/// `src` must be valid for reads up to byte `bit_idx / 8`.
+#[inline(always)]
+unsafe fn pack_bit(src: *const u8, bit_idx: usize, out_pos: usize) -> u8 {
+    let byte = unsafe { *src.add(bit_idx >> 3) }; // byte containing bit `bit_idx`
+    ((byte >> (bit_idx & 7)) & 1) << out_pos // extract the bit, shift to output position
+}
+
 #[inline(never)]
 fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
     values: &BooleanBuffer,
@@ -478,11 +514,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                     unsafe { indices.value_unchecked(valid_idx) }.as_usize()
                 } + src_offset;
                 // SAFETY: src_idx bounded by take's prior bounds check
-                unsafe {
-                    if bit_util::get_bit_raw(src_ptr, src_idx) {
-                        bit_util::set_bit_raw(out_ptr, valid_idx);
-                    }
-                }
+                unsafe { copy_bit_if_set(src_ptr, src_idx, out_ptr, valid_idx) };
             });
             BooleanBuffer::new(Buffer::from(output), 0, len)
         }
@@ -493,9 +525,9 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
             let out_slice = output.as_mut_slice();
             let full_bytes = len / 8;
 
-            for (byte_idx, out_slot) in out_slice.iter_mut().enumerate().take(full_bytes) {
+            for (byte_idx, out_byte) in out_slice.iter_mut().enumerate().take(full_bytes) {
                 let base = byte_idx * 8;
-                let mut out_byte = 0u8;
+                let mut byte = 0u8;
                 for bit in 0..8usize {
                     let src_idx = if CHECKED {
                         indices.value(base + bit).as_usize()
@@ -504,15 +536,13 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
                     // SAFETY: src_idx bounded by take's prior bounds check
-                    let src_byte = unsafe { *src_ptr.add(src_idx >> 3) }; // byte containing bit src_idx
-                    out_byte |= ((src_byte >> (src_idx & 7)) & 1) << bit; // extract that bit, place it at position `bit`
+                    byte |= unsafe { pack_bit(src_ptr, src_idx, bit) };
                 }
-                *out_slot = out_byte;
+                *out_byte = byte;
             }
-            // Handle remaining bits when len is not a multiple of 8.
             if full_bytes < out_bytes {
                 let base = full_bytes * 8;
-                let mut out_byte = 0u8;
+                let mut byte = 0u8;
                 for bit in 0..(len - base) {
                     let src_idx = if CHECKED {
                         indices.value(base + bit).as_usize()
@@ -521,10 +551,9 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
                     // SAFETY: src_idx bounded by take's prior bounds check
-                    let src_byte = unsafe { *src_ptr.add(src_idx >> 3) }; // byte containing bit src_idx
-                    out_byte |= ((src_byte >> (src_idx & 7)) & 1) << bit; // extract that bit, place it at position `bit`
+                    byte |= unsafe { pack_bit(src_ptr, src_idx, bit) };
                 }
-                out_slice[full_bytes] = out_byte;
+                out_slice[full_bytes] = byte;
             }
             BooleanBuffer::new(Buffer::from(output), 0, len)
         }
@@ -557,16 +586,20 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
             for out_pos in index_nulls.valid_indices() {
                 // SAFETY: out_pos < len from the validity bitmap
                 let src_idx = unsafe { indices.value_unchecked(out_pos) }.as_usize();
+                // SAFETY: src_idx + offsets bounded by take's prior bounds check
                 unsafe {
-                    let value_byte = *value_data_ptr.add((src_idx + value_bit_offset) >> 3); // byte containing value bit
-                    if (value_byte >> ((src_idx + value_bit_offset) & 7)) & 1 != 0 {
-                        bit_util::set_bit_raw(value_out_ptr, out_pos);
-                    }
-                    let validity_byte =
-                        *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3); // byte containing validity bit
-                    if (validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1 != 0 {
-                        bit_util::set_bit_raw(validity_out_ptr, out_pos);
-                    }
+                    copy_bit_if_set(
+                        value_data_ptr,
+                        src_idx + value_bit_offset,
+                        value_out_ptr,
+                        out_pos,
+                    );
+                    copy_bit_if_set(
+                        validity_data_ptr,
+                        src_idx + validity_bit_offset,
+                        validity_out_ptr,
+                        out_pos,
+                    );
                 }
             }
         }
@@ -587,14 +620,12 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
                 for bit_pos in 0..8usize {
                     // SAFETY: bit_base + bit_pos < len
                     let src_idx = unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
-                    let value_byte =
-                        unsafe { *value_data_ptr.add((src_idx + value_bit_offset) >> 3) }; // byte containing value bit
-                    let validity_byte =
-                        unsafe { *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3) }; // byte containing validity bit
+                    // SAFETY: src_idx + offsets bounded by take's prior bounds check
                     packed_values |=
-                        ((value_byte >> ((src_idx + value_bit_offset) & 7)) & 1) << bit_pos; // extract value bit, place at position `bit_pos`
-                    packed_validity |=
-                        ((validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1) << bit_pos; // extract validity bit, place at position `bit_pos`
+                        unsafe { pack_bit(value_data_ptr, src_idx + value_bit_offset, bit_pos) };
+                    packed_validity |= unsafe {
+                        pack_bit(validity_data_ptr, src_idx + validity_bit_offset, bit_pos)
+                    };
                 }
                 *value_out_byte = packed_values;
                 *validity_out_byte = packed_validity;
@@ -607,14 +638,12 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
                 for bit_pos in 0..(len - bit_base) {
                     // SAFETY: bit_base + bit_pos < len
                     let src_idx = unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
-                    let value_byte =
-                        unsafe { *value_data_ptr.add((src_idx + value_bit_offset) >> 3) }; // byte containing value bit
-                    let validity_byte =
-                        unsafe { *validity_data_ptr.add((src_idx + validity_bit_offset) >> 3) }; // byte containing validity bit
+                    // SAFETY: src_idx + offsets bounded by take's prior bounds check
                     packed_values |=
-                        ((value_byte >> ((src_idx + value_bit_offset) & 7)) & 1) << bit_pos; // extract value bit, place at position `bit_pos`
-                    packed_validity |=
-                        ((validity_byte >> ((src_idx + validity_bit_offset) & 7)) & 1) << bit_pos; // extract validity bit, place at position `bit_pos`
+                        unsafe { pack_bit(value_data_ptr, src_idx + value_bit_offset, bit_pos) };
+                    packed_validity |= unsafe {
+                        pack_bit(validity_data_ptr, src_idx + validity_bit_offset, bit_pos)
+                    };
                 }
                 value_out_slice[full_bytes] = packed_values;
                 validity_out_slice[full_bytes] = packed_validity;

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -471,8 +471,12 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
             let mut output = MutableBuffer::new_null(len);
             let out_ptr = output.as_mut_ptr();
             nulls.valid_indices().for_each(|i| {
-                // SAFETY: i < len from the validity bitmap
-                let src_idx = unsafe { indices.value_unchecked(i) }.as_usize() + src_offset;
+                let src_idx = if CHECKED {
+                    indices.value(i).as_usize()
+                } else {
+                    // SAFETY: i < len from the validity bitmap
+                    unsafe { indices.value_unchecked(i) }.as_usize()
+                } + src_offset;
                 // SAFETY: src_idx bounded by take's prior bounds check
                 unsafe {
                     if bit_util::get_bit_raw(src_ptr, src_idx) {
@@ -495,9 +499,12 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let base = byte_idx * 8;
                 let mut byte = 0u8;
                 for bit in 0..8usize {
-                    // SAFETY: base + bit < len
-                    let src_idx =
-                        unsafe { indices.value_unchecked(base + bit) }.as_usize() + src_offset;
+                    let src_idx = if CHECKED {
+                        indices.value(base + bit).as_usize()
+                    } else {
+                        // SAFETY: base + bit < len
+                        unsafe { indices.value_unchecked(base + bit) }.as_usize()
+                    } + src_offset;
                     // SAFETY: src_idx bounded by take's prior bounds check
                     let raw = unsafe { *src_ptr.add(src_idx >> 3) };
                     byte |= ((raw >> (src_idx & 7)) & 1) << bit;
@@ -508,8 +515,13 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let base = full_bytes * 8;
                 let mut byte = 0u8;
                 for bit in 0..(len - base) {
-                    let src_idx =
-                        unsafe { indices.value_unchecked(base + bit) }.as_usize() + src_offset;
+                    let src_idx = if CHECKED {
+                        indices.value(base + bit).as_usize()
+                    } else {
+                        // SAFETY: base + bit < len
+                        unsafe { indices.value_unchecked(base + bit) }.as_usize()
+                    } + src_offset;
+                    // SAFETY: src_idx bounded by take's prior bounds check
                     let raw = unsafe { *src_ptr.add(src_idx >> 3) };
                     byte |= ((raw >> (src_idx & 7)) & 1) << bit;
                 }
@@ -611,17 +623,18 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
 
 /// `take` implementation for boolean arrays
 fn take_boolean<IndexType: ArrowPrimitiveType, const CHECKED: bool>(
-    values: &BooleanArray,
+    array: &BooleanArray,
     indices: &PrimitiveArray<IndexType>,
 ) -> BooleanArray {
-    match values.nulls().filter(|n| n.null_count() > 0) {
-        Some(value_nulls) => {
+    let bits = array.values();
+    match array.nulls().filter(|n| n.null_count() > 0) {
+        Some(array_nulls) => {
             let (val_buf, null_buf) =
-                take_bits_with_validity(values.values(), value_nulls.inner(), indices);
+                take_bits_with_validity(bits, array_nulls.inner(), indices);
             BooleanArray::new(val_buf, null_buf)
         }
         None => {
-            let val_buf = take_bits::<_, CHECKED>(values.values(), indices);
+            let val_buf = take_bits::<_, CHECKED>(bits, indices);
             let null_buf = take_nulls::<_, CHECKED>(None, indices);
             BooleanArray::new(val_buf, null_buf)
         }
@@ -1263,6 +1276,36 @@ pub fn take_record_batch(
         .map(|c| take(c, indices, None))
         .collect::<Result<Vec<_>, _>>()?;
     RecordBatch::try_new(record_batch.schema(), columns)
+}
+
+/// Take rows by index from [`RecordBatch`], returning a new [`RecordBatch`], without bounds
+/// checking.
+///
+/// # Safety
+///
+/// The caller must guarantee that every non-null value in `indices` is a valid row index for
+/// `record_batch` (i.e. `index < record_batch.num_rows()`). Violating this will cause a panic
+/// or undefined behaviour inside the inner kernels.
+///
+/// # Errors
+///
+/// Returns an [`ArrowError`] if `indices` is not an integer array type.
+pub unsafe fn take_record_batch_unchecked(
+    record_batch: &RecordBatch,
+    indices: &dyn Array,
+) -> Result<RecordBatch, ArrowError> {
+    downcast_integer_array!(
+        indices => {
+            let indices = indices.to_indices();
+            let columns = record_batch
+                .columns()
+                .iter()
+                .map(|c| take_impl::<_, false>(c.as_ref(), &indices))
+                .collect::<Result<Vec<_>, _>>()?;
+            RecordBatch::try_new(record_batch.schema(), columns)
+        },
+        d => Err(ArrowError::InvalidArgumentError(format!("Take only supported for integers, got {d:?}")))
+    )
 }
 
 #[cfg(test)]

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -466,22 +466,21 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
     let src_ptr = values.values().as_ptr();
     let out_bytes = len.div_ceil(8);
 
-    match indices.nulls().filter(|n| n.null_count() > 0) {
-        Some(nulls) => {
-            let mut output = Vec::with_capacity(out_bytes);
-            output.resize(out_bytes, 0u8);
+    match indices.nulls().filter(|nulls| nulls.null_count() > 0) {
+        Some(index_nulls) => {
+            let mut output = vec![0u8; out_bytes];
             let out_ptr = output.as_mut_ptr();
-            nulls.valid_indices().for_each(|i| {
+            index_nulls.valid_indices().for_each(|valid_idx| {
                 let src_idx = if CHECKED {
-                    indices.value(i).as_usize()
+                    indices.value(valid_idx).as_usize()
                 } else {
-                    // SAFETY: i < len from the validity bitmap
-                    unsafe { indices.value_unchecked(i) }.as_usize()
+                    // SAFETY: valid_idx < len from the validity bitmap
+                    unsafe { indices.value_unchecked(valid_idx) }.as_usize()
                 } + src_offset;
                 // SAFETY: src_idx bounded by take's prior bounds check
                 unsafe {
                     if bit_util::get_bit_raw(src_ptr, src_idx) {
-                        bit_util::set_bit_raw(out_ptr, i);
+                        bit_util::set_bit_raw(out_ptr, valid_idx);
                     }
                 }
             });
@@ -490,14 +489,13 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
         None => {
             // Build the output byte-by-byte with an 8-element inner loop so the
             // compiler can fully unroll it and issue the 8 source loads in parallel.
-            let mut output = Vec::with_capacity(out_bytes);
-            output.resize(out_bytes, 0u8);
+            let mut output = vec![0u8; out_bytes];
             let out_slice = output.as_mut_slice();
             let full_bytes = len / 8;
 
-            for (byte_idx, out_byte) in out_slice.iter_mut().enumerate().take(full_bytes) {
+            for (byte_idx, out_slot) in out_slice.iter_mut().enumerate().take(full_bytes) {
                 let base = byte_idx * 8;
-                let mut byte = 0u8;
+                let mut out_byte = 0u8;
                 for bit in 0..8usize {
                     let src_idx = if CHECKED {
                         indices.value(base + bit).as_usize()
@@ -506,14 +504,15 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
                     // SAFETY: src_idx bounded by take's prior bounds check
-                    let raw = unsafe { *src_ptr.add(src_idx >> 3) }; // byte containing bit src_idx
-                    byte |= ((raw >> (src_idx & 7)) & 1) << bit; // extract that bit, place it at position `bit`
+                    let src_byte = unsafe { *src_ptr.add(src_idx >> 3) }; // byte containing bit src_idx
+                    out_byte |= ((src_byte >> (src_idx & 7)) & 1) << bit; // extract that bit, place it at position `bit`
                 }
-                *out_byte = byte;
+                *out_slot = out_byte;
             }
+            // Handle remaining bits when len is not a multiple of 8.
             if full_bytes < out_bytes {
                 let base = full_bytes * 8;
-                let mut byte = 0u8;
+                let mut out_byte = 0u8;
                 for bit in 0..(len - base) {
                     let src_idx = if CHECKED {
                         indices.value(base + bit).as_usize()
@@ -522,10 +521,10 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
                     // SAFETY: src_idx bounded by take's prior bounds check
-                    let raw = unsafe { *src_ptr.add(src_idx >> 3) }; // byte containing bit src_idx
-                    byte |= ((raw >> (src_idx & 7)) & 1) << bit; // extract that bit, place it at position `bit`
+                    let src_byte = unsafe { *src_ptr.add(src_idx >> 3) }; // byte containing bit src_idx
+                    out_byte |= ((src_byte >> (src_idx & 7)) & 1) << bit; // extract that bit, place it at position `bit`
                 }
-                out_slice[full_bytes] = byte;
+                out_slice[full_bytes] = out_byte;
             }
             BooleanBuffer::new(Buffer::from(output), 0, len)
         }
@@ -550,7 +549,7 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
     let mut value_out = vec![0u8; out_bytes];
     let mut validity_out = vec![0u8; out_bytes];
 
-    match indices.nulls().filter(|n| n.null_count() > 0) {
+    match indices.nulls().filter(|nulls| nulls.null_count() > 0) {
         Some(index_nulls) => {
             // Vec is pre-zeroed; only set bits for valid indices via raw pointer.
             let value_out_ptr = value_out.as_mut_ptr();
@@ -600,6 +599,7 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
                 *value_out_byte = packed_values;
                 *validity_out_byte = packed_validity;
             }
+            // Handle remaining bits when len is not a multiple of 8.
             if full_bytes < out_bytes {
                 let bit_base = full_bytes * 8;
                 let mut packed_values = 0u8;
@@ -1872,6 +1872,96 @@ mod tests {
             None,
             vec![None, Some(false), Some(true), None],
         );
+    }
+
+    #[test]
+    // Null indices + sliced source boolean array — exercises src_offset in the sparse take_bits path.
+    fn test_take_bool_nullable_index_sliced_source() {
+        let source = BooleanArray::from(vec![Some(true), Some(false), Some(true), Some(false)]);
+        let source = source.slice(1, 3); // logical: [false, true, false], offset=1
+        let source = source.as_any().downcast_ref::<BooleanArray>().unwrap();
+
+        let indices = UInt32Array::from(vec![Some(2), None, Some(0)]);
+        let result = take(source, &indices, None).unwrap();
+        let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+
+        let expected = BooleanArray::from(vec![Some(false), None, Some(false)]);
+        assert_eq!(result, &expected);
+    }
+
+    #[test]
+    // >8 elements: exercises the 8-at-a-time unrolled byte packing in take_bits.
+    fn test_take_bool_no_nulls_multi_byte() {
+        let source = BooleanArray::from(vec![
+            true, false, true, true, false, false, true, false, true, true,
+        ]);
+        let indices = UInt32Array::from(vec![0, 2, 4, 6, 8, 1, 3, 5, 7, 9]);
+        let result = take(&source, &indices, None).unwrap();
+        let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let expected = BooleanArray::from(vec![
+            true, true, false, true, true, false, true, false, false, true,
+        ]);
+        assert_eq!(result, &expected);
+    }
+
+    #[test]
+    // Sliced source: verifies src_offset is applied when no null indices.
+    fn test_take_bool_no_nulls_sliced_source() {
+        let source = BooleanArray::from(vec![true, false, true, false, true]);
+        let source = source.slice(2, 3); // [true, false, true], offset=2
+        let source = source.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let indices = UInt32Array::from(vec![2, 0, 1]);
+        let result = take(source, &indices, None).unwrap();
+        let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let expected = BooleanArray::from(vec![true, true, false]);
+        assert_eq!(result, &expected);
+    }
+
+    #[test]
+    // Nullable source, >8 elements: exercises the 8-at-a-time unrolled byte packing in take_bits_with_validity.
+    fn test_take_bool_nullable_values_multi_byte() {
+        let source = BooleanArray::from(vec![
+            Some(true),
+            None,
+            Some(false),
+            Some(true),
+            None,
+            Some(false),
+            Some(true),
+            Some(false),
+            Some(true),
+            None,
+        ]);
+        let indices = UInt32Array::from(vec![0, 2, 4, 6, 8, 1, 3, 5, 7, 9]);
+        let result = take(&source, &indices, None).unwrap();
+        let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let expected = BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            None,
+            Some(true),
+            Some(true),
+            None,
+            Some(true),
+            Some(false),
+            Some(false),
+            None,
+        ]);
+        assert_eq!(result, &expected);
+    }
+
+    #[test]
+    // Nullable source, null indices, sliced source: verifies src_offset with both null paths.
+    fn test_take_bool_nullable_values_sliced_source_null_indices() {
+        let source =
+            BooleanArray::from(vec![Some(true), Some(false), None, Some(true), Some(false)]);
+        let source = source.slice(1, 4); // [false, null, true, false], offset=1
+        let source = source.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let indices = UInt32Array::from(vec![Some(3), None, Some(1), Some(0)]);
+        let result = take(source, &indices, None).unwrap();
+        let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let expected = BooleanArray::from(vec![Some(false), None, None, Some(false)]);
+        assert_eq!(result, &expected);
     }
 
     fn _test_take_string<'a, K>()

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -462,27 +462,151 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
     indices: &PrimitiveArray<I>,
 ) -> BooleanBuffer {
     let len = indices.len();
+    let src_offset = values.offset();
+    let src_ptr = values.values().as_ptr();
+    let out_bytes = len.div_ceil(8);
 
     match indices.nulls().filter(|n| n.null_count() > 0) {
         Some(nulls) => {
-            let mut output_buffer = MutableBuffer::new_null(len);
-            let output_slice = output_buffer.as_slice_mut();
-            nulls.valid_indices().for_each(|idx| {
-                // SAFETY: idx is a valid index in indices.nulls() --> idx<indices.len()
-                if unsafe { values.value(indices.value_unchecked(idx).as_usize()) } {
-                    // SAFETY: MutableBuffer was created with space for indices.len() bit, and idx < indices.len()
-                    unsafe { bit_util::set_bit_raw(output_slice.as_mut_ptr(), idx) };
+            let mut output = MutableBuffer::new_null(len);
+            let out_ptr = output.as_mut_ptr();
+            nulls.valid_indices().for_each(|i| {
+                // SAFETY: i < len from the validity bitmap
+                let src_idx = unsafe { indices.value_unchecked(i) }.as_usize() + src_offset;
+                // SAFETY: src_idx bounded by take's prior bounds check
+                unsafe {
+                    if bit_util::get_bit_raw(src_ptr, src_idx) {
+                        bit_util::set_bit_raw(out_ptr, i);
+                    }
                 }
             });
-            BooleanBuffer::new(output_buffer.into(), 0, len)
+            BooleanBuffer::new(output.into(), 0, len)
         }
         None => {
-            BooleanBuffer::collect_bool(len, |idx: usize| {
-                // SAFETY: idx<indices.len()
-                values.value(unsafe { indices.value_unchecked(idx).as_usize() })
-            })
+            // Build the output byte-by-byte with an 8-element inner loop so the
+            // compiler can fully unroll it and issue the 8 source loads in parallel.
+            let mut output = MutableBuffer::with_capacity(out_bytes);
+            // SAFETY: every byte is written before BooleanBuffer reads it
+            unsafe { output.set_len(out_bytes) };
+            let out_slice = output.as_slice_mut();
+            let full_bytes = len / 8;
+
+            for byte_idx in 0..full_bytes {
+                let base = byte_idx * 8;
+                let mut byte = 0u8;
+                for bit in 0..8usize {
+                    // SAFETY: base + bit < len
+                    let src_idx =
+                        unsafe { indices.value_unchecked(base + bit) }.as_usize() + src_offset;
+                    // SAFETY: src_idx bounded by take's prior bounds check
+                    let raw = unsafe { *src_ptr.add(src_idx >> 3) };
+                    byte |= ((raw >> (src_idx & 7)) & 1) << bit;
+                }
+                out_slice[byte_idx] = byte;
+            }
+            if full_bytes < out_bytes {
+                let base = full_bytes * 8;
+                let mut byte = 0u8;
+                for bit in 0..(len - base) {
+                    let src_idx =
+                        unsafe { indices.value_unchecked(base + bit) }.as_usize() + src_offset;
+                    let raw = unsafe { *src_ptr.add(src_idx >> 3) };
+                    byte |= ((raw >> (src_idx & 7)) & 1) << bit;
+                }
+                out_slice[full_bytes] = byte;
+            }
+            BooleanBuffer::new(output.into(), 0, len)
         }
     }
+}
+
+/// Gather value bits and validity bits from two boolean buffers in a single pass.
+/// Used when the values array itself has nulls, avoiding two separate `take_bits` calls.
+#[inline(never)]
+fn take_bits_with_validity<I: ArrowPrimitiveType>(
+    values: &BooleanBuffer,
+    validity: &BooleanBuffer,
+    indices: &PrimitiveArray<I>,
+) -> (BooleanBuffer, Option<NullBuffer>) {
+    let len = indices.len();
+    let val_offset = values.offset();
+    let null_offset = validity.offset();
+    let val_ptr = values.values().as_ptr();
+    let null_ptr = validity.values().as_ptr();
+    let out_bytes = len.div_ceil(8);
+
+    let mut val_buf = MutableBuffer::with_capacity(out_bytes);
+    let mut null_buf = MutableBuffer::with_capacity(out_bytes);
+
+    match indices.nulls().filter(|n| n.null_count() > 0) {
+        Some(index_nulls) => {
+            // SAFETY: every byte is written (fill) before reading
+            unsafe {
+                val_buf.set_len(out_bytes);
+                null_buf.set_len(out_bytes)
+            };
+            val_buf.as_slice_mut().fill(0);
+            null_buf.as_slice_mut().fill(0);
+            let vp = val_buf.as_mut_ptr();
+            let np = null_buf.as_mut_ptr();
+            for i in index_nulls.valid_indices() {
+                let src_idx = unsafe { indices.value_unchecked(i) }.as_usize();
+                unsafe {
+                    let v = *val_ptr.add((src_idx + val_offset) >> 3);
+                    if (v >> ((src_idx + val_offset) & 7)) & 1 != 0 {
+                        bit_util::set_bit_raw(vp, i);
+                    }
+                    let n = *null_ptr.add((src_idx + null_offset) >> 3);
+                    if (n >> ((src_idx + null_offset) & 7)) & 1 != 0 {
+                        bit_util::set_bit_raw(np, i);
+                    }
+                }
+            }
+        }
+        None => {
+            // SAFETY: every byte is written below before BooleanBuffer reads it
+            unsafe {
+                val_buf.set_len(out_bytes);
+                null_buf.set_len(out_bytes)
+            };
+            let val_slice = val_buf.as_slice_mut();
+            let null_slice = null_buf.as_slice_mut();
+            let full_bytes = len / 8;
+
+            for byte_idx in 0..full_bytes {
+                let base = byte_idx * 8;
+                let mut v_byte = 0u8;
+                let mut n_byte = 0u8;
+                for bit in 0..8usize {
+                    let src_idx = unsafe { indices.value_unchecked(base + bit) }.as_usize();
+                    let v = unsafe { *val_ptr.add((src_idx + val_offset) >> 3) };
+                    let n = unsafe { *null_ptr.add((src_idx + null_offset) >> 3) };
+                    v_byte |= ((v >> ((src_idx + val_offset) & 7)) & 1) << bit;
+                    n_byte |= ((n >> ((src_idx + null_offset) & 7)) & 1) << bit;
+                }
+                val_slice[byte_idx] = v_byte;
+                null_slice[byte_idx] = n_byte;
+            }
+            if full_bytes < out_bytes {
+                let base = full_bytes * 8;
+                let mut v_byte = 0u8;
+                let mut n_byte = 0u8;
+                for bit in 0..(len - base) {
+                    let src_idx = unsafe { indices.value_unchecked(base + bit) }.as_usize();
+                    let v = unsafe { *val_ptr.add((src_idx + val_offset) >> 3) };
+                    let n = unsafe { *null_ptr.add((src_idx + null_offset) >> 3) };
+                    v_byte |= ((v >> ((src_idx + val_offset) & 7)) & 1) << bit;
+                    n_byte |= ((n >> ((src_idx + null_offset) & 7)) & 1) << bit;
+                }
+                val_slice[full_bytes] = v_byte;
+                null_slice[full_bytes] = n_byte;
+            }
+        }
+    }
+
+    let val_out = BooleanBuffer::new(val_buf.into(), 0, len);
+    let null_out = NullBuffer::from_unsliced_buffer(null_buf, len);
+    (val_out, null_out)
 }
 
 /// `take` implementation for boolean arrays
@@ -490,9 +614,18 @@ fn take_boolean<IndexType: ArrowPrimitiveType, const CHECKED: bool>(
     values: &BooleanArray,
     indices: &PrimitiveArray<IndexType>,
 ) -> BooleanArray {
-    let val_buf = take_bits::<_, CHECKED>(values.values(), indices);
-    let null_buf = take_nulls::<_, CHECKED>(values.nulls(), indices);
-    BooleanArray::new(val_buf, null_buf)
+    match values.nulls().filter(|n| n.null_count() > 0) {
+        Some(value_nulls) => {
+            let (val_buf, null_buf) =
+                take_bits_with_validity(values.values(), value_nulls.inner(), indices);
+            BooleanArray::new(val_buf, null_buf)
+        }
+        None => {
+            let val_buf = take_bits::<_, CHECKED>(values.values(), indices);
+            let null_buf = take_nulls::<_, CHECKED>(None, indices);
+            BooleanArray::new(val_buf, null_buf)
+        }
+    }
 }
 
 /// `take` implementation for string arrays

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -468,7 +468,8 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
 
     match indices.nulls().filter(|n| n.null_count() > 0) {
         Some(nulls) => {
-            let mut output = MutableBuffer::new_null(len);
+            let mut output = Vec::with_capacity(out_bytes);
+            output.resize(out_bytes, 0u8);
             let out_ptr = output.as_mut_ptr();
             nulls.valid_indices().for_each(|i| {
                 let src_idx = if CHECKED {
@@ -484,15 +485,14 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                     }
                 }
             });
-            BooleanBuffer::new(output.into(), 0, len)
+            BooleanBuffer::new(Buffer::from(output), 0, len)
         }
         None => {
             // Build the output byte-by-byte with an 8-element inner loop so the
             // compiler can fully unroll it and issue the 8 source loads in parallel.
-            let mut output = MutableBuffer::with_capacity(out_bytes);
-            // SAFETY: every byte is written before BooleanBuffer reads it
-            unsafe { output.set_len(out_bytes) };
-            let out_slice = output.as_slice_mut();
+            let mut output = Vec::with_capacity(out_bytes);
+            output.resize(out_bytes, 0u8);
+            let out_slice = output.as_mut_slice();
             let full_bytes = len / 8;
 
             for (byte_idx, out_byte) in out_slice.iter_mut().enumerate().take(full_bytes) {
@@ -527,7 +527,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                 }
                 out_slice[full_bytes] = byte;
             }
-            BooleanBuffer::new(output.into(), 0, len)
+            BooleanBuffer::new(Buffer::from(output), 0, len)
         }
     }
 }
@@ -547,18 +547,12 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
     let validity_data_ptr = validity.values().as_ptr();
     let out_bytes = len.div_ceil(8);
 
-    let mut value_out = MutableBuffer::with_capacity(out_bytes);
-    let mut validity_out = MutableBuffer::with_capacity(out_bytes);
+    let mut value_out = vec![0u8; out_bytes];
+    let mut validity_out = vec![0u8; out_bytes];
 
     match indices.nulls().filter(|n| n.null_count() > 0) {
         Some(index_nulls) => {
-            // SAFETY: every byte is written (fill) before reading
-            unsafe {
-                value_out.set_len(out_bytes);
-                validity_out.set_len(out_bytes)
-            };
-            value_out.as_slice_mut().fill(0);
-            validity_out.as_slice_mut().fill(0);
+            // Vec is pre-zeroed; only set bits for valid indices via raw pointer.
             let value_out_ptr = value_out.as_mut_ptr();
             let validity_out_ptr = validity_out.as_mut_ptr();
             for out_pos in index_nulls.valid_indices() {
@@ -578,13 +572,8 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
             }
         }
         None => {
-            // SAFETY: every byte is written below before BooleanBuffer reads it
-            unsafe {
-                value_out.set_len(out_bytes);
-                validity_out.set_len(out_bytes)
-            };
-            let value_out_slice = value_out.as_slice_mut();
-            let validity_out_slice = validity_out.as_slice_mut();
+            let value_out_slice = value_out.as_mut_slice();
+            let validity_out_slice = validity_out.as_mut_slice();
             let full_bytes = len / 8;
 
             for (byte_idx, (value_out_byte, validity_out_byte)) in value_out_slice
@@ -633,7 +622,7 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
         }
     }
 
-    let value_buf_out = BooleanBuffer::new(value_out.into(), 0, len);
+    let value_buf_out = BooleanBuffer::new(Buffer::from(value_out), 0, len);
     let validity_buf_out = NullBuffer::from_unsliced_buffer(validity_out, len);
     (value_buf_out, validity_buf_out)
 }

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1912,10 +1912,10 @@ mod tests {
     fn test_take_bool_nullable_index_sliced_source() {
         let source = BooleanArray::from(vec![Some(true), Some(false), Some(true), Some(false)]);
         let source = source.slice(1, 3); // logical: [false, true, false], offset=1
-        let source = source.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let source = source;
 
         let indices = UInt32Array::from(vec![Some(2), None, Some(0)]);
-        let result = take(source, &indices, None).unwrap();
+        let result = take(&source, &indices, None).unwrap();
         let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
 
         let expected = BooleanArray::from(vec![Some(false), None, Some(false)]);

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -513,7 +513,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                     // SAFETY: valid_idx < len (validity bitmap); caller guarantees index values are in bounds when CHECKED=false
                     unsafe { indices.value_unchecked(valid_idx) }.as_usize()
                 } + src_offset;
-                // SAFETY: src_idx bounded by take's prior bounds check
+                // SAFETY: src_idx is in bounds; indices.value() guarantees it when CHECKED=true, caller guarantees it when CHECKED=false
                 unsafe { copy_bit_if_set(src_ptr, src_idx, out_ptr, valid_idx) };
             });
             BooleanBuffer::new(Buffer::from(output), 0, len)
@@ -535,7 +535,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                         // SAFETY: base + bit < len (loop bound); caller guarantees index values are in bounds when CHECKED=false
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
-                    // SAFETY: src_idx bounded by take's prior bounds check
+                    // SAFETY: src_idx is in bounds; indices.value() guarantees it when CHECKED=true, caller guarantees it when CHECKED=false
                     byte |= unsafe { pack_bit(src_ptr, src_idx, bit) };
                 }
                 *out_byte = byte;
@@ -551,7 +551,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                         // SAFETY: base + bit < len (loop bound); caller guarantees index values are in bounds when CHECKED=false
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
-                    // SAFETY: src_idx bounded by take's prior bounds check
+                    // SAFETY: src_idx is in bounds; indices.value() guarantees it when CHECKED=true, caller guarantees it when CHECKED=false
                     byte |= unsafe { pack_bit(src_ptr, src_idx, bit) };
                 }
                 out_slice[full_bytes] = byte;
@@ -591,7 +591,7 @@ fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
                     // SAFETY: out_pos < len (validity bitmap); caller guarantees index values are in bounds when CHECKED=false
                     unsafe { indices.value_unchecked(out_pos) }.as_usize()
                 };
-                // SAFETY: src_idx < values.len(); check_bounds ensures this when CHECKED, caller guarantees it otherwise
+                // SAFETY: src_idx < values.len();
                 unsafe {
                     copy_bit_if_set(
                         value_data_ptr,

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -507,12 +507,8 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
             let mut output = vec![0u8; out_bytes];
             let out_ptr = output.as_mut_ptr();
             index_nulls.valid_indices().for_each(|valid_idx| {
-                let index_val = if CHECKED {
-                    indices.value(valid_idx).as_usize()
-                } else {
-                    // SAFETY: valid_idx < indices.len(), guaranteed by valid_indices().
-                    unsafe { indices.value_unchecked(valid_idx) }.as_usize()
-                };
+                // SAFETY: valid_idx < indices.len(), guaranteed by valid_indices().
+                let index_val = unsafe { indices.value_unchecked(valid_idx) }.as_usize();
                 if CHECKED {
                     if values.value(index_val) {
                         // SAFETY: valid_idx < indices.len() = len, output buffer holds len bits.
@@ -593,12 +589,8 @@ fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
             let value_out_ptr = value_out.as_mut_ptr();
             let validity_out_ptr = validity_out.as_mut_ptr();
             for out_pos in index_nulls.valid_indices() {
-                let src_idx = if CHECKED {
-                    indices.value(out_pos).as_usize()
-                } else {
-                    // SAFETY: out_pos < indices.len(), guaranteed by valid_indices().
-                    unsafe { indices.value_unchecked(out_pos) }.as_usize()
-                };
+                // SAFETY: out_pos < indices.len(), guaranteed by valid_indices().
+                let src_idx = unsafe { indices.value_unchecked(out_pos) }.as_usize();
                 if CHECKED {
                     if values.value(src_idx) {
                         // SAFETY: out_pos < indices.len() = len, output buffer holds len bits.
@@ -642,12 +634,8 @@ fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let mut packed_values = 0u8;
                 let mut packed_validity = 0u8;
                 for bit_pos in 0..8usize {
-                    let src_idx = if CHECKED {
-                        indices.value(bit_base + bit_pos).as_usize()
-                    } else {
-                        // SAFETY: bit_base + bit_pos < full_bytes * 8 <= len.
-                        unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize()
-                    };
+                    // SAFETY: bit_base + bit_pos < full_bytes * 8 <= len.
+                    let src_idx = unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
                     if CHECKED {
                         packed_values |= (values.value(src_idx) as u8) << bit_pos;
                         packed_validity |= (validity.value(src_idx) as u8) << bit_pos;
@@ -670,12 +658,8 @@ fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let mut packed_values = 0u8;
                 let mut packed_validity = 0u8;
                 for bit_pos in 0..(len - bit_base) {
-                    let src_idx = if CHECKED {
-                        indices.value(bit_base + bit_pos).as_usize()
-                    } else {
-                        // SAFETY: bit_base + bit_pos < len (remainder loop bound).
-                        unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize()
-                    };
+                    // SAFETY: bit_base + bit_pos < len (remainder loop bound).
+                    let src_idx = unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
                     if CHECKED {
                         packed_values |= (values.value(src_idx) as u8) << bit_pos;
                         packed_validity |= (validity.value(src_idx) as u8) << bit_pos;

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -510,10 +510,13 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let src_idx = if CHECKED {
                     indices.value(valid_idx).as_usize()
                 } else {
-                    // SAFETY: valid_idx < len (validity bitmap); caller guarantees index values are in bounds when CHECKED=false
+                    // SAFETY: valid_idx < indices.len() (valid_indices() guarantee).
                     unsafe { indices.value_unchecked(valid_idx) }.as_usize()
                 } + src_offset;
-                // SAFETY: src_idx is in bounds; indices.value() guarantees it when CHECKED=true, caller guarantees it when CHECKED=false
+                // SAFETY: src_idx = index_value + src_offset is a valid bit position in the
+                // values buffer. When CHECKED=true, check_bounds verified every index value is
+                // < values.len() before this function was called. When CHECKED=false, the caller
+                // upholds that invariant.
                 unsafe { copy_bit_if_set(src_ptr, src_idx, out_ptr, valid_idx) };
             });
             BooleanBuffer::new(Buffer::from(output), 0, len)
@@ -532,10 +535,14 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                     let src_idx = if CHECKED {
                         indices.value(base + bit).as_usize()
                     } else {
-                        // SAFETY: base + bit < len (loop bound); caller guarantees index values are in bounds when CHECKED=false
+                        // SAFETY: base + bit < full_bytes * 8 <= len, so base + bit is a valid
+                        // position in the indices array.
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
-                    // SAFETY: src_idx is in bounds; indices.value() guarantees it when CHECKED=true, caller guarantees it when CHECKED=false
+                    // SAFETY: src_idx = index_value + src_offset is a valid bit position in the
+                    // values buffer. When CHECKED=true, check_bounds verified every index value is
+                    // < values.len() before this function was called. When CHECKED=false, the caller
+                    // upholds that invariant.
                     byte |= unsafe { pack_bit(src_ptr, src_idx, bit) };
                 }
                 *out_byte = byte;
@@ -548,10 +555,14 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                     let src_idx = if CHECKED {
                         indices.value(base + bit).as_usize()
                     } else {
-                        // SAFETY: base + bit < len (loop bound); caller guarantees index values are in bounds when CHECKED=false
+                        // SAFETY: base + bit < len (remainder loop bound), so base + bit is a
+                        // valid position in the indices array.
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
-                    // SAFETY: src_idx is in bounds; indices.value() guarantees it when CHECKED=true, caller guarantees it when CHECKED=false
+                    // SAFETY: src_idx = index_value + src_offset is a valid bit position in the
+                    // values buffer. When CHECKED=true, check_bounds verified every index value is
+                    // < values.len() before this function was called. When CHECKED=false, the caller
+                    // upholds that invariant.
                     byte |= unsafe { pack_bit(src_ptr, src_idx, bit) };
                 }
                 out_slice[full_bytes] = byte;

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -96,13 +96,9 @@ pub fn take(
         indices => {
             let indices = indices.to_indices();
             if options.check_bounds {
-                // Pre-verify all index values once: take_impl can skip safe accessor overhead.
                 check_bounds(values.len(), &indices)?;
-                take_impl::<_, false>(values, &indices)
-            } else {
-                // No pre-check: take_impl uses safe accessors that panic on OOB instead of UB.
-                take_impl::<_, true>(values, &indices)
             }
+            take_impl::<_, true>(values, &indices)
         },
         d => Err(ArrowError::InvalidArgumentError(format!("Take only supported for integers, got {d:?}")))
     )

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1310,37 +1310,12 @@ pub fn take_record_batch(
     record_batch: &RecordBatch,
     indices: &dyn Array,
 ) -> Result<RecordBatch, ArrowError> {
-    unsafe { take_record_batch_unchecked(record_batch, indices) }
-}
-
-/// Take rows by index from [`RecordBatch`], returning a new [`RecordBatch`], without bounds
-/// checking.
-///
-/// # Safety
-///
-/// The caller must guarantee that every non-null value in `indices` is a valid row index for
-/// `record_batch` (i.e. `index < record_batch.num_rows()`). Violating this will cause a panic
-/// or undefined behaviour inside the inner kernels.
-///
-/// # Errors
-///
-/// Returns an [`ArrowError`] if `indices` is not an integer array type.
-pub unsafe fn take_record_batch_unchecked(
-    record_batch: &RecordBatch,
-    indices: &dyn Array,
-) -> Result<RecordBatch, ArrowError> {
-    downcast_integer_array!(
-        indices => {
-            let indices = indices.to_indices();
-            let columns = record_batch
-                .columns()
-                .iter()
-                .map(|c| take_impl::<_, false>(c.as_ref(), &indices))
-                .collect::<Result<Vec<_>, _>>()?;
-            RecordBatch::try_new(record_batch.schema(), columns)
-        },
-        d => Err(ArrowError::InvalidArgumentError(format!("Take only supported for integers, got {d:?}")))
-    )
+    let columns = record_batch
+        .columns()
+        .iter()
+        .map(|c| take(c, indices, None))
+        .collect::<Result<Vec<_>, _>>()?;
+    RecordBatch::try_new(record_batch.schema(), columns)
 }
 
 #[cfg(test)]

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -510,7 +510,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let src_idx = if CHECKED {
                     indices.value(valid_idx).as_usize()
                 } else {
-                    // SAFETY: valid_idx < indices.len() (valid_indices() guarantee).
+                    // SAFETY: valid_idx < index_nulls.len() == indices.len(), guaranteed by valid_indices().
                     unsafe { indices.value_unchecked(valid_idx) }.as_usize()
                 } + src_offset;
                 // SAFETY: src_idx = index_value + src_offset is a valid bit position in the

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -540,6 +540,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                 }
                 *out_byte = byte;
             }
+            // Handle remaining bits when len is not a multiple of 8.
             if full_bytes < out_bytes {
                 let base = full_bytes * 8;
                 let mut byte = 0u8;
@@ -563,7 +564,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
 /// Gather value bits and validity bits from two boolean buffers in a single pass.
 /// Used when the values array itself has nulls, avoiding two separate `take_bits` calls.
 #[inline(never)]
-fn take_bits_with_validity<I: ArrowPrimitiveType>(
+fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
     values: &BooleanBuffer,
     validity: &BooleanBuffer,
     indices: &PrimitiveArray<I>,
@@ -585,7 +586,11 @@ fn take_bits_with_validity<I: ArrowPrimitiveType>(
             let validity_out_ptr = validity_out.as_mut_ptr();
             for out_pos in index_nulls.valid_indices() {
                 // SAFETY: out_pos < len from the validity bitmap
-                let src_idx = unsafe { indices.value_unchecked(out_pos) }.as_usize();
+                let src_idx = if CHECKED {
+                    indices.value(out_pos).as_usize()
+                } else {
+                    unsafe { indices.value_unchecked(out_pos) }.as_usize()
+                };
                 // SAFETY: src_idx + offsets bounded by take's prior bounds check
                 unsafe {
                     copy_bit_if_set(
@@ -664,7 +669,7 @@ fn take_boolean<IndexType: ArrowPrimitiveType, const CHECKED: bool>(
     let bits = array.values();
     match array.nulls().filter(|n| n.null_count() > 0) {
         Some(array_nulls) => {
-            let (val_buf, null_buf) = take_bits_with_validity(bits, array_nulls.inner(), indices);
+            let (val_buf, null_buf) = take_bits_with_validity::<_, CHECKED>(bits, array_nulls.inner(), indices);
             BooleanArray::new(val_buf, null_buf)
         }
         None => {

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -510,7 +510,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let src_idx = if CHECKED {
                     indices.value(valid_idx).as_usize()
                 } else {
-                    // SAFETY: valid_idx < len from the validity bitmap
+                    // SAFETY: valid_idx < len (validity bitmap); caller guarantees index values are in bounds when CHECKED=false
                     unsafe { indices.value_unchecked(valid_idx) }.as_usize()
                 } + src_offset;
                 // SAFETY: src_idx bounded by take's prior bounds check
@@ -532,7 +532,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                     let src_idx = if CHECKED {
                         indices.value(base + bit).as_usize()
                     } else {
-                        // SAFETY: base + bit < len
+                        // SAFETY: base + bit < len (loop bound); caller guarantees index values are in bounds when CHECKED=false
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
                     // SAFETY: src_idx bounded by take's prior bounds check
@@ -548,7 +548,7 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                     let src_idx = if CHECKED {
                         indices.value(base + bit).as_usize()
                     } else {
-                        // SAFETY: base + bit < len
+                        // SAFETY: base + bit < len (loop bound); caller guarantees index values are in bounds when CHECKED=false
                         unsafe { indices.value_unchecked(base + bit) }.as_usize()
                     } + src_offset;
                     // SAFETY: src_idx bounded by take's prior bounds check
@@ -585,13 +585,13 @@ fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
             let value_out_ptr = value_out.as_mut_ptr();
             let validity_out_ptr = validity_out.as_mut_ptr();
             for out_pos in index_nulls.valid_indices() {
-                // SAFETY: out_pos < len from the validity bitmap
                 let src_idx = if CHECKED {
                     indices.value(out_pos).as_usize()
                 } else {
+                    // SAFETY: out_pos < len (validity bitmap); caller guarantees index values are in bounds when CHECKED=false
                     unsafe { indices.value_unchecked(out_pos) }.as_usize()
                 };
-                // SAFETY: src_idx + offsets bounded by take's prior bounds check
+                // SAFETY: src_idx < values.len(); check_bounds ensures this when CHECKED, caller guarantees it otherwise
                 unsafe {
                     copy_bit_if_set(
                         value_data_ptr,
@@ -625,7 +625,7 @@ fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
                 for bit_pos in 0..8usize {
                     // SAFETY: bit_base + bit_pos < len
                     let src_idx = unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
-                    // SAFETY: src_idx + offsets bounded by take's prior bounds check
+                    // SAFETY: src_idx < values.len(); check_bounds ensures this when CHECKED, caller guarantees it otherwise
                     packed_values |=
                         unsafe { pack_bit(value_data_ptr, src_idx + value_bit_offset, bit_pos) };
                     packed_validity |= unsafe {
@@ -643,7 +643,7 @@ fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
                 for bit_pos in 0..(len - bit_base) {
                     // SAFETY: bit_base + bit_pos < len
                     let src_idx = unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
-                    // SAFETY: src_idx + offsets bounded by take's prior bounds check
+                    // SAFETY: src_idx < values.len(); check_bounds ensures this when CHECKED, caller guarantees it otherwise
                     packed_values |=
                         unsafe { pack_bit(value_data_ptr, src_idx + value_bit_offset, bit_pos) };
                     packed_validity |= unsafe {

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -94,11 +94,15 @@ pub fn take(
     let options = options.unwrap_or_default();
     downcast_integer_array!(
         indices => {
-            if options.check_bounds {
-                check_bounds(values.len(), indices)?;
-            }
             let indices = indices.to_indices();
-            take_impl::<_, true>(values, &indices)
+            if options.check_bounds {
+                // Pre-verify all index values once: take_impl can skip safe accessor overhead.
+                check_bounds(values.len(), &indices)?;
+                take_impl::<_, false>(values, &indices)
+            } else {
+                // No pre-check: take_impl uses safe accessors that panic on OOB instead of UB.
+                take_impl::<_, true>(values, &indices)
+            }
         },
         d => Err(ArrowError::InvalidArgumentError(format!("Take only supported for integers, got {d:?}")))
     )
@@ -507,17 +511,21 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
             let mut output = vec![0u8; out_bytes];
             let out_ptr = output.as_mut_ptr();
             index_nulls.valid_indices().for_each(|valid_idx| {
-                let src_idx = if CHECKED {
+                let index_val = if CHECKED {
                     indices.value(valid_idx).as_usize()
                 } else {
-                    // SAFETY: valid_idx < index_nulls.len() == indices.len(), guaranteed by valid_indices().
+                    // SAFETY: valid_idx < indices.len(), guaranteed by valid_indices().
                     unsafe { indices.value_unchecked(valid_idx) }.as_usize()
-                } + src_offset;
-                // SAFETY: src_idx = index_value + src_offset is a valid bit position in the
-                // values buffer. When CHECKED=true, check_bounds verified every index value is
-                // < values.len() before this function was called. When CHECKED=false, the caller
-                // upholds that invariant.
-                unsafe { copy_bit_if_set(src_ptr, src_idx, out_ptr, valid_idx) };
+                };
+                if CHECKED {
+                    if values.value(index_val) {
+                        // SAFETY: valid_idx < indices.len() = len, output buffer holds len bits.
+                        unsafe { bit_util::set_bit_raw(out_ptr, valid_idx) };
+                    }
+                } else {
+                    // SAFETY: caller guarantees index_val < values.len().
+                    unsafe { copy_bit_if_set(src_ptr, index_val + src_offset, out_ptr, valid_idx) };
+                }
             });
             BooleanBuffer::new(Buffer::from(output), 0, len)
         }
@@ -532,18 +540,15 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let base = byte_idx * 8;
                 let mut byte = 0u8;
                 for bit in 0..8usize {
-                    let src_idx = if CHECKED {
-                        indices.value(base + bit).as_usize()
+                    // SAFETY: base + bit < full_bytes * 8 <= len, so base + bit is a valid
+                    // position in the indices array.
+                    let index_val = unsafe { indices.value_unchecked(base + bit) }.as_usize();
+                    if CHECKED {
+                        byte |= (values.value(index_val) as u8) << bit;
                     } else {
-                        // SAFETY: base + bit < full_bytes * 8 <= len, so base + bit is a valid
-                        // position in the indices array.
-                        unsafe { indices.value_unchecked(base + bit) }.as_usize()
-                    } + src_offset;
-                    // SAFETY: src_idx = index_value + src_offset is a valid bit position in the
-                    // values buffer. When CHECKED=true, check_bounds verified every index value is
-                    // < values.len() before this function was called. When CHECKED=false, the caller
-                    // upholds that invariant.
-                    byte |= unsafe { pack_bit(src_ptr, src_idx, bit) };
+                        // SAFETY: caller guarantees index_val < values.len().
+                        byte |= unsafe { pack_bit(src_ptr, index_val + src_offset, bit) };
+                    }
                 }
                 *out_byte = byte;
             }
@@ -552,18 +557,15 @@ fn take_bits<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let base = full_bytes * 8;
                 let mut byte = 0u8;
                 for bit in 0..(len - base) {
-                    let src_idx = if CHECKED {
-                        indices.value(base + bit).as_usize()
+                    // SAFETY: base + bit < len (remainder loop bound), so base + bit is a
+                    // valid position in the indices array.
+                    let index_val = unsafe { indices.value_unchecked(base + bit) }.as_usize();
+                    if CHECKED {
+                        byte |= (values.value(index_val) as u8) << bit;
                     } else {
-                        // SAFETY: base + bit < len (remainder loop bound), so base + bit is a
-                        // valid position in the indices array.
-                        unsafe { indices.value_unchecked(base + bit) }.as_usize()
-                    } + src_offset;
-                    // SAFETY: src_idx = index_value + src_offset is a valid bit position in the
-                    // values buffer. When CHECKED=true, check_bounds verified every index value is
-                    // < values.len() before this function was called. When CHECKED=false, the caller
-                    // upholds that invariant.
-                    byte |= unsafe { pack_bit(src_ptr, src_idx, bit) };
+                        // SAFETY: caller guarantees index_val < values.len().
+                        byte |= unsafe { pack_bit(src_ptr, index_val + src_offset, bit) };
+                    }
                 }
                 out_slice[full_bytes] = byte;
             }
@@ -592,30 +594,40 @@ fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
 
     match indices.nulls().filter(|nulls| nulls.null_count() > 0) {
         Some(index_nulls) => {
-            // Vec is pre-zeroed; only set bits for valid indices via raw pointer.
             let value_out_ptr = value_out.as_mut_ptr();
             let validity_out_ptr = validity_out.as_mut_ptr();
             for out_pos in index_nulls.valid_indices() {
                 let src_idx = if CHECKED {
                     indices.value(out_pos).as_usize()
                 } else {
-                    // SAFETY: out_pos < len (validity bitmap); caller guarantees index values are in bounds when CHECKED=false
+                    // SAFETY: out_pos < indices.len(), guaranteed by valid_indices().
                     unsafe { indices.value_unchecked(out_pos) }.as_usize()
                 };
-                // SAFETY: src_idx < values.len();
-                unsafe {
-                    copy_bit_if_set(
-                        value_data_ptr,
-                        src_idx + value_bit_offset,
-                        value_out_ptr,
-                        out_pos,
-                    );
-                    copy_bit_if_set(
-                        validity_data_ptr,
-                        src_idx + validity_bit_offset,
-                        validity_out_ptr,
-                        out_pos,
-                    );
+                if CHECKED {
+                    if values.value(src_idx) {
+                        // SAFETY: out_pos < indices.len() = len, output buffer holds len bits.
+                        unsafe { bit_util::set_bit_raw(value_out_ptr, out_pos) };
+                    }
+                    if validity.value(src_idx) {
+                        // SAFETY: out_pos < indices.len() = len, output buffer holds len bits.
+                        unsafe { bit_util::set_bit_raw(validity_out_ptr, out_pos) };
+                    }
+                } else {
+                    // SAFETY: caller guarantees src_idx < values.len().
+                    unsafe {
+                        copy_bit_if_set(
+                            value_data_ptr,
+                            src_idx + value_bit_offset,
+                            value_out_ptr,
+                            out_pos,
+                        );
+                        copy_bit_if_set(
+                            validity_data_ptr,
+                            src_idx + validity_bit_offset,
+                            validity_out_ptr,
+                            out_pos,
+                        );
+                    }
                 }
             }
         }
@@ -634,14 +646,24 @@ fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let mut packed_values = 0u8;
                 let mut packed_validity = 0u8;
                 for bit_pos in 0..8usize {
-                    // SAFETY: bit_base + bit_pos < len
-                    let src_idx = unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
-                    // SAFETY: src_idx < values.len(); check_bounds ensures this when CHECKED, caller guarantees it otherwise
-                    packed_values |=
-                        unsafe { pack_bit(value_data_ptr, src_idx + value_bit_offset, bit_pos) };
-                    packed_validity |= unsafe {
-                        pack_bit(validity_data_ptr, src_idx + validity_bit_offset, bit_pos)
+                    let src_idx = if CHECKED {
+                        indices.value(bit_base + bit_pos).as_usize()
+                    } else {
+                        // SAFETY: bit_base + bit_pos < full_bytes * 8 <= len.
+                        unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize()
                     };
+                    if CHECKED {
+                        packed_values |= (values.value(src_idx) as u8) << bit_pos;
+                        packed_validity |= (validity.value(src_idx) as u8) << bit_pos;
+                    } else {
+                        // SAFETY: caller guarantees src_idx < values.len().
+                        packed_values |= unsafe {
+                            pack_bit(value_data_ptr, src_idx + value_bit_offset, bit_pos)
+                        };
+                        packed_validity |= unsafe {
+                            pack_bit(validity_data_ptr, src_idx + validity_bit_offset, bit_pos)
+                        };
+                    }
                 }
                 *value_out_byte = packed_values;
                 *validity_out_byte = packed_validity;
@@ -652,14 +674,24 @@ fn take_bits_with_validity<I: ArrowPrimitiveType, const CHECKED: bool>(
                 let mut packed_values = 0u8;
                 let mut packed_validity = 0u8;
                 for bit_pos in 0..(len - bit_base) {
-                    // SAFETY: bit_base + bit_pos < len
-                    let src_idx = unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize();
-                    // SAFETY: src_idx < values.len(); check_bounds ensures this when CHECKED, caller guarantees it otherwise
-                    packed_values |=
-                        unsafe { pack_bit(value_data_ptr, src_idx + value_bit_offset, bit_pos) };
-                    packed_validity |= unsafe {
-                        pack_bit(validity_data_ptr, src_idx + validity_bit_offset, bit_pos)
+                    let src_idx = if CHECKED {
+                        indices.value(bit_base + bit_pos).as_usize()
+                    } else {
+                        // SAFETY: bit_base + bit_pos < len (remainder loop bound).
+                        unsafe { indices.value_unchecked(bit_base + bit_pos) }.as_usize()
                     };
+                    if CHECKED {
+                        packed_values |= (values.value(src_idx) as u8) << bit_pos;
+                        packed_validity |= (validity.value(src_idx) as u8) << bit_pos;
+                    } else {
+                        // SAFETY: caller guarantees src_idx < values.len().
+                        packed_values |= unsafe {
+                            pack_bit(value_data_ptr, src_idx + value_bit_offset, bit_pos)
+                        };
+                        packed_validity |= unsafe {
+                            pack_bit(validity_data_ptr, src_idx + validity_bit_offset, bit_pos)
+                        };
+                    }
                 }
                 value_out_slice[full_bytes] = packed_values;
                 validity_out_slice[full_bytes] = packed_validity;
@@ -1983,6 +2015,14 @@ mod tests {
         let result = result.as_any().downcast_ref::<BooleanArray>().unwrap();
         let expected = BooleanArray::from(vec![Some(false), None, None, Some(false)]);
         assert_eq!(result, &expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: idx < self.bit_len")]
+    fn test_take_bool_oob_no_check_bounds_panics() {
+        let array = BooleanArray::from(vec![true, false, true]);
+        let indices = Int32Array::from(vec![0, 1, 10]);
+        take(&array, &indices, None).unwrap();
     }
 
     fn _test_take_string<'a, K>()

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -669,7 +669,8 @@ fn take_boolean<IndexType: ArrowPrimitiveType, const CHECKED: bool>(
     let bits = array.values();
     match array.nulls().filter(|n| n.null_count() > 0) {
         Some(array_nulls) => {
-            let (val_buf, null_buf) = take_bits_with_validity::<_, CHECKED>(bits, array_nulls.inner(), indices);
+            let (val_buf, null_buf) =
+                take_bits_with_validity::<_, CHECKED>(bits, array_nulls.inner(), indices);
             BooleanArray::new(val_buf, null_buf)
         }
         None => {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- works towards #8879.

# Rationale for this change
take on boolean arrays was slower than necessary: the nullable path called take_bits twice (once for values, once for validity), and the non-nullable path used high-level accessors that prevented the compiler from issuing parallel loads.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- `take_bits`: rewrites the None-nulls path to build output one byte at a time with an 8-element inner loop, letting the compiler fully unroll it and issue 8 source loads in parallel. Branches on the CHECKED const generic to use value_unchecked when bounds are already guaranteed by the caller.
- `take_bits_with_validity`: new single-pass helper that gathers value bits and validity bits together when the source boolean array itself has nulls, avoiding the previous double traversal.
- `take_boolean`: updated to use take_bits_with_validity in the nullable case.
- ~~`take_record_batch_unchecked`: new pub unsafe counterpart to `take_record_batch` that calls `take_impl::<_, false>` directly, allowing us to use unsafe accessor methods~~
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes, I added new several boolean test

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
~~yes new public method. `take_record_batch_unchecked()`~~

none
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
