### PR TITLE
[59_maintenance] Backport `cargo audit` fix by updating `h2` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
# Which issue does this PR close?

- part of https://github.com/apache/arrow-rs/issues/10738

# Rationale for this change

Backport the `cargo audit` fix ([RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258), unbounded empty DATA frames in `h2`) to the `59_maintenance` branch so it is included in the 59.3.0 release.

# What changes are included in this PR?

Backport / Cherry-pick:
- https://github.com/apache/arrow-rs/pull/10740

Note the `59_maintenance` branch had `h2` 0.4.14 (`main` had 0.4.15), so this updates `Cargo.lock` directly to `h2` 0.4.16 rather than a clean cherry-pick.

# Are these changes tested?

By CI

# Are there any user-facing changes?

No
