### PR TITLE
fix: Avoid spurious assert when Parquet decimal has scale == precision

### DIFF
--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -990,11 +990,11 @@ fn convert_time_micros_to_string(value: i64) -> String {
 }
 
 /// Helper method to convert Parquet decimal into a string.
-/// We assert that `scale >= 0` and `precision > scale`, but this will be enforced
-/// when constructing Parquet schema.
+/// We assert that `scale >= 0` and `precision >= scale`, which is enforced when
+/// constructing a Parquet schema.
 #[inline]
 fn convert_decimal_to_string(decimal: &Decimal) -> String {
-    assert!(decimal.scale() >= 0 && decimal.precision() > decimal.scale());
+    assert!(decimal.scale() >= 0 && decimal.precision() >= decimal.scale());
 
     // Specify as signed bytes to resolve sign as part of conversion.
     let num = BigInt::from_signed_bytes_be(decimal.data());
@@ -1428,6 +1428,9 @@ mod tests {
         check_decimal(vec![0, 0, 0, 0, 1, 201, 195, 140], 18, 2, "300000.12");
         check_decimal(vec![207, 200], 10, 2, "-123.44");
         check_decimal(vec![207, 200], 10, 8, "-0.00012344");
+        check_decimal(vec![48, 57], 5, 5, "0.12345");
+        check_decimal(vec![207, 199], 5, 5, "-0.12345");
+        check_decimal(vec![45], 5, 5, "0.00045");
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10874.

# Rationale for this change

`convert_decimal_to_string` asserted `precision > scale`, but the Parquet spec requires only `scale <= precision`, so displaying a row from a file with a `DECIMAL(p, p)` column resulted in a spurious assertion failure.

# What changes are included in this PR?

* Weaken assert to match Parquet spec
* Update test coverage

# Are these changes tested?

Yes, test coverage added.

# Are there any user-facing changes?

No.
