### PR TITLE
fix: Correctly decode zero-valued Decimal256s in integration tests

### DIFF
--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -962,10 +962,13 @@ pub fn array_from_json(
                         let str = value.as_str().unwrap();
                         let integer = BigInt::parse_bytes(str.as_bytes(), 10).unwrap();
                         let integer_bytes = integer.to_signed_bytes_le();
-                        let mut bytes = if integer.is_positive() {
-                            [0_u8; 32]
-                        } else {
+                        // Sign-extend the minimal-length two's-complement
+                        // encoding to the full 32 bytes: 0x00 fill for
+                        // non-negative values, 0xFF for negative ones.
+                        let mut bytes = if integer.is_negative() {
                             [255_u8; 32]
+                        } else {
+                            [0_u8; 32]
                         };
                         bytes[0..integer_bytes.len()].copy_from_slice(integer_bytes.as_slice());
                         b.append_value(i256::from_le_bytes(bytes));
@@ -1268,6 +1271,34 @@ impl ArrowJsonBatch {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_decimal256_from_json() {
+        let field = Field::new("c", DataType::Decimal256(76, 0), false);
+        let col: ArrowJsonColumn = serde_json::from_str(
+            r#"{
+                "name": "c",
+                "count": 5,
+                "VALIDITY": [1, 1, 1, 1, 1],
+                "DATA": [
+                    "0",
+                    "1",
+                    "-1",
+                    "123456789012345678901234567890",
+                    "-123456789012345678901234567890"
+                ]
+            }"#,
+        )
+        .unwrap();
+        let arr = array_from_json(&field, col, None).unwrap();
+        let arr = arr.as_any().downcast_ref::<Decimal256Array>().unwrap();
+        assert_eq!(arr.value(0), i256::ZERO);
+        assert_eq!(arr.value(1), i256::from_i128(1));
+        assert_eq!(arr.value(2), i256::from_i128(-1));
+        let big = i256::from_string("123456789012345678901234567890").unwrap();
+        assert_eq!(arr.value(3), big);
+        assert_eq!(arr.value(4), i256::ZERO - big);
+    }
 
     #[test]
     fn test_schema_equality() {


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10872.

# Rationale for this change

The Decimal256 branch of `array_from_json` didn't handle zeros correctly. It builds a little-endian two's-complement buffer as part of converting string-valued decimals into native Decimal256 values, but for `0` inputs exactly, it used the wrong fill bytes (it used `0xFF` instead of `0`). This lead to `0` being decoded as `-256`.

# What changes are included in this PR?

* Fix decoding bug (use `0` fill bytes for `0` input values)
* Add unit test

# Are these changes tested?

Yes, new test added.

# Are there any user-facing changes?

No.
