### PR TITLE
Feat: support semantic_equality for datatypes

### DIFF
--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{ArrowError, EquivlenceGauge, Field, FieldRef, Fields, UnionFields};
+use crate::{ArrowError, EquivalenceGauge, Field, FieldRef, Fields, UnionFields};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -878,9 +878,9 @@ impl DataType {
     /// # Example
     /// ```
     /// use std::sync::Arc;
-    /// use arrow_schema::{DataType, EquivlenceGauge, Field};
+    /// use arrow_schema::{DataType, EquivalenceGauge, Field};
     ///
-    /// let ignore_names = EquivlenceGauge {
+    /// let ignore_names = EquivalenceGauge {
     ///     check_nullibility: true,
     ///     check_field_name: false,
     ///     check_metadata: true,
@@ -892,8 +892,8 @@ impl DataType {
     /// assert_ne!(a, b);
     /// assert!(a.semantic_equality(&b, &ignore_names));
     /// ```
-    pub fn semantic_equality(&self, other: &DataType, gauge: &EquivlenceGauge) -> bool {
-        fn fields_eq(a: &Field, b: &Field, gauge: &EquivlenceGauge) -> bool {
+    pub fn semantic_equality(&self, other: &DataType, gauge: &EquivalenceGauge) -> bool {
+        fn fields_eq(a: &Field, b: &Field, gauge: &EquivalenceGauge) -> bool {
             (!gauge.check_field_name || a.name() == b.name())
                 && (!gauge.check_nullibility || a.is_nullable() == b.is_nullable())
                 && (!gauge.check_metadata || a.metadata() == b.metadata())
@@ -904,9 +904,7 @@ impl DataType {
             (DataType::List(a), DataType::List(b))
             | (DataType::ListView(a), DataType::ListView(b))
             | (DataType::LargeList(a), DataType::LargeList(b))
-            | (DataType::LargeListView(a), DataType::LargeListView(b)) => {
-                fields_eq(a, b, gauge)
-            }
+            | (DataType::LargeListView(a), DataType::LargeListView(b)) => fields_eq(a, b, gauge),
             (DataType::FixedSizeList(a, size_a), DataType::FixedSizeList(b, size_b)) => {
                 size_a == size_b && fields_eq(a, b, gauge)
             }
@@ -1356,12 +1354,12 @@ mod tests {
 
     #[test]
     fn test_semantic_equality_ignores_field_name() {
-        let strict = EquivlenceGauge {
+        let strict = EquivalenceGauge {
             check_nullibility: true,
             check_field_name: true,
             check_metadata: true,
         };
-        let ignore_names = EquivlenceGauge {
+        let ignore_names = EquivalenceGauge {
             check_field_name: false,
             ..strict.clone()
         };
@@ -1386,12 +1384,12 @@ mod tests {
         ]));
         let b = DataType::Struct(Fields::from(vec![Field::new("a", DataType::Int32, true)]));
 
-        let strict = EquivlenceGauge {
+        let strict = EquivalenceGauge {
             check_nullibility: true,
             check_field_name: true,
             check_metadata: true,
         };
-        let lenient = EquivlenceGauge {
+        let lenient = EquivalenceGauge {
             check_nullibility: false,
             check_field_name: true,
             check_metadata: false,
@@ -1403,7 +1401,7 @@ mod tests {
 
     #[test]
     fn test_semantic_equality_recurses_into_nested_types() {
-        let gauge = EquivlenceGauge {
+        let gauge = EquivalenceGauge {
             check_nullibility: true,
             check_field_name: false,
             check_metadata: true,

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -878,9 +878,9 @@ impl DataType {
     /// # Example
     /// ```
     /// use std::sync::Arc;
-    /// use arrow_schema::{DataType, EquivalenceGauge, Field};
+    /// use arrow_schema::{DataType, SemanticEqualityOptions, Field};
     ///
-    /// let ignore_names = EquivalenceGauge {
+    /// let ignore_names = SemanticEqualityOptions {
     ///     check_nullibility: true,
     ///     check_field_name: false,
     ///     check_metadata: true,

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{ArrowError, EquivalenceGauge, Field, FieldRef, Fields, UnionFields};
+use crate::{ArrowError, Field, FieldRef, Fields, SemanticEqualityOptions, UnionFields};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -892,8 +892,8 @@ impl DataType {
     /// assert_ne!(a, b);
     /// assert!(a.semantic_equality(&b, &ignore_names));
     /// ```
-    pub fn semantic_equality(&self, other: &DataType, gauge: &EquivalenceGauge) -> bool {
-        fn fields_eq(a: &Field, b: &Field, gauge: &EquivalenceGauge) -> bool {
+    pub fn semantic_equality(&self, other: &DataType, options: &SemanticEqualityOptions) -> bool {
+        fn fields_eq(a: &Field, b: &Field, gauge: &SemanticEqualityOptions) -> bool {
             (!gauge.check_field_name || a.name() == b.name())
                 && (!gauge.check_nullibility || a.is_nullable() == b.is_nullable())
                 && (!gauge.check_metadata || a.metadata() == b.metadata())
@@ -904,31 +904,31 @@ impl DataType {
             (DataType::List(a), DataType::List(b))
             | (DataType::ListView(a), DataType::ListView(b))
             | (DataType::LargeList(a), DataType::LargeList(b))
-            | (DataType::LargeListView(a), DataType::LargeListView(b)) => fields_eq(a, b, gauge),
+            | (DataType::LargeListView(a), DataType::LargeListView(b)) => fields_eq(a, b, options),
             (DataType::FixedSizeList(a, size_a), DataType::FixedSizeList(b, size_b)) => {
-                size_a == size_b && fields_eq(a, b, gauge)
+                size_a == size_b && fields_eq(a, b, options)
             }
             (DataType::Struct(a), DataType::Struct(b)) => {
                 a.len() == b.len()
                     && a.iter()
                         .zip(b.iter())
-                        .all(|(fa, fb)| fields_eq(fa, fb, gauge))
+                        .all(|(fa, fb)| fields_eq(fa, fb, options))
             }
             (DataType::Union(a, mode_a), DataType::Union(b, mode_b)) => {
                 mode_a == mode_b
                     && a.len() == b.len()
                     && a.iter()
                         .zip(b.iter())
-                        .all(|((id_a, fa), (id_b, fb))| id_a == id_b && fields_eq(fa, fb, gauge))
+                        .all(|((id_a, fa), (id_b, fb))| id_a == id_b && fields_eq(fa, fb, options))
             }
             (DataType::Map(a, sorted_a), DataType::Map(b, sorted_b)) => {
-                sorted_a == sorted_b && fields_eq(a, b, gauge)
+                sorted_a == sorted_b && fields_eq(a, b, options)
             }
             (DataType::Dictionary(key_a, val_a), DataType::Dictionary(key_b, val_b)) => {
-                key_a.semantic_equality(key_b, gauge) && val_a.semantic_equality(val_b, gauge)
+                key_a.semantic_equality(key_b, options) && val_a.semantic_equality(val_b, options)
             }
             (DataType::RunEndEncoded(re_a, val_a), DataType::RunEndEncoded(re_b, val_b)) => {
-                fields_eq(re_a, re_b, gauge) && fields_eq(val_a, val_b, gauge)
+                fields_eq(re_a, re_b, options) && fields_eq(val_a, val_b, options)
             }
             _ => self == other,
         }
@@ -1354,12 +1354,12 @@ mod tests {
 
     #[test]
     fn test_semantic_equality_ignores_field_name() {
-        let strict = EquivalenceGauge {
+        let strict = SemanticEqualityOptions {
             check_nullibility: true,
             check_field_name: true,
             check_metadata: true,
         };
-        let ignore_names = EquivalenceGauge {
+        let ignore_names = SemanticEqualityOptions {
             check_field_name: false,
             ..strict.clone()
         };
@@ -1384,12 +1384,12 @@ mod tests {
         ]));
         let b = DataType::Struct(Fields::from(vec![Field::new("a", DataType::Int32, true)]));
 
-        let strict = EquivalenceGauge {
+        let strict = SemanticEqualityOptions {
             check_nullibility: true,
             check_field_name: true,
             check_metadata: true,
         };
-        let lenient = EquivalenceGauge {
+        let lenient = SemanticEqualityOptions {
             check_nullibility: false,
             check_field_name: true,
             check_metadata: false,
@@ -1401,7 +1401,7 @@ mod tests {
 
     #[test]
     fn test_semantic_equality_recurses_into_nested_types() {
-        let gauge = EquivalenceGauge {
+        let gauge = SemanticEqualityOptions {
             check_nullibility: true,
             check_field_name: false,
             check_metadata: true,

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -15,10 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::{ArrowError, EquivlenceGauge, Field, FieldRef, Fields, UnionFields};
 use std::str::FromStr;
 use std::sync::Arc;
-
-use crate::{ArrowError, Field, FieldRef, Fields, UnionFields};
 
 /// Datatypes supported by this implementation of Apache Arrow.
 ///
@@ -864,6 +863,78 @@ impl DataType {
     pub fn new_fixed_size_list(data_type: DataType, size: i32, nullable: bool) -> Self {
         DataType::FixedSizeList(Arc::new(Field::new_list_field(data_type, nullable)), size)
     }
+    /// Compares this [`DataType`] with `other` for semantic equality, according
+    /// to the rules configured by `gauge`.
+    ///
+    /// Unlike the derived [`PartialEq`], this recursively compares nested
+    /// [`Field`]s (e.g. the element field of a [`DataType::List`], or the
+    /// fields of a [`DataType::Struct`]) while letting the caller ignore
+    /// aspects of those fields that don't matter for their use case, such as
+    /// field names, nullability, or metadata. This is useful when comparing
+    /// data types that describe logically-compatible data but were built
+    /// with different conventions, e.g. a `List` whose inner field is named
+    /// `"item"` vs. one named `"element"`.
+    ///
+    /// # Example
+    /// ```
+    /// use std::sync::Arc;
+    /// use arrow_schema::{DataType, EquivlenceGauge, Field};
+    ///
+    /// let ignore_names = EquivlenceGauge {
+    ///     check_nullibility: true,
+    ///     check_field_name: false,
+    ///     check_metadata: true,
+    /// };
+    ///
+    /// let a = DataType::new_list(DataType::Int32, true);
+    /// let b = DataType::List(Arc::new(Field::new("element", DataType::Int32, true)));
+    ///
+    /// assert_ne!(a, b);
+    /// assert!(a.semantic_equality(&b, &ignore_names));
+    /// ```
+    pub fn semantic_equality(&self, other: &DataType, gauge: &EquivlenceGauge) -> bool {
+        fn fields_eq(a: &Field, b: &Field, gauge: &EquivlenceGauge) -> bool {
+            (!gauge.check_field_name || a.name() == b.name())
+                && (!gauge.check_nullibility || a.is_nullable() == b.is_nullable())
+                && (!gauge.check_metadata || a.metadata() == b.metadata())
+                && a.data_type().semantic_equality(b.data_type(), gauge)
+        }
+
+        match (self, other) {
+            (DataType::List(a), DataType::List(b))
+            | (DataType::ListView(a), DataType::ListView(b))
+            | (DataType::LargeList(a), DataType::LargeList(b))
+            | (DataType::LargeListView(a), DataType::LargeListView(b)) => {
+                fields_eq(a, b, gauge)
+            }
+            (DataType::FixedSizeList(a, size_a), DataType::FixedSizeList(b, size_b)) => {
+                size_a == size_b && fields_eq(a, b, gauge)
+            }
+            (DataType::Struct(a), DataType::Struct(b)) => {
+                a.len() == b.len()
+                    && a.iter()
+                        .zip(b.iter())
+                        .all(|(fa, fb)| fields_eq(fa, fb, gauge))
+            }
+            (DataType::Union(a, mode_a), DataType::Union(b, mode_b)) => {
+                mode_a == mode_b
+                    && a.len() == b.len()
+                    && a.iter()
+                        .zip(b.iter())
+                        .all(|((id_a, fa), (id_b, fb))| id_a == id_b && fields_eq(fa, fb, gauge))
+            }
+            (DataType::Map(a, sorted_a), DataType::Map(b, sorted_b)) => {
+                sorted_a == sorted_b && fields_eq(a, b, gauge)
+            }
+            (DataType::Dictionary(key_a, val_a), DataType::Dictionary(key_b, val_b)) => {
+                key_a.semantic_equality(key_b, gauge) && val_a.semantic_equality(val_b, gauge)
+            }
+            (DataType::RunEndEncoded(re_a, val_a), DataType::RunEndEncoded(re_b, val_b)) => {
+                fields_eq(re_a, re_b, gauge) && fields_eq(val_a, val_b, gauge)
+            }
+            _ => self == other,
+        }
+    }
 }
 
 /// The maximum precision for [DataType::Decimal32] values
@@ -1281,5 +1352,78 @@ mod tests {
             },
         )
         ");
+    }
+
+    #[test]
+    fn test_semantic_equality_ignores_field_name() {
+        let strict = EquivlenceGauge {
+            check_nullibility: true,
+            check_field_name: true,
+            check_metadata: true,
+        };
+        let ignore_names = EquivlenceGauge {
+            check_field_name: false,
+            ..strict.clone()
+        };
+
+        let item = DataType::new_list(DataType::Int32, true);
+        let element = DataType::List(Arc::new(Field::new("element", DataType::Int32, true)));
+
+        assert_ne!(item, element);
+        assert!(!item.semantic_equality(&element, &strict));
+        assert!(item.semantic_equality(&element, &ignore_names));
+    }
+
+    #[test]
+    fn test_semantic_equality_ignores_nullability_and_metadata() {
+        use std::collections::HashMap;
+
+        let mut metadata = HashMap::new();
+        metadata.insert("k".to_string(), "v".to_string());
+
+        let a = DataType::Struct(Fields::from(vec![
+            Field::new("a", DataType::Int32, false).with_metadata(metadata.clone()),
+        ]));
+        let b = DataType::Struct(Fields::from(vec![Field::new("a", DataType::Int32, true)]));
+
+        let strict = EquivlenceGauge {
+            check_nullibility: true,
+            check_field_name: true,
+            check_metadata: true,
+        };
+        let lenient = EquivlenceGauge {
+            check_nullibility: false,
+            check_field_name: true,
+            check_metadata: false,
+        };
+
+        assert!(!a.semantic_equality(&b, &strict));
+        assert!(a.semantic_equality(&b, &lenient));
+    }
+
+    #[test]
+    fn test_semantic_equality_recurses_into_nested_types() {
+        let gauge = EquivlenceGauge {
+            check_nullibility: true,
+            check_field_name: false,
+            check_metadata: true,
+        };
+
+        let a = DataType::new_list(
+            DataType::Struct(Fields::from(vec![Field::new("x", DataType::Int32, true)])),
+            true,
+        );
+        let matching = DataType::List(Arc::new(Field::new(
+            "element",
+            DataType::Struct(Fields::from(vec![Field::new("y", DataType::Int32, true)])),
+            true,
+        )));
+        let mismatched = DataType::new_list(
+            DataType::Struct(Fields::from(vec![Field::new("x", DataType::Int64, true)])),
+            true,
+        );
+
+        assert!(a.semantic_equality(&matching, &gauge));
+        assert!(!a.semantic_equality(&mismatched, &gauge));
     }
 }

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -881,7 +881,7 @@ impl DataType {
     /// use arrow_schema::{DataType, SemanticEqualityOptions, Field};
     ///
     /// let ignore_names = SemanticEqualityOptions {
-    ///     check_nullibility: true,
+    ///     check_nullability: true,
     ///     check_field_name: false,
     ///     check_metadata: true,
     /// };

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -893,11 +893,11 @@ impl DataType {
     /// assert!(a.semantic_equality(&b, &ignore_names));
     /// ```
     pub fn semantic_equality(&self, other: &DataType, options: &SemanticEqualityOptions) -> bool {
-        fn fields_eq(a: &Field, b: &Field, gauge: &SemanticEqualityOptions) -> bool {
-            (!gauge.check_field_name || a.name() == b.name())
-                && (!gauge.check_nullibility || a.is_nullable() == b.is_nullable())
-                && (!gauge.check_metadata || a.metadata() == b.metadata())
-                && a.data_type().semantic_equality(b.data_type(), gauge)
+        fn fields_eq(a: &Field, b: &Field, options: &SemanticEqualityOptions) -> bool {
+            (!options.check_field_name || a.name() == b.name())
+                && (!options.check_nullability || a.is_nullable() == b.is_nullable())
+                && (!options.check_metadata || a.metadata() == b.metadata())
+                && a.data_type().semantic_equality(b.data_type(), options)
         }
 
         match (self, other) {
@@ -1355,7 +1355,7 @@ mod tests {
     #[test]
     fn test_semantic_equality_ignores_field_name() {
         let strict = SemanticEqualityOptions {
-            check_nullibility: true,
+            check_nullability: true,
             check_field_name: true,
             check_metadata: true,
         };
@@ -1385,12 +1385,12 @@ mod tests {
         let b = DataType::Struct(Fields::from(vec![Field::new("a", DataType::Int32, true)]));
 
         let strict = SemanticEqualityOptions {
-            check_nullibility: true,
+            check_nullability: true,
             check_field_name: true,
             check_metadata: true,
         };
         let lenient = SemanticEqualityOptions {
-            check_nullibility: false,
+            check_nullability: false,
             check_field_name: true,
             check_metadata: false,
         };
@@ -1402,7 +1402,7 @@ mod tests {
     #[test]
     fn test_semantic_equality_recurses_into_nested_types() {
         let gauge = SemanticEqualityOptions {
-            check_nullibility: true,
+            check_nullability: true,
             check_field_name: false,
             check_metadata: true,
         };

--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -915,11 +915,14 @@ impl DataType {
                         .all(|(fa, fb)| fields_eq(fa, fb, options))
             }
             (DataType::Union(a, mode_a), DataType::Union(b, mode_b)) => {
+                // Match by type ID rather than position so that unions with the same
+                // fields in a different order are still correctly considered semantically equal.
                 mode_a == mode_b
                     && a.len() == b.len()
-                    && a.iter()
-                        .zip(b.iter())
-                        .all(|((id_a, fa), (id_b, fb))| id_a == id_b && fields_eq(fa, fb, options))
+                    && a.iter().all(|(id_a, fa)| {
+                        b.iter()
+                            .any(|(id_b, fb)| id_a == id_b && fields_eq(fa, fb, options))
+                    })
             }
             (DataType::Map(a, sorted_a), DataType::Map(b, sorted_b)) => {
                 sorted_a == sorted_b && fields_eq(a, b, options)
@@ -1423,5 +1426,55 @@ mod tests {
 
         assert!(a.semantic_equality(&matching, &gauge));
         assert!(!a.semantic_equality(&mismatched, &gauge));
+    }
+
+    #[test]
+    fn test_semantic_equality_union_matches_by_type_id_not_position() {
+        // Two unions with the same (id, field) pairs but listed in different order must
+        // be semantically equal; matching by zip position would incorrectly return false.
+        let options = SemanticEqualityOptions {
+            check_nullability: true,
+            check_field_name: true,
+            check_metadata: true,
+        };
+
+        let a = DataType::Union(
+            UnionFields::try_new(
+                vec![0, 1],
+                vec![
+                    Field::new("x", DataType::Int32, false),
+                    Field::new("y", DataType::Utf8, false),
+                ],
+            )
+            .unwrap(),
+            UnionMode::Dense,
+        );
+        // Same fields, reversed order.
+        let b = DataType::Union(
+            UnionFields::try_new(
+                vec![1, 0],
+                vec![
+                    Field::new("y", DataType::Utf8, false),
+                    Field::new("x", DataType::Int32, false),
+                ],
+            )
+            .unwrap(),
+            UnionMode::Dense,
+        );
+        // Different type IDs — must not be equal.
+        let c = DataType::Union(
+            UnionFields::try_new(
+                vec![0, 2],
+                vec![
+                    Field::new("x", DataType::Int32, false),
+                    Field::new("y", DataType::Utf8, false),
+                ],
+            )
+            .unwrap(),
+            UnionMode::Dense,
+        );
+
+        assert!(a.semantic_equality(&b, &options));
+        assert!(!a.semantic_equality(&c, &options));
     }
 }

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -187,11 +187,11 @@ impl ops::Not for SortOptions {
 /// two [`DataType`]s for [semantic equality](DataType::semantic_equality).
 ///
 /// Plain [`PartialEq`] on [`DataType`] requires an exact match of every nested
-/// field, including its name, nullability, and metadata. `EquivlenceGauge` lets
+/// field, including its name, nullability, and metadata. `EquivalenceGauge` lets
 /// callers relax those checks, e.g. to treat `List<item: Int32>` and
 /// `List<element: Int32>` as equivalent by setting `check_field_name` to `false`.
 #[derive(Clone, Debug)]
-pub struct EquivlenceGauge {
+pub struct EquivalenceGauge {
     /// If `true`, nested fields must have the same nullability to be considered equal.
     pub check_nullibility: bool,
     /// If `true`, nested fields must have the same name to be considered equal.
@@ -202,7 +202,7 @@ pub struct EquivlenceGauge {
 
 /// Compares two [`DataType`]s for semantic equality, according to the rules
 /// configured by `depth`. See [`DataType::semantic_equality`] for details.
-pub fn equal_datatypes(dt: &DataType, other: &DataType, depth: &EquivlenceGauge) -> bool {
+pub fn equal_datatypes(dt: &DataType, other: &DataType, depth: &EquivalenceGauge) -> bool {
     dt.semantic_equality(other, depth)
 }
 

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -183,6 +183,28 @@ impl ops::Not for SortOptions {
         }
     }
 }
+/// Controls which properties of nested [`Field`]s are considered when comparing
+/// two [`DataType`]s for [semantic equality](DataType::semantic_equality).
+///
+/// Plain [`PartialEq`] on [`DataType`] requires an exact match of every nested
+/// field, including its name, nullability, and metadata. `EquivlenceGauge` lets
+/// callers relax those checks, e.g. to treat `List<item: Int32>` and
+/// `List<element: Int32>` as equivalent by setting `check_field_name` to `false`.
+#[derive(Clone, Debug)]
+pub struct EquivlenceGauge {
+    /// If `true`, nested fields must have the same nullability to be considered equal.
+    pub check_nullibility: bool,
+    /// If `true`, nested fields must have the same name to be considered equal.
+    pub check_field_name: bool,
+    /// If `true`, nested fields must have the same metadata to be considered equal.
+    pub check_metadata: bool,
+}
+
+/// Compares two [`DataType`]s for semantic equality, according to the rules
+/// configured by `depth`. See [`DataType::semantic_equality`] for details.
+pub fn equal_datatypes(dt: &DataType, other: &DataType, depth: &EquivlenceGauge) -> bool {
+    dt.semantic_equality(other, depth)
+}
 
 #[test]
 fn test_overloaded_not_sort_options() {

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -187,11 +187,11 @@ impl ops::Not for SortOptions {
 /// two [`DataType`]s for [semantic equality](DataType::semantic_equality).
 ///
 /// Plain [`PartialEq`] on [`DataType`] requires an exact match of every nested
-/// field, including its name, nullability, and metadata. `EquivalenceGauge` lets
+/// field, including its name, nullability, and metadata. `SemanticEqualityOptions` lets
 /// callers relax those checks, e.g. to treat `List<item: Int32>` and
 /// `List<element: Int32>` as equivalent by setting `check_field_name` to `false`.
-#[derive(Clone, Debug)]
-pub struct EquivalenceGauge {
+#[derive(Clone, Debug, Default)]
+pub struct SemanticEqualityOptions {
     /// If `true`, nested fields must have the same nullability to be considered equal.
     pub check_nullibility: bool,
     /// If `true`, nested fields must have the same name to be considered equal.
@@ -202,8 +202,8 @@ pub struct EquivalenceGauge {
 
 /// Compares two [`DataType`]s for semantic equality, according to the rules
 /// configured by `depth`. See [`DataType::semantic_equality`] for details.
-pub fn equal_datatypes(dt: &DataType, other: &DataType, depth: &EquivalenceGauge) -> bool {
-    dt.semantic_equality(other, depth)
+pub fn equal_datatypes(dt: &DataType, other: &DataType, options: &SemanticEqualityOptions) -> bool {
+    dt.semantic_equality(other, options)
 }
 
 #[test]

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -193,7 +193,7 @@ impl ops::Not for SortOptions {
 #[derive(Clone, Debug, Default)]
 pub struct SemanticEqualityOptions {
     /// If `true`, nested fields must have the same nullability to be considered equal.
-    pub check_nullibility: bool,
+    pub check_nullability: bool,
     /// If `true`, nested fields must have the same name to be considered equal.
     pub check_field_name: bool,
     /// If `true`, nested fields must have the same metadata to be considered equal.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #3199.

# Rationale for this change
Arrow's derived `PartialEq` on `DataType`/`Field` requires exact equality (name, nullability, metadata), so logically-equivalent types like `List<item: Int32>` and `List<element: Int32>` compare unequal.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Add `EquivlenceGauge` and `DataType::semantic_equality`/`equal_datatypes` to compare nested types (List, FixedSizeList, Struct, Union, Map, Dictionary, RunEndEncoded) while optionally ignoring field name, nullability, and/or metadata.


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Yes, unit tests in `datatype.rs`.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?

Yes, new public API: `EquivlenceGauge`, `DataType::semantic_equality`, `equal_datatypes`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
