### PR TITLE
chore: ensure miri ignores are properly commented, add guidelines

### DIFF
--- a/.github/workflows/miri.sh
+++ b/.github/workflows/miri.sh
@@ -27,7 +27,7 @@ CRATES="
 "
 
 setup_miri() {
-    export MIRIFLAGS="-Zmiri-disable-isolation"
+    export MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-no-extra-rounding-error"
     export INSTA_WORKSPACE_ROOT="$PWD"
     cargo miri setup
     cargo clean

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,38 @@ parquet files run the following from the top-level `arrow-rs` directory:
 cargo fmt -p parquet -- --check --config skip_children=true `find ./parquet -name "*.rs" \! -name format.rs`
 ```
 
+## Miri
+
+Run tests under [`Miri`](https://github.com/rust-lang/miri) like so, assuming
+[`cargo-nextest`](https://nexte.st/) is available:
+
+```sh
+# Run all tests
+MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri nextest run
+# Run specific tests
+MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri nextest run -p arrow-buffer --lib bigint
+```
+
+The whole suite will take a long time to run so it's suggested to run individual
+suites/tests when required.
+
+Add a `cfg_attr` to tests in cases where the test should be ignored by Miri:
+
+```rust
+#[test]
+#[cfg_attr(miri, ignore)] // Takes too long
+fn test123() {}
+```
+
+Ensuring to annotate with a comment why the test is being ignored. Common cases
+are:
+
+- Takes too long
+  - Threshold is if it takes longer than 1 minute
+- Zstd code unsupported by Miri
+- Inline assembly unsupported by Miri
+- Any other operation thats unsupported by Miri
+
 ## Breaking Changes
 
 Our [release schedule] allows breaking API changes only in major releases.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,8 @@ Run tests under [`Miri`](https://github.com/rust-lang/miri) like so, assuming
 MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-no-extra-rounding-error" cargo +nightly miri nextest run
 # Run specific tests
 MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-no-extra-rounding-error" cargo +nightly miri nextest run -p arrow-buffer --lib bigint
+# Run specific crate
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-no-extra-rounding-error" cargo +nightly miri nextest run -p arrow-buffer
 ```
 
 The whole suite will take a long time to run so it's suggested to run individual

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ Add a `cfg_attr` to tests in cases where the test should be ignored by Miri:
 fn test123() {}
 ```
 
-Ensuring to annotate with a comment why the test is being ignored. Common cases
+Please ensure you include a comment why the test is being ignored. Common cases
 are:
 
 - Takes too long

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,9 +173,9 @@ Run tests under [`Miri`](https://github.com/rust-lang/miri) like so, assuming
 
 ```sh
 # Run all tests
-MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri nextest run
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-no-extra-rounding-error" cargo +nightly miri nextest run
 # Run specific tests
-MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri nextest run -p arrow-buffer --lib bigint
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-no-extra-rounding-error" cargo +nightly miri nextest run -p arrow-buffer --lib bigint
 ```
 
 The whole suite will take a long time to run so it's suggested to run individual

--- a/arrow-array/src/array/union_array.rs
+++ b/arrow-array/src/array/union_array.rs
@@ -1128,7 +1128,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_dense_i32_large() {
         let mut builder = UnionBuilder::new_dense();
 

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -1553,7 +1553,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_i256() {
         let candidates = [
             i256::ZERO,
@@ -1616,7 +1616,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn test_i256_fuzz() {
         let mut rng = rng();
 
@@ -1819,7 +1819,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // conversion to float isn't accurate under miri
     fn test_decimal256_to_f64_typical_values() {
         let v = i256::from_i128(42_i128);
         assert_eq!(v.to_f64().unwrap(), 42.0);

--- a/arrow-buffer/src/bigint/mod.rs
+++ b/arrow-buffer/src/bigint/mod.rs
@@ -1819,7 +1819,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // conversion to float isn't accurate under miri
     fn test_decimal256_to_f64_typical_values() {
         let v = i256::from_i128(42_i128);
         assert_eq!(v.to_f64().unwrap(), 42.0);

--- a/arrow-buffer/src/util/bit_chunk_iterator.rs
+++ b/arrow-buffer/src/util/bit_chunk_iterator.rs
@@ -730,7 +730,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn fuzz_unaligned_bit_chunk_iterator() {
         let mut rng = rng();
 

--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -1611,7 +1611,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function: mktime
     fn string_to_timestamp_no_timezone() {
         // This test is designed to succeed in regardless of the local
         // timezone the test machine is running. Thus it is still

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -5200,7 +5200,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn fuzz_test() {
         let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..100 {

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -1271,7 +1271,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // Can't handle the inlined strings of the assert_debug_snapshot macro
+    #[cfg_attr(miri, ignore)] // fork is not supported
     fn test_debug_format_field() {
         // Make sure the `Debug` formatting of `DataType` is readable and not too long
         insta::assert_debug_snapshot!(DataType::new_list(DataType::Int8, false), @r"

--- a/arrow-schema/src/field.rs
+++ b/arrow-schema/src/field.rs
@@ -1058,7 +1058,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // Can't handle the inlined strings of the assert_debug_snapshot macro
+    #[cfg_attr(miri, ignore)] // fork is not supported
     fn test_debug_format_field() {
         // Make sure the `Debug` formatting of `Field` is readable and not too long
         insta::assert_debug_snapshot!(Field::new("item", DataType::UInt8, false), @r"

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -1817,7 +1817,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn fuzz_test_slices_iterator() {
         let mut rng = rng();
 
@@ -1889,7 +1889,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Takes too long
     fn fuzz_filter() {
         let mut rng = rng();
 

--- a/arrow/tests/array_cast.rs
+++ b/arrow/tests/array_cast.rs
@@ -146,7 +146,7 @@ fn test_cast_timestamp_with_timezone_daylight_3() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // running forever
+#[cfg_attr(miri, ignore)] // Takes too long
 fn test_can_cast_types() {
     // this function attempts to ensure that can_cast_types stays
     // in sync with cast.  It simply tries all combinations of


### PR DESCRIPTION
Make sure we always have a clear reason why certain tests are ignored; also try enabling some, and add guidelines for these annotations so we have a reference

Also adding the `-Zmiri-no-extra-rounding-error` flag so some of our floating point tests dont fail on miri