### PR TITLE
perf(parquet): compile `ValueStatistics` `Display`/`Debug` formatting once, not per type

### DIFF
--- a/parquet/src/file/statistics.rs
+++ b/parquet/src/file/statistics.rs
@@ -705,15 +705,66 @@ impl<T: AsBytes> ValueStatistics<T> {
 
 impl<T: ParquetValueType> fmt::Display for ValueStatistics<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Erase the value type and dispatch to a non-generic helper, so the
+        // formatting machinery is compiled once instead of once per
+        // ParquetValueType (only `min` / `max` actually depend on `T`)
+        self.type_erased().display(f)
+    }
+}
+
+impl<T: ParquetValueType> fmt::Debug for ValueStatistics<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // See `Display`: dispatch to a non-generic helper
+        self.type_erased().debug(f)
+    }
+}
+
+impl<T: ParquetValueType> ValueStatistics<T> {
+    /// Return `self` with `min` / `max` behind trait objects, for use by
+    /// non-generic code such as the [`fmt::Display`] and [`fmt::Debug`] impls
+    fn type_erased(&self) -> ErasedValueStatistics<'_> {
+        ErasedValueStatistics {
+            min: self.min.as_ref().map(|v| v as _),
+            max: self.max.as_ref().map(|v| v as _),
+            distinct_count: self.distinct_count,
+            null_count: self.null_count,
+            is_min_max_deprecated: self.is_min_max_deprecated,
+            is_min_max_backwards_compatible: self.is_min_max_backwards_compatible,
+            is_max_value_exact: self.is_max_value_exact,
+            is_min_value_exact: self.is_min_value_exact,
+        }
+    }
+}
+
+/// [`ValueStatistics`] with the value type erased, so formatting can be
+/// compiled once rather than once per [`ParquetValueType`]
+struct ErasedValueStatistics<'a> {
+    min: Option<&'a dyn ParquetValueFormat>,
+    max: Option<&'a dyn ParquetValueFormat>,
+    distinct_count: Option<u64>,
+    null_count: Option<u64>,
+    is_min_max_deprecated: bool,
+    is_min_max_backwards_compatible: bool,
+    is_max_value_exact: bool,
+    is_min_value_exact: bool,
+}
+
+/// Helper trait to allow a single trait object to be formatted with both
+/// [`fmt::Display`] and [`fmt::Debug`]
+trait ParquetValueFormat: fmt::Display + fmt::Debug {}
+impl<T: fmt::Display + fmt::Debug> ParquetValueFormat for T {}
+
+impl ErasedValueStatistics<'_> {
+    fn display(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{{")?;
         write!(f, "min: ")?;
         match self.min {
-            Some(ref value) => write!(f, "{value}")?,
+            Some(value) => write!(f, "{value}")?,
             None => write!(f, "N/A")?,
         }
         write!(f, ", max: ")?;
         match self.max {
-            Some(ref value) => write!(f, "{value}")?,
+            Some(value) => write!(f, "{value}")?,
             None => write!(f, "N/A")?,
         }
         write!(f, ", distinct_count: ")?;
@@ -731,10 +782,8 @@ impl<T: ParquetValueType> fmt::Display for ValueStatistics<T> {
         write!(f, ", min_value_exact: {}", self.is_min_value_exact)?;
         write!(f, "}}")
     }
-}
 
-impl<T: ParquetValueType> fmt::Debug for ValueStatistics<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn debug(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "{{min: {:?}, max: {:?}, distinct_count: {:?}, null_count: {:?}, \


### PR DESCRIPTION
# Which issue does this PR close?

- Part of the binary-size / LLVM IR reduction effort started in #10889.

# Rationale for this change

`Display for ValueStatistics<T>` is monomorphized for all 8 `ParquetValueType`s, and each copy is ~2,000 lines of LLVM IR (~16,000 lines total in the `parquet` lib) even though only the `min`/`max` writes actually depend on `T`. `Debug` has the same shape. Statistics formatting is not performance-sensitive, so this is a pure code-size / compile-time win.

# What changes are included in this PR?

Introduce a private `ErasedValueStatistics` struct that borrows the statistics with `min`/`max` behind trait objects. The generic `Display`/`Debug` impls shrink to constructing it and delegating; the (unchanged) formatting bodies move to non-generic methods on it, compiled once. Output is byte-for-byte identical.

## Measurements

I measured the size of the `arrow_writer` benchmark binary with

```shell
cargo bench -p parquet --features arrow --bench arrow_writer --no-run
```

| before | after | delta |
|---:|---:|---:|
| 16,311,200 bytes | 16,310,608 bytes | −592 bytes |

The binary size change is small for this benchmark because the linker already dead-strips the `Display` copies it doesn't call — the savings here are mainly the ~13,000 lines of LLVM IR that every build of `parquet` no longer has to generate and optimize (compile time), plus binary size in applications that actually format statistics (e.g. anything that prints `ParquetMetaData`).

I measured the generated LLVM IR with

```shell
cargo llvm-lines --release -p parquet --features arrow --lib
```

| | before | after | delta |
|---|---:|---:|---:|
| `ValueStatistics` formatting IR | 16,168 lines (8 × ~2,020) | ~3,100 lines (one shared body + 8 thin shims) | **−81%** |

# Are these changes tested?

Covered by existing tests; the format strings are unchanged.

# Are there any user-facing changes?

No. `ErasedValueStatistics` is private and the formatted output is identical.