### PR TITLE
perf: use binary search for small run-index selections

### DIFF
--- a/arrow-buffer/src/buffer/run.rs
+++ b/arrow-buffer/src/buffer/run.rs
@@ -351,11 +351,13 @@ where
 
         // Skip some physical indices based on offset.
         let skip_value = self.get_start_physical_index();
+        // Stop at the run containing the largest requested logical index.
+        let end = self.get_physical_index(largest_logical_index) + 1;
 
         let mut physical_indices = vec![0; indices_len];
 
         let mut ordered_index = 0_usize;
-        for (physical_index, run_end) in self.values().iter().enumerate().skip(skip_value) {
+        for (physical_index, run_end) in self.values()[..end].iter().enumerate().skip(skip_value) {
             // Get the run end index (relative to offset) of current physical index
             let run_end_value = run_end.as_usize() - offset;
 
@@ -381,6 +383,17 @@ where
 #[cfg(test)]
 mod tests {
     use crate::buffer::RunEndBuffer;
+
+    #[test]
+    fn test_get_physical_indices_prefix() {
+        let buffer = RunEndBuffer::new(vec![2_i32, 4, 7, 9].into(), 0, 9);
+        assert_eq!(buffer.get_physical_indices(&[2, 0, 2]).unwrap(), [1, 0, 1]);
+
+        let sliced = buffer.slice(1, 3);
+        assert_eq!(sliced.get_physical_indices(&[2, 0, 2]).unwrap(), [1, 0, 1]);
+        assert_eq!(sliced.get_physical_indices(&[3, 0]), Err(3));
+        assert_eq!(sliced.get_physical_indices(&[-1, 0]), Err(-1));
+    }
 
     #[test]
     fn test_zero_length_slice() {

--- a/arrow-buffer/src/buffer/run.rs
+++ b/arrow-buffer/src/buffer/run.rs
@@ -305,11 +305,11 @@ where
     /// Given a slice of logical indices, this method returns a `Vec` containing the
     /// corresponding physical indices into the run-ends buffer.
     ///
-    /// This method operates by iterating the logical indices in sorted order, instead of
-    /// finding the physical index for each logical index using binary search via
-    /// the function [`RunEndBuffer::get_physical_index`].
+    /// This method sorts the logical indices and uses binary search via
+    /// [`RunEndBuffer::get_physical_index`] for small selections over large remaining
+    /// buffers. Other selections use a sequential scan of the physical runs.
     ///
-    /// Running benchmarks on both approaches showed that the approach used here
+    /// Running benchmarks on both approaches showed that the sequential scan
     /// scaled well for larger inputs.
     ///
     /// See <https://github.com/apache/arrow-rs/pull/3622#issuecomment-1407753727> for more details.
@@ -351,13 +351,25 @@ where
 
         // Skip some physical indices based on offset.
         let skip_value = self.get_start_physical_index();
-        // Stop at the run containing the largest requested logical index.
-        let end = self.get_physical_index(largest_logical_index) + 1;
+
+        // Avoid walking a large backing buffer for a small number of lookups.
+        // Keep the sequential scan for larger selections and small buffers.
+        if indices_len <= 8 && self.values().len() - skip_value >= 1024 {
+            let mut physical_indices = vec![0; indices_len];
+            for &index in &ordered_indices {
+                let logical_index = logical_indices[index].as_usize();
+                if logical_index >= len {
+                    return Err(logical_indices[index]);
+                }
+                physical_indices[index] = self.get_physical_index(logical_index);
+            }
+            return Ok(physical_indices);
+        }
 
         let mut physical_indices = vec![0; indices_len];
 
         let mut ordered_index = 0_usize;
-        for (physical_index, run_end) in self.values()[..end].iter().enumerate().skip(skip_value) {
+        for (physical_index, run_end) in self.values().iter().enumerate().skip(skip_value) {
             // Get the run end index (relative to offset) of current physical index
             let run_end_value = run_end.as_usize() - offset;
 
@@ -382,7 +394,61 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::ArrowNativeType;
     use crate::buffer::RunEndBuffer;
+
+    #[test]
+    fn test_get_physical_indices_small_selections() {
+        fn check<E: ArrowNativeType>() {
+            let mut expanded = Vec::new();
+            let mut run_ends = Vec::new();
+            for run in 0..2048 {
+                expanded.extend(std::iter::repeat_n(run, 1 + run % 3));
+                run_ends.push(E::from_usize(expanded.len()).unwrap());
+            }
+            let buffer = RunEndBuffer::new(run_ends.into(), 0, expanded.len());
+
+            // Include boundaries, offsets inside runs, and a short tail of a
+            // large backing buffer. Physical indices stay absolute.
+            for (start_run, offset_in_run) in [
+                (0, 0),
+                (1, 0),
+                (1, 1),
+                (1024, 0),
+                (1024, 1),
+                (1025, 0),
+                (2046, 0),
+            ] {
+                let offset =
+                    expanded.iter().position(|&run| run == start_run).unwrap() + offset_in_run;
+                for length in [1, 3, expanded.len() - offset] {
+                    let sliced = buffer.slice(offset, length);
+                    for count in [1, 2, 8, 9] {
+                        let indices = (0..count)
+                            .map(|i| ((i * 17 + length - 1) % length) as u32)
+                            .collect::<Vec<_>>();
+                        let expected = indices
+                            .iter()
+                            .map(|&i| expanded[offset + i as usize])
+                            .collect::<Vec<_>>();
+                        assert_eq!(sliced.get_physical_indices(&indices), Ok(expected));
+                    }
+
+                    // Preserve signed-index errors and the largest-index check.
+                    assert_eq!(sliced.get_physical_indices(&[-1_i32, 0]), Err(-1));
+                    assert_eq!(sliced.get_physical_indices(&[-2_i32, -1]), Err(-1));
+                    assert_eq!(
+                        sliced.get_physical_indices(&[-1_i32, length as i32]),
+                        Err(length as i32)
+                    );
+                }
+            }
+        }
+
+        check::<i16>();
+        check::<i32>();
+        check::<i64>();
+    }
 
     #[test]
     fn test_get_physical_indices_prefix() {


### PR DESCRIPTION
## Why are the changes needed?

### Which issue does this PR close?

Addresses the small-selection cases in https://github.com/apache/arrow-rs/issues/10846. Benchmark coverage is supplied separately in https://github.com/apache/arrow-rs/pull/10848. Larger sparse selections remain outside this optimization's scope.

### Rationale for this change

Selecting two early rows, a short logical slice, or the last row of a large run-end array can traverse a large physical backing buffer. For a few requested indices, individual binary searches avoid that scan.

**Draft status:** the sparse path has strong local results, but performance still needs validation on an automated runner and the original regression host. Full-selection results from an earlier local harness varied with execution order; the published benchmark now has late-selection and dispatch-boundary controls. This PR does not claim a universal no-regression result.

## What changes were proposed in this PR?

### What changes are included in this PR?

- Use per-index binary search for at most eight requested indices when at least 1,024 physical runs remain after the logical offset.
- Retain the original sequential scan for other selections. Counting remaining runs avoids applying the sparse path to a small tail of a large backing buffer.
- Preserve the existing sort and largest-index validation; check each sparse index before searching to retain signed-index error behavior.
- Add coverage across `i16`, `i32`, and `i64` run ends, reordered/duplicate requests, slices starting inside runs, absolute physical indices, and both dispatch thresholds.

The cutoffs are conservative heuristics, with benchmark controls at eight/nine indices and 1,023/1,024/1,025 remaining runs. The sequential loop is unchanged from the original implementation.

### Are there any user-facing changes?

Tiny early, late, and distant selections avoid walking a large backing buffer. Results, ordering, duplicates, slice handling, bounds errors, and the public API are preserved. Selections with more than eight indices continue to use the original scan.

## How was this PR tested?

### Are these changes tested?

- `cargo +1.97.1 test --locked -p arrow-buffer --lib`: 346 passed.
- `cargo +1.97.1 test --locked -p arrow-array --lib get_physical_indices`: 2 passed.
- `cargo +1.97.1 test --locked -p arrow-select --lib run`: 28 passed.
- `cargo +1.97.1 clippy --locked -p arrow-buffer --all-targets --all-features -- -D warnings`: passed.
- `cargo +1.97.1 fmt --all -- --check`: passed.
- Independent source review found no correctness blocker.

All 30 cases in benchmark commit `85d2aa875ea6f52e72d25300bde9d873095e38ac` ran twice on original `900ec3ee38276ab651e210c4a85b38f8a8a61bcf` and twice on this implementation (`98203ab30a5723426e29665948694e09e3366de9`). The same benchmark was applied to both versions. Builds used independent target directories and distinct verified binaries. Runs were sequential, pinned to one CPU on a shared x86_64 Linux host, in base/head/head/base order, using Rust 1.97.1, 30 samples, 0.2-second warmup, and 0.6-second measurement time.

Ranges below span the two run means:

| Selection | Original | This PR |
| --- | ---: | ---: |
| Two early rows, 1,048,576 runs | 674–688 us | 124–126 ns |
| Last row, 1,048,576 runs | 1.015–1.019 ms | 108–109 ns |
| Eight distant rows, 1,048,576 runs | 1.018–1.021 ms | 527–533 ns |
| Eight distant rows, near-end slice with 1,024 remaining runs | 1.161–1.171 us | 445–449 ns |
| All rows, 1,048,576 runs | 17.605–18.001 ms | 17.675–18.125 ms |

The full-selection paired differences were +0.7% and +0.4%. Small-buffer timings differed by a few nanoseconds; the eight-index prefix at 32 runs measured +1.7% and +6.1%. An earlier separate harness produced full-selection differences from +13% to -3%, so broader performance validation remains outstanding. End-to-end query performance has not been measured.

AI assistance: Codex generated the implementation, regression tests, benchmarks, and PR text, reviewed the code, and performed the stated local checks. No separate human review is claimed.
