### PR TITLE
Validate Parquet page size before allocation

### DIFF
--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -586,6 +586,9 @@ pub struct SerializedPageReader<R: ChunkReader> {
     /// Column chunk type.
     physical_type: Type,
 
+    /// Total uncompressed size declared by the containing column chunk.
+    column_uncompressed_size: i64,
+
     state: SerializedPageReaderState,
 
     context: SerializedPageReaderContext,
@@ -690,6 +693,7 @@ impl<R: ChunkReader> SerializedPageReader<R> {
             decompressor,
             state,
             physical_type: meta.column_type(),
+            column_uncompressed_size: meta.uncompressed_size(),
             context,
         })
     }
@@ -915,11 +919,22 @@ fn verify_page_size(
     compressed_size: i32,
     uncompressed_size: i32,
     remaining_bytes: u64,
+    column_uncompressed_size: i64,
 ) -> Result<()> {
     // The page's compressed size should not exceed the remaining bytes that are
     // available to read. The page's uncompressed size is the expected size
     // after decompression, which can never be negative.
-    if compressed_size < 0 || compressed_size as u64 > remaining_bytes || uncompressed_size < 0 {
+    if compressed_size < 0 || compressed_size as u64 > remaining_bytes {
+        return Err(eof_err!("Invalid page header"));
+    }
+    verify_page_uncompressed_size(uncompressed_size, column_uncompressed_size)
+}
+
+fn verify_page_uncompressed_size(
+    uncompressed_size: i32,
+    column_uncompressed_size: i64,
+) -> Result<()> {
+    if uncompressed_size < 0 || i64::from(uncompressed_size) > column_uncompressed_size {
         return Err(eof_err!("Invalid page header"));
     }
     Ok(())
@@ -959,6 +974,7 @@ impl<R: ChunkReader> PageReader for SerializedPageReader<R> {
                         header.compressed_page_size,
                         header.uncompressed_page_size,
                         *remaining,
+                        self.column_uncompressed_size,
                     )?;
                     let data_len = header.compressed_page_size as usize;
                     let data_start = *offset;
@@ -1010,6 +1026,10 @@ impl<R: ChunkReader> PageReader for SerializedPageReader<R> {
                         buffer.as_ref(),
                         *page_index,
                         is_dictionary_page,
+                    )?;
+                    verify_page_uncompressed_size(
+                        header.uncompressed_page_size,
+                        self.column_uncompressed_size,
                     )?;
                     let bytes = buffer.slice(offset..);
                     let bytes =
@@ -1119,6 +1139,7 @@ impl<R: ChunkReader> PageReader for SerializedPageReader<R> {
                         buffered_header.compressed_page_size,
                         buffered_header.uncompressed_page_size,
                         *remaining_bytes,
+                        self.column_uncompressed_size,
                     )?;
                     // The next page header has already been peeked, so just advance the offset
                     *offset += buffered_header.compressed_page_size as u64;
@@ -1136,6 +1157,7 @@ impl<R: ChunkReader> PageReader for SerializedPageReader<R> {
                         header.compressed_page_size,
                         header.uncompressed_page_size,
                         *remaining_bytes,
+                        self.column_uncompressed_size,
                     )?;
                     let data_page_size = header.compressed_page_size as u64;
                     *offset += header_len as u64 + data_page_size;
@@ -1197,10 +1219,12 @@ mod tests {
     use crate::column::reader::ColumnReader;
     use crate::data_type::private::ParquetValueType;
     use crate::data_type::{AsBytes, FixedLenByteArrayType, Int32Type};
-    use crate::file::metadata::thrift::DataPageHeaderV2;
+    use crate::file::metadata::thrift::{DataPageHeader, DataPageHeaderV2};
     use crate::file::writer::SerializedFileWriter;
+    use crate::parquet_thrift::{ThriftCompactOutputProtocol, WriteThrift};
     use crate::record::RowAccessor;
     use crate::schema::parser::parse_message_type;
+    use crate::schema::types::SchemaDescriptor;
     use crate::util::test_common::file_util::{get_test_file, get_test_path};
 
     use super::*;
@@ -1233,6 +1257,64 @@ mod tests {
             err.to_string()
                 .contains("DataPage v2 header contains implausible values")
         );
+    }
+
+    #[test]
+    fn test_page_uncompressed_size_exceeds_column_chunk() {
+        let page_header = PageHeader {
+            r#type: PageType::DATA_PAGE,
+            uncompressed_page_size: 1024,
+            compressed_page_size: 1,
+            data_page_header: Some(DataPageHeader {
+                num_values: 0,
+                encoding: Encoding::PLAIN,
+                definition_level_encoding: Encoding::RLE,
+                repetition_level_encoding: Encoding::RLE,
+                statistics: None,
+            }),
+            index_page_header: None,
+            dictionary_page_header: None,
+            crc: None,
+            data_page_header_v2: None,
+        };
+
+        let mut data = Vec::new();
+        page_header
+            .write_thrift(&mut ThriftCompactOutputProtocol::new(&mut data))
+            .unwrap();
+        data.push(0);
+
+        let schema =
+            Arc::new(parse_message_type("message schema { REQUIRED INT32 value; }").unwrap());
+        let schema = SchemaDescriptor::new(schema);
+        let metadata = ColumnChunkMetaData::builder(schema.column(0))
+            // An invalid Snappy payload ensures this test only observes the expected error if
+            // the page size is rejected before allocating a decompression buffer.
+            .set_compression(basic::Compression::SNAPPY)
+            .set_encodings(vec![Encoding::PLAIN, Encoding::RLE])
+            .set_num_values(0)
+            .set_total_compressed_size(data.len() as i64)
+            .set_total_uncompressed_size(data.len() as i64)
+            .set_data_page_offset(0)
+            .build()
+            .unwrap();
+
+        let page_location = PageLocation {
+            offset: 0,
+            compressed_page_size: data.len() as i32,
+            first_row_index: 0,
+        };
+        for page_locations in [None, Some(vec![page_location])] {
+            let mut reader = SerializedPageReader::new(
+                Arc::new(Bytes::from(data.clone())),
+                &metadata,
+                0,
+                page_locations,
+            )
+            .unwrap();
+            let error = reader.get_next_page().unwrap_err();
+            assert!(error.to_string().contains("Invalid page header"));
+        }
     }
 
     #[test]

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1698,12 +1698,14 @@ mod tests {
 
         let mut buffer: Vec<u8> = vec![];
         let mut result_pages: Vec<Page> = vec![];
+        let mut total_uncompressed_size = 0;
         {
             let mut writer = TrackedWrite::new(&mut buffer);
             let mut page_writer = SerializedPageWriter::new(&mut writer);
 
             for page in compressed_pages {
-                page_writer.write_page(page).unwrap();
+                let page_spec = page_writer.write_page(page).unwrap();
+                total_uncompressed_size += page_spec.uncompressed_size as i64;
             }
             page_writer.close().unwrap();
         }
@@ -1718,6 +1720,7 @@ mod tests {
             let meta = ColumnChunkMetaData::builder(Arc::new(desc))
                 .set_compression_codec(codec.into())
                 .set_total_compressed_size(reader.len() as i64)
+                .set_total_uncompressed_size(total_uncompressed_size)
                 .set_num_values(total_num_values)
                 .build()
                 .unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10734.

# Rationale for this change

`SerializedPageReader` validates a page's compressed size against the bytes remaining in its column chunk, but previously only checked that `uncompressed_page_size` was non-negative. `decode_page` then used that untrusted value as a `Vec` capacity before decompression could detect a mismatch.

Parquet's column metadata already supplies a structural bound: one page's uncompressed payload cannot exceed the column chunk's total uncompressed size, which includes every page and its header. Checking that invariant before decode rejects an inconsistent file without introducing a configurable limit for valid large pages.

# What changes are included in this PR?

- Retain the column chunk's declared uncompressed size in `SerializedPageReader`.
- Validate each page's uncompressed size before decode in both the sequential and offset-index paths.
- Populate required total-uncompressed-size metadata in two page-writer test fixtures that construct column metadata directly.

# Are these changes tested?

Yes. The regression constructs a tiny invalid Snappy page and verifies that both reader paths return `Invalid page header` before decompression. The compressed payload is intentionally invalid, so reaching the codec would produce a different error.

Commands run:

- `cargo test -p parquet`
- `cargo clippy -p parquet --all-targets --all-features -- -D warnings`
- `cargo +stable fmt --all -- --check`
- `git diff --check`

# Are there any user-facing changes?

Malformed Parquet files whose page uncompressed size exceeds their column chunk total now return an error before allocating a decompression buffer. There is no public API change.

# AI usage

Codex assisted with tracing the reader paths, constructing the regression test, and drafting the change. I reviewed the Parquet metadata invariant, inspected every changed line, ran the checks above, and can debug and own the final patch.
