### PR TITLE
(arrow-row) Replace BufferBuilder with Vec in decode_binary

### DIFF
--- a/arrow-row/src/variable.rs
+++ b/arrow-row/src/variable.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use crate::null_sentinel;
-use arrow_array::builder::BufferBuilder;
 use arrow_array::types::ByteArrayType;
 use arrow_array::*;
 use arrow_buffer::bit_util::ceil;
@@ -284,14 +283,14 @@ pub fn decode_binary<I: OffsetSizeTrait>(
     let nulls = decode_nulls_sentinel(rows, options);
 
     let values_capacity = rows.iter().map(|row| decoded_len(row, options)).sum();
-    let mut offsets = BufferBuilder::<I>::new(len + 1);
-    offsets.append(I::zero());
+    let mut offsets = Vec::<I>::with_capacity(len + 1);
+    offsets.push(I::zero());
     let mut values = MutableBuffer::new(values_capacity);
 
     for row in rows {
         let offset = decode_blocks(row, options, |b| values.extend_from_slice(b));
         *row = &row[offset..];
-        offsets.append(I::from_usize(values.len()).expect("offset overflow"))
+        offsets.push(I::from_usize(values.len()).expect("offset overflow"))
     }
 
     if options.descending {


### PR DESCRIPTION
# Which issue does this PR close?

- Part of #10245.

# Rationale for this change

This replaces one of the remaining `BufferBuilder` callsites listed in #10245. Using `Vec` for the offsets avoids the builder overhead while preserving the resulting `ScalarBuffer`.

# What changes are included in this PR?

`decode_binary` now constructs its offsets with `Vec<I>` instead of `BufferBuilder<I>`.

# Are these changes tested?

Yes:

- `cargo fmt --all -- --check`
- `cargo test -p arrow-row` — 95 unit tests and 8 doc tests passed
- `cargo clippy -p arrow-row --all-targets --all-features -- -D warnings`

Existing round-trip tests cover the changed path, so no new tests were added.

Benchmark: `convert_rows 4096 string(100, 0)`

| | Time |
| --- | ---: |
| `main` | 47.769 µs |
| This PR | 45.488 µs |

Criterion reported a 4.4% improvement.

# Are there any user-facing changes?

No.

# AI assistance

Codex was used to identify the callsite, prepare the focused refactor, run validation, and draft this description.
