### PR TITLE
bench(take): add FixedSizeList and Map benchmarks

### DIFF
--- a/arrow/benches/take_kernels.rs
+++ b/arrow/benches/take_kernels.rs
@@ -356,6 +356,68 @@ fn add_benchmark(c: &mut Criterion) {
         "take_record_batch 7 mixed cols null values null indices 1024",
         |b| b.iter(|| bench_take_record_batch(&batch, &indices)),
     );
+
+    // FixedSizeList — list_size=8 (power-of-two) and list_size=22 (arbitrary/dynamic length)
+    let values = create_primitive_fixed_size_list_array::<Int32Type>(1024, 0.0, 0.0, 8);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function("take fixed_size_list<i32>[8] 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_primitive_fixed_size_list_array::<Int32Type>(1024, 0.5, 0.0, 8);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function("take fixed_size_list<i32>[8] null values 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_primitive_fixed_size_list_array::<Int32Type>(1024, 0.0, 0.0, 8);
+    let indices = create_random_index(1024, 0.5);
+    c.bench_function("take fixed_size_list<i32>[8] null indices 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_primitive_fixed_size_list_array::<Int32Type>(1024, 0.0, 0.0, 22);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function("take fixed_size_list<i32>[22] 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_primitive_fixed_size_list_array::<Int32Type>(1024, 0.5, 0.0, 22);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function("take fixed_size_list<i32>[22] null values 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_primitive_fixed_size_list_array::<Int32Type>(1024, 0.0, 0.0, 22);
+    let indices = create_random_index(1024, 0.5);
+    c.bench_function("take fixed_size_list<i32>[22] null indices 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    // Map
+    let values = create_string_map_array::<Int32Type>(512, 0.0, 10, 8);
+    let indices = create_random_index(512, 0.0);
+    c.bench_function("take map<str, i32> 512", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_map_array::<Int32Type>(1024, 0.0, 10, 8);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function("take map<str, i32> 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_map_array::<Int32Type>(1024, 0.5, 10, 8);
+    let indices = create_random_index(1024, 0.0);
+    c.bench_function("take map<str, i32> null values 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_string_map_array::<Int32Type>(1024, 0.0, 10, 8);
+    let indices = create_random_index(1024, 0.5);
+    c.bench_function("take map<str, i32> null indices 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- works towards #10815.

# Rationale for this change
FixedSizeList and Map were absent from the take benchmark suite. having no benchmarks made it impossible to detect regressions or measure the effect of future optimizations.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- FixedSizeList<i32> : list sizes 8 (power-of-two) and 22 (arbitrary/dynamic), each with variants for no nulls, null values, and null indices
- Map<str, i32> : sizes 512 and 1024, with variants for no nulls, null values, and null indices


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
n/a
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
