### PR TITLE
chore: change gh action dependabot update schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 10
     labels: [auto-dependencies, development-process]
     groups:


### PR DESCRIPTION
same as for datafusion:

- https://github.com/apache/datafusion/blob/2a7a1e3060c42e5ade6ad88b9be667e1b72639bb/.github/dependabot.yml#L93

main reason is because `taiki` updates come too frequently