### PR TITLE
Fix BinaryViewArray construction after buffer ownership API change

### DIFF
--- a/parquet-variant-compute/src/variant_array_builder.rs
+++ b/parquet-variant-compute/src/variant_array_builder.rs
@@ -474,7 +474,7 @@ fn binary_view_array_from_buffers(buffer: Vec<u8>, offsets: Vec<usize>) -> Binar
 
     // SAFETY: `make_view` constructs every view from an in-bounds slice of buffer 0, and there
     // are no nulls. The buffer length check above guarantees every offset fits in a `u32`.
-    unsafe { BinaryViewArray::new_unchecked(views.into(), vec![buffer], None) }
+    unsafe { BinaryViewArray::new_unchecked(views.into(), vec![buffer].into(), None) }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes the parquet-variant-compute compilation failure introduced when #10708 was merged after #10640.

BinaryViewArray::new_unchecked now expects Arc<[Buffer]>, but the call added by #10640 still passed Vec<Buffer>. This converts the newly constructed buffer vector into the required shared slice.

Verified with:

- cargo fmt --all -- --check
- cargo check -p parquet-variant-compute --all-targets