### PR TITLE
bench: cover sparse and dense run-index selections

### DIFF
--- a/arrow-buffer/Cargo.toml
+++ b/arrow-buffer/Cargo.toml
@@ -62,6 +62,10 @@ name = "offset"
 harness = false
 
 [[bench]]
+name = "run_end_buffer"
+harness = false
+
+[[bench]]
 name = "mutable_buffer_repeat_slice"
 harness = false
 

--- a/arrow-buffer/benches/run_end_buffer.rs
+++ b/arrow-buffer/benches/run_end_buffer.rs
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_buffer::RunEndBuffer;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+fn get_physical_indices(c: &mut Criterion) {
+    let mut group = c.benchmark_group("get_physical_indices");
+
+    for run_count in [1_024, 1_048_576] {
+        let run_ends = (1..=run_count as i32).collect::<Vec<_>>();
+        let buffer = RunEndBuffer::new(run_ends.into(), 0, run_count);
+        let indices = [0_u32, 2];
+
+        for (name, buffer) in [
+            ("prefix", buffer.clone()),
+            ("sliced_prefix", buffer.slice(run_count / 2, 3)),
+        ] {
+            group.bench_with_input(BenchmarkId::new(name, run_count), &buffer, |b, buffer| {
+                b.iter(|| {
+                    black_box(buffer)
+                        .get_physical_indices(black_box(&indices))
+                        .unwrap()
+                })
+            });
+        }
+
+        let indices = (0..run_count as u32).collect::<Vec<_>>();
+        group.bench_with_input(
+            BenchmarkId::new("all_indices", run_count),
+            &buffer,
+            |b, buffer| {
+                b.iter(|| {
+                    black_box(buffer)
+                        .get_physical_indices(black_box(&indices))
+                        .unwrap()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, get_physical_indices);
+criterion_main!(benches);

--- a/arrow-buffer/benches/run_end_buffer.rs
+++ b/arrow-buffer/benches/run_end_buffer.rs
@@ -22,7 +22,7 @@ use std::hint::black_box;
 fn get_physical_indices(c: &mut Criterion) {
     let mut group = c.benchmark_group("get_physical_indices");
 
-    for run_count in [1_024, 1_048_576] {
+    for run_count in [32, 1_024, 1_048_576] {
         let run_ends = (1..=run_count as i32).collect::<Vec<_>>();
         let buffer = RunEndBuffer::new(run_ends.into(), 0, run_count);
         let indices = [0_u32, 2];
@@ -40,18 +40,50 @@ fn get_physical_indices(c: &mut Criterion) {
             });
         }
 
-        let indices = (0..run_count as u32).collect::<Vec<_>>();
-        group.bench_with_input(
-            BenchmarkId::new("all_indices", run_count),
-            &buffer,
-            |b, buffer| {
+        let last = run_count as u32 - 1;
+        for (name, indices) in [
+            ("last_single", vec![last]),
+            ("last_pair", vec![last - 1, last]),
+            ("prefix_eight", (0..8).collect()),
+            (
+                "distant_eight",
+                (0..8).map(|index| index * last / 7).collect(),
+            ),
+            ("prefix_nine", (0..9).collect()),
+            ("all_indices", (0..run_count as u32).collect()),
+        ] {
+            group.bench_with_input(BenchmarkId::new(name, run_count), &buffer, |b, buffer| {
                 b.iter(|| {
                     black_box(buffer)
                         .get_physical_indices(black_box(&indices))
                         .unwrap()
                 })
-            },
-        );
+            });
+        }
+    }
+
+    // Check the lookup-count and remaining-run boundaries with a large backing buffer.
+    let run_count = 1_048_576;
+    let run_ends = (1..=run_count as i32).collect::<Vec<_>>();
+    let buffer = RunEndBuffer::new(run_ends.into(), 0, run_count);
+    for remaining_runs in [1_023, 1_024, 1_025] {
+        let sliced = buffer.slice(run_count - remaining_runs, remaining_runs);
+        for (name, index_count) in [("sliced_distant_eight", 8), ("sliced_distant_nine", 9)] {
+            let indices = (0..index_count)
+                .map(|index| index * (remaining_runs as u32 - 1) / (index_count - 1))
+                .collect::<Vec<_>>();
+            group.bench_with_input(
+                BenchmarkId::new(name, remaining_runs),
+                &sliced,
+                |b, buffer| {
+                    b.iter(|| {
+                        black_box(buffer)
+                            .get_physical_indices(black_box(&indices))
+                            .unwrap()
+                    })
+                },
+            );
+        }
     }
 
     group.finish();


### PR DESCRIPTION
## Why are the changes needed?

### Which issue does this PR close?

Related to https://github.com/apache/arrow-rs/issues/10846. The implementation is in https://github.com/apache/arrow-rs/pull/10849.

### Rationale for this change

Mapping a few logical indices can scan a large run-end backing buffer after all requested outputs are known. Changing lookup strategies also needs controls for late selections, full selections, and the dispatch boundaries.

## What changes were proposed in this PR?

### What changes are included in this PR?

Add 30 Criterion cases:

- Prefix, sliced prefix, last single/pair, eight-index prefix/distant, nine-index prefix, and all-index selections at 32, 1,024, and 1,048,576 physical runs.
- Eight/nine distant indices from slices with 1,023, 1,024, and 1,025 remaining physical runs in a 1,048,576-run backing buffer.

Inputs are constructed outside the timed loop and passed through `black_box`. This separate benchmark PR follows the contributor guide's benchmark-first workflow.

### Are there any user-facing changes?

This PR adds benchmarks only.

## How was this PR tested?

### Are these changes tested?

- All 30 cases ran twice on the original implementation at `900ec3ee38276ab651e210c4a85b38f8a8a61bcf`, with this benchmark added, and twice with the companion implementation.
- `cargo +1.97.1 bench --locked -p arrow-buffer --bench run_end_buffer --no-run` passed.
- `cargo +1.97.1 clippy --locked -p arrow-buffer --all-targets --all-features -- -D warnings` passed.
- `cargo +1.97.1 fmt --all -- --check` passed.

Measurements used independent build directories, distinct verified binaries, one pinned CPU, and sequential base/head/head/base execution on a shared x86_64 Linux host. Results and remaining performance limitations are described in #10849. Automated-runner validation remains outstanding.

AI assistance: Codex generated the benchmark and PR text, reviewed the changes, and performed the stated local checks. No separate human review is claimed.
