### PR TITLE
perf(parquet): cache dictionary key lookups when writing dictionary arrays

### DIFF
--- a/parquet/src/arrow/arrow_writer/byte_array.rs
+++ b/parquet/src/arrow/arrow_writer/byte_array.rs
@@ -31,10 +31,11 @@ use crate::schema::types::ColumnDescPtr;
 use crate::util::bit_util::num_required_bits;
 use crate::util::interner::{Interner, Storage};
 use crate::util::prefix::common_prefix_length;
-use arrow_array::types::ByteArrayType;
+use arrow_array::types::{ArrowDictionaryKeyType, ByteArrayType};
 use arrow_array::{
     Array, ArrayAccessor, BinaryArray, BinaryViewArray, DictionaryArray, FixedSizeBinaryArray,
     GenericByteArray, LargeBinaryArray, LargeStringArray, StringArray, StringViewArray,
+    TypedDictionaryArray,
 };
 use arrow_buffer::{ArrowNativeType, Buffer};
 use arrow_schema::DataType;
@@ -66,8 +67,12 @@ macro_rules! downcast_dict_op {
     };
 }
 
+/// Downcasts `$array` to its concrete byte-array type and applies an operation.
+///
+/// Dictionary-typed arrays go to `$dict_op` rather than `$op`, so the callee can
+/// see the dictionary keys instead of a flattened [`ArrayAccessor`].
 macro_rules! downcast_op {
-    ($data_type:expr, $array:ident, $op:expr $(, $arg:expr)*) => {
+    ($data_type:expr, $array:ident, $op:expr, $dict_op:expr $(, $arg:expr)*) => {
         match $data_type {
             DataType::Utf8 => $op($array.as_any().downcast_ref::<StringArray>().unwrap()$(, $arg)*),
             DataType::LargeUtf8 => {
@@ -84,22 +89,22 @@ macro_rules! downcast_op {
                 $op($array.as_any().downcast_ref::<BinaryViewArray>().unwrap()$(, $arg)*)
             }
             DataType::Dictionary(key, value) => match value.as_ref() {
-                DataType::Utf8 => downcast_dict_op!(key, StringArray, $array, $op$(, $arg)*),
+                DataType::Utf8 => downcast_dict_op!(key, StringArray, $array, $dict_op$(, $arg)*),
                 DataType::LargeUtf8 => {
-                    downcast_dict_op!(key, LargeStringArray, $array, $op$(, $arg)*)
+                    downcast_dict_op!(key, LargeStringArray, $array, $dict_op$(, $arg)*)
                 }
                 DataType::Utf8View => {
-                    downcast_dict_op!(key, StringViewArray, $array, $op$(, $arg)*)
+                    downcast_dict_op!(key, StringViewArray, $array, $dict_op$(, $arg)*)
                 }
-                DataType::Binary => downcast_dict_op!(key, BinaryArray, $array, $op$(, $arg)*),
+                DataType::Binary => downcast_dict_op!(key, BinaryArray, $array, $dict_op$(, $arg)*),
                 DataType::LargeBinary => {
-                    downcast_dict_op!(key, LargeBinaryArray, $array, $op$(, $arg)*)
+                    downcast_dict_op!(key, LargeBinaryArray, $array, $dict_op$(, $arg)*)
                 }
                 DataType::BinaryView => {
-                    downcast_dict_op!(key, BinaryViewArray, $array, $op$(, $arg)*)
+                    downcast_dict_op!(key, BinaryViewArray, $array, $dict_op$(, $arg)*)
                 }
                 DataType::FixedSizeBinary(_) => {
-                    downcast_dict_op!(key, FixedSizeBinaryArray, $array, $op$(, $arg)*)
+                    downcast_dict_op!(key, FixedSizeBinaryArray, $array, $dict_op$(, $arg)*)
                 }
                 d => unreachable!("cannot downcast {} dictionary value to byte array", d),
             },
@@ -335,12 +340,41 @@ impl Storage for ByteArrayStorage {
     }
 }
 
+/// Slots in [`DictEncoder`]'s dictionary-key cache.
+///
+/// A power of two so the index is a mask. At 24 bytes per slot the cache is
+/// 24 KiB and stays cache-resident whatever the input dictionary's size, which
+/// is what lets the lookup be unconditional rather than gated on a heuristic
+/// over the dictionary size or the row count.
+const DICT_KEY_CACHE_SLOTS: usize = 1024;
+
+/// One slot of [`DictEncoder::key_cache`].
+///
+/// `generation` records which [`DictEncoder::encode_dict`] call wrote the slot,
+/// so a new call invalidates the whole cache without clearing it -- necessary
+/// because `dict_key` is only meaningful relative to one input dictionary.
+#[derive(Debug, Clone, Copy, Default)]
+struct DictKeyCacheSlot {
+    generation: u32,
+    /// Byte length of the dictionary value, so a hit needs no access to the
+    /// dictionary at all to maintain `variable_length_bytes`.
+    len: u32,
+    /// The input dictionary key this slot describes.
+    dict_key: usize,
+    /// The key [`Interner::intern`] returned for that dictionary entry.
+    interned: u64,
+}
+
 /// A dictionary encoder for byte array data
 #[derive(Debug, Default)]
 struct DictEncoder {
     interner: Interner<ByteArrayStorage>,
     indices: Vec<u64>,
     variable_length_bytes: i64,
+    /// Direct-mapped cache from *input* dictionary key to interned key, used by
+    /// [`Self::encode_dict`]. Empty until the first dictionary-typed batch.
+    key_cache: Vec<DictKeyCacheSlot>,
+    key_cache_generation: u32,
 }
 
 impl DictEncoder {
@@ -360,13 +394,89 @@ impl DictEncoder {
         }
     }
 
+    /// Encode a dictionary-typed array to the in-progress page.
+    ///
+    /// Produces exactly the same output as [`Self::encode`] on the same logical
+    /// values, but consults a small direct-mapped cache keyed by the *input*
+    /// dictionary key first. The input dictionary has already deduplicated the
+    /// values, so a hit replaces a hash of the value bytes plus a probe of the
+    /// dictionary page with one L1-resident lookup.
+    ///
+    /// The cache is a fixed 6 KiB regardless of the input dictionary's size, so
+    /// this needs no size heuristic: columns whose keys repeat -- either a small
+    /// dictionary or the runs a sorted column produces -- hit nearly always,
+    /// while a column with no repetition simply misses and pays one predictable
+    /// integer comparison per row.
+    ///
+    /// Duplicate and unused dictionary entries stay correct: duplicates intern
+    /// to the same key, unused entries are never interned.
+    fn encode_dict<'a, K, V>(
+        &mut self,
+        values: TypedDictionaryArray<'a, K, V>,
+        indices: impl ExactSizeIterator<Item = usize>,
+    ) where
+        K: ArrowDictionaryKeyType,
+        V: Sync + Send,
+        &'a V: ArrayAccessor,
+        <&'a V as ArrayAccessor>::Item: AsRef<[u8]> + Default,
+    {
+        let keys = values.keys().values();
+        let dict_values = values.values();
+
+        // A new generation invalidates every slot without touching the cache.
+        // On wrap-around, clear so a slot written 2^32 calls ago cannot be read
+        // as live against a different dictionary.
+        self.key_cache_generation = self.key_cache_generation.wrapping_add(1);
+        if self.key_cache_generation == 0 {
+            self.key_cache.clear();
+            self.key_cache_generation = 1;
+        }
+        if self.key_cache.is_empty() {
+            self.key_cache
+                .resize(DICT_KEY_CACHE_SLOTS, DictKeyCacheSlot::default());
+        }
+        let generation = self.key_cache_generation;
+
+        self.indices.reserve(indices.len());
+
+        for idx in indices {
+            // `indices` only ever holds non-null positions, whose keys
+            // `DictionaryArray` validates, so this is always in range.
+            let dict_key = keys[idx].as_usize();
+            let slot = dict_key & (DICT_KEY_CACHE_SLOTS - 1);
+
+            let cached = self.key_cache[slot];
+            let (interned, len) = if cached.generation == generation && cached.dict_key == dict_key
+            {
+                (cached.interned, cached.len)
+            } else {
+                let value = dict_values.value(dict_key);
+                let bytes = value.as_ref();
+                let interned = self.interner.intern(bytes);
+                let len = bytes.len() as u32;
+                self.key_cache[slot] = DictKeyCacheSlot {
+                    generation,
+                    len,
+                    dict_key,
+                    interned,
+                };
+                (interned, len)
+            };
+
+            self.indices.push(interned);
+            self.variable_length_bytes += len as i64;
+        }
+    }
+
     fn bit_width(&self) -> u8 {
         let length = self.interner.storage().values.len();
         num_required_bits(length.saturating_sub(1) as u64)
     }
 
     fn estimated_memory_size(&self) -> usize {
-        self.interner.estimated_memory_size() + self.indices.capacity() * std::mem::size_of::<u64>()
+        self.interner.estimated_memory_size()
+            + self.indices.capacity() * std::mem::size_of::<u64>()
+            + self.key_cache.capacity() * std::mem::size_of::<DictKeyCacheSlot>()
     }
 
     fn estimated_data_page_size(&self) -> usize {
@@ -478,6 +588,7 @@ impl ColumnValueEncoder for ByteArrayEncoder {
             values.data_type(),
             values,
             encode,
+            encode_dict,
             indices.iter().copied(),
             self
         );
@@ -655,6 +766,62 @@ where
     T::Item: Copy + Ord + AsRef<[u8]>,
     I: ExactSizeIterator<Item = usize> + Clone,
 {
+    update_statistics_and_bloom_filter(values, indices.clone(), encoder);
+
+    match &mut encoder.dict_encoder {
+        Some(dict_encoder) => dict_encoder.encode(values, indices),
+        None => encoder.fallback.encode(values, indices),
+    }
+}
+
+/// Encodes the provided dictionary-typed `values` and `indices` to `encoder`
+///
+/// Produces the same output as [`encode`] on the same logical values, but hands
+/// the dictionary keys to [`DictEncoder::encode_dict`] so repeated keys skip
+/// re-interning the value they already resolved to.
+///
+/// This is a free function so it can be used with `downcast_op!`
+fn encode_dict<'a, K, V, I>(
+    values: TypedDictionaryArray<'a, K, V>,
+    indices: I,
+    encoder: &mut ByteArrayEncoder,
+) where
+    K: ArrowDictionaryKeyType,
+    V: Sync + Send,
+    &'a V: ArrayAccessor,
+    <&'a V as ArrayAccessor>::Item: Copy + Ord + AsRef<[u8]> + Default,
+    I: ExactSizeIterator<Item = usize> + Clone,
+{
+    // Once the dictionary page hits its size limit the encoder is dropped and
+    // the rest of the column is written like any other byte array, with nothing
+    // left for the key cache to do. Hand those values back to `encode` rather
+    // than repeating its body here, so the fallback path keeps the shape it has
+    // on `main` -- for a column whose dictionary is abandoned early that is the
+    // overwhelming majority of the rows.
+    if encoder.dict_encoder.is_none() {
+        return encode(values, indices, encoder);
+    }
+
+    update_statistics_and_bloom_filter(values, indices.clone(), encoder);
+
+    match &mut encoder.dict_encoder {
+        Some(dict_encoder) => dict_encoder.encode_dict(values, indices),
+        // Unreachable: checked above, and nothing between here and there can
+        // drop the encoder.
+        None => encoder.fallback.encode(values, indices),
+    }
+}
+
+/// Updates `encoder`'s statistics and bloom filter for the values at `indices`.
+///
+/// Shared by [`encode`] and [`encode_dict`] so the two entry points cannot drift.
+#[inline]
+fn update_statistics_and_bloom_filter<T, I>(values: T, indices: I, encoder: &mut ByteArrayEncoder)
+where
+    T: ArrayAccessor + Copy,
+    T::Item: Copy + Ord + AsRef<[u8]>,
+    I: ExactSizeIterator<Item = usize> + Clone,
+{
     if encoder.statistics_enabled != EnabledStatistics::None {
         if let Some(accumulator) = encoder.geo_stats_accumulator.as_mut() {
             update_geo_stats_accumulator(accumulator.as_mut(), values, indices.clone());
@@ -677,14 +844,9 @@ where
 
     // encode the values into bloom filter if enabled
     if let Some(bloom_filter) = &mut encoder.bloom_filter {
-        for idx in indices.clone() {
+        for idx in indices {
             bloom_filter.insert(values.value(idx).as_ref());
         }
-    }
-
-    match &mut encoder.dict_encoder {
-        Some(dict_encoder) => dict_encoder.encode(values, indices),
-        None => encoder.fallback.encode(values, indices),
     }
 }
 

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -4620,6 +4620,83 @@ mod tests {
     }
 
     #[test]
+    fn arrow_writer_dictionary_key_cache_handles_collisions_and_rebinding() {
+        // `DictEncoder::encode_dict` resolves an input dictionary key through a
+        // direct-mapped cache, so this covers the two ways that cache could hand
+        // back a stale answer: distinct keys landing in the same slot, and a
+        // later batch binding the same key to a different value. Each batch also
+        // carries a duplicate value and an entry no key references, which must
+        // not change what is written.
+        //
+        // Deliberately larger than `DICT_KEY_CACHE_SLOTS` so keys collide; the
+        // test only needs *some* collisions, so it does not track that constant.
+        const KEYS: i32 = 1024;
+
+        fn logical_values(batch: &RecordBatch) -> Vec<Option<String>> {
+            let utf8 = arrow::compute::cast(batch.column(0), &DataType::Utf8).unwrap();
+            let utf8 = utf8.as_any().downcast_ref::<StringArray>().unwrap();
+            (0..utf8.len())
+                .map(|i| utf8.is_valid(i).then(|| utf8.value(i).to_string()))
+                .collect()
+        }
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "d",
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            true,
+        )]));
+
+        let batch = |tag: &str| -> RecordBatch {
+            let mut values: Vec<String> = (0..2 * KEYS).map(|i| format!("{tag}-{i}")).collect();
+            values.push("duplicate".to_string());
+            values.push("duplicate".to_string());
+            values.push("never-referenced".to_string());
+
+            // Alternate k and k + KEYS so both fall in the same cache slot.
+            let mut keys: Vec<Option<i32>> = Vec::new();
+            for k in 0..KEYS {
+                keys.push(Some(k));
+                keys.push(Some(k + KEYS));
+                if k % 97 == 0 {
+                    keys.push(None);
+                    keys.push(Some(2 * KEYS)); // first "duplicate"
+                    keys.push(Some(2 * KEYS + 1)); // second, identical, value
+                }
+            }
+
+            let dict = DictionaryArray::<arrow::datatypes::Int32Type>::try_new(
+                Int32Array::from(keys),
+                Arc::new(StringArray::from(values)),
+            )
+            .unwrap();
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(dict)]).unwrap()
+        };
+
+        let first = batch("first");
+        let second = batch("second");
+        let expected: Vec<Option<String>> = logical_values(&first)
+            .into_iter()
+            .chain(logical_values(&second))
+            .collect();
+
+        let mut buffer = Vec::with_capacity(1024);
+        let mut writer = ArrowWriter::try_new(&mut buffer, schema.clone(), None).unwrap();
+        writer.write(&first).unwrap();
+        writer.write(&second).unwrap();
+        writer.close().unwrap();
+
+        let actual: Vec<Option<String>> =
+            ParquetRecordBatchReader::try_new(Bytes::from(buffer), 1024)
+                .unwrap()
+                .map(|b| b.unwrap())
+                .flat_map(|b| logical_values(&b))
+                .collect();
+
+        assert_eq!(actual.len(), expected.len());
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn arrow_writer_string_dictionary_unsigned_index() {
         // define schema
         #[expect(deprecated)]


### PR DESCRIPTION


# Which issue does this PR close?

N/A — small, self-contained perf fix. Happy to open one if you'd prefer it tracked.

# Rationale for this change

When the input column is already a DictionaryArray, the writer throws that structure away before encoding it. downcast_dict_op! hands a TypedDictionaryArray to encode, which only sees T: ArrayAccessor — so values.value(idx) flattens key → value, and DictEncoder::encode interns once per row. That re-derives, for every row, a mapping the input dictionary already carried: an ahash of the value bytes, a hash table probe, and a byte comparison against the dictionary page.

I found this profiling compaction in GreptimeDB, where mito2 stores each SST's primary key as a Dictionary(UInt32, Binary) column. Rows are sorted by primary key, so keys arrive in long runs — and 82% of the time spent encoding that column was in Interner::intern, re-hashing values the dictionary had already deduplicated.

# What changes are included in this PR?

downcast_op! takes a second op, and the Dictionary arms dispatch to it. The new encode_dict keeps the keys visible and resolves each one through a small direct-mapped cache from input dictionary key to interned key. A hit is one comparison and no hashing; the slot also stores the value length so the loop maintains variable_length_bytes without touching the dictionary at all.

The cache is a fixed 24 KiB regardless of dictionary size, which is what lets the lookup be unconditional. I tried an exact per-dictionary remap table first and it needed a size heuristic to avoid regressing high-cardinality columns — a fixed cache degrades on its own instead: columns whose keys repeat hit nearly always, columns with no repetition miss and pay one predictable integer compare per row.

Slots are generation-stamped so a new call invalidates the cache without clearing it. That's required, not an optimization — a key only means anything relative to one input dictionary, and consecutive batches can carry different ones.

Duplicate and unused dictionary entries stay correct: duplicates intern to the same key, unused entries are never interned.

Statistics and bloom filter updates moved into a shared helper so the two entry points can't drift.

Scope: only Dictionary(_, Utf8 | LargeUtf8 | Binary | LargeBinary | FixedSizeBinary) inputs. All other byte array types keep the existing path, and if parquet dictionary encoding is off the fallback encoder is used as before.

# Are these changes tested?

Existing tests cover the round trips. Added arrow_writer_dictionary_key_cache_handles_collisions_and_rebinding for the two ways a direct-mapped cache can go wrong: keys colliding in the same slot, and a later batch binding the same key to a different value. Removing either the slot tag check or the generation check makes it fail.

arrow_writer benchmarks, 1,048,576 rows per batch. Running two binaries alternately rather than --save-baseline, because this machine drifted ~13% on string_dictionary/zstd over half an hour and the first comparison I did was mostly measuring that:

string_dictionary_low_cardinality_20/default    -47% / -42%
string_dictionary_low_cardinality_20/zstd       -39% / -45%
string_dictionary_low_cardinality_100/default   -36% / -41%
string_dictionary_low_cardinality_400/default   -21% .. -31%
string_dictionary/default                      -3.3% .. -4.9%
string_dictionary/zstd                         -1.5% .. -2.2%
string_dictionary/bloom_filter                 -0.5% / +1.9%

string_dictionary is the high-cardinality case, where the cache mostly misses — it's there to show the miss path doesn't cost anything, not as a win.

# Are there any user-facing changes?

no