### PR TITLE
[59_maintenance] Backport parquet-testing revision update for ALP tests

### DIFF
--- a/parquet/tests/arrow_reader/bad_data.rs
+++ b/parquet/tests/arrow_reader/bad_data.rs
@@ -35,6 +35,7 @@ static KNOWN_FILES: &[&str] = &[
     "ARROW-GH-45185.parquet",
     "ARROW-GH-47662.parquet",
     "README.md",
+    "variants",
 ];
 
 /// Returns the path to 'parquet-testing/bad_data'


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Backport https://github.com/apache/arrow-rs/pull/10786 to the `59_maintenance` branch -- so I don't hit an error validating the release
- https://github.com/apache/arrow-rs/issues/10738#issuecomment-5430613192

# What changes are included in this PR?

Cherry-pick of 0e581556e8ba4ec4fff4d1e0ed11d44730b92767 (#10786):
1. Update the `parquet-testing` submodule to `09f3cdbd`
2. Add the new `variants` entry to the known files list in the `bad_data` test

The submodule pointer had a trivial conflict with the revision on `59_maintenance` (`ffdcbb5e`); it was resolved by taking the newer revision from #10786, of which `ffdcbb5e` is an ancestor.

# Are these changes tested?

By CI

# Are there any user-facing changes?

No