### PR TITLE
Replace BufferBuilder with Vec in cast_byte_container

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2832,7 +2832,7 @@ where
     let str_values_buf = data.buffers()[1].clone();
     let offsets = data.buffers()[0].typed_data::<FROM::Offset>();
 
-    let mut offset_builder = BufferBuilder::<TO::Offset>::new(offsets.len());
+    let mut cast_offsets = Vec::<TO::Offset>::with_capacity(offsets.len());
     offsets
         .iter()
         .try_for_each::<_, Result<_, ArrowError>>(|offset| {
@@ -2846,11 +2846,11 @@ where
                         TO::PREFIX
                     ))
                 })?;
-            offset_builder.append(offset);
+            cast_offsets.push(offset);
             Ok(())
         })?;
 
-    let offset_buffer = offset_builder.finish();
+    let offset_buffer = arrow_buffer::Buffer::from_vec(cast_offsets);
 
     let dtype = TO::DATA_TYPE;
 

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -65,7 +65,7 @@ use crate::parse::{
     string_to_datetime,
 };
 use arrow_array::{builder::*, cast::*, temporal_conversions::*, timezone::Tz, types::*, *};
-use arrow_buffer::{ArrowNativeType, OffsetBuffer, i256};
+use arrow_buffer::{ArrowNativeType, Buffer, OffsetBuffer, i256};
 use arrow_data::ArrayData;
 use arrow_data::transform::MutableArrayData;
 use arrow_schema::*;
@@ -2850,7 +2850,7 @@ where
             Ok(())
         })?;
 
-    let offset_buffer = arrow_buffer::Buffer::from_vec(cast_offsets);
+    let offset_buffer = Buffer::from_vec(cast_offsets);
 
     let dtype = TO::DATA_TYPE;
 


### PR DESCRIPTION
# Which issue does this PR close?

- Part of #10245.

# Rationale for this change

This replaces another remaining `BufferBuilder` callsite listed in #10245. Using `Vec` for the converted offsets avoids the builder overhead.

# What changes are included in this PR?

`cast_byte_container` now collects converted offsets in a `Vec<TO::Offset>` and converts it directly into an Arrow `Buffer`.

# Are these changes tested?

Yes:

- `cargo fmt --all -- --check`
- `cargo test -p arrow-cast` — 375 unit tests and 11 doc tests passed
- `cargo clippy -p arrow-cast --all-targets --all-features -- -D warnings`

Existing string and binary cast tests cover the changed path, so no new tests were added.

A temporary local Criterion benchmark for a 512-row `Utf8` to `LargeUtf8` cast produced:

| | Time |
| --- | ---: |
| `main` | 504.35 ns |
| This PR | 403.76 ns |

Criterion reported a 19.9% improvement.

# Are there any user-facing changes?

No.

# AI assistance

Codex was used to identify the callsite, prepare the focused refactor, run validation and benchmarking, and draft this description.
