### PR TITLE
feat(csv): add option to ignore extra fields

### DIFF
--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -269,6 +269,16 @@ impl InferredDataType {
     }
 }
 
+/// Defines how to handle CSV rows with more fields than the schema
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExtraFields {
+    /// Return an error when extra fields are encountered (default)
+    #[default]
+    Error,
+    /// Ignore trailing fields beyond the schema's width
+    Ignore,
+}
+
 /// The format specification for the CSV file
 #[derive(Debug, Clone, Default)]
 pub struct Format {
@@ -281,6 +291,7 @@ pub struct Format {
     comment: Option<u8>,
     null_regex: NullRegex,
     truncated_rows: bool,
+    extra_fields: ExtraFields,
 }
 
 impl Format {
@@ -348,6 +359,16 @@ impl Format {
     /// will still return an error.
     pub fn with_truncated_rows(mut self, allow: bool) -> Self {
         self.truncated_rows = allow;
+        self
+    }
+
+    /// Whether to ignore extra fields when parsing.
+    ///
+    /// By default this is set to `ExtraFields::Error` and will error if the CSV rows have more
+    /// columns than expected. When set to `ExtraFields::Ignore` then it will allow records with
+    /// more than the expected number of columns and ignore the extra fields.
+    pub fn with_extra_fields(mut self, extra_fields: ExtraFields) -> Self {
+        self.extra_fields = extra_fields;
         self
     }
 
@@ -1326,6 +1347,12 @@ impl ReaderBuilder {
         self
     }
 
+    /// Set the behavior for CSV rows with more fields than the schema
+    pub fn with_extra_fields(mut self, extra_fields: ExtraFields) -> Self {
+        self.format.extra_fields = extra_fields;
+        self
+    }
+
     /// Create a new `Reader` from a non-buffered reader
     ///
     /// If `R: BufRead` consider using [`Self::build_buffered`] to avoid unnecessary additional
@@ -1355,6 +1382,7 @@ impl ReaderBuilder {
             delimiter,
             self.schema.fields().len(),
             self.format.truncated_rows,
+            self.format.extra_fields,
         );
 
         let header = self.format.header as usize;
@@ -2645,6 +2673,132 @@ mod tests {
         assert!(c.value(1));
         assert!(c.value(2));
         assert!(c.is_null(3));
+    }
+
+    #[test]
+    fn test_extra_fields_ignore() {
+        let data = "a,b\n1,2,3,4\n5,6\n7,8,9";
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+        ]));
+
+        let mut reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_extra_fields(ExtraFields::Ignore)
+            .build(Cursor::new(data))
+            .unwrap();
+
+        let batch = reader.next().unwrap().unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.num_columns(), 2);
+
+        let col_a = batch.column(0).as_primitive::<Int32Type>();
+        assert_eq!(col_a.value(0), 1);
+        assert_eq!(col_a.value(1), 5);
+        assert_eq!(col_a.value(2), 7);
+
+        let col_b = batch.column(1).as_primitive::<Int32Type>();
+        assert_eq!(col_b.value(0), 2);
+        assert_eq!(col_b.value(1), 6);
+        assert_eq!(col_b.value(2), 8);
+    }
+
+    #[test]
+    fn test_extra_fields_default_errors() {
+        let data = "a,b\n1,2,3\n4,5";
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+        ]));
+
+        // No with_extra_fields called (should default to Error)
+        let mut reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .build(Cursor::new(data))
+            .unwrap();
+
+        let result = reader.next();
+        assert!(match result {
+            Some(Err(ArrowError::CsvError(e))) => e.contains("got more than"),
+            _ => false,
+        });
+    }
+
+    #[test]
+    fn test_extra_fields_error() {
+        let data = "a,b\n1,2,3\n4,5";
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+        ]));
+
+        let mut reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_extra_fields(ExtraFields::Error)
+            .build(Cursor::new(data))
+            .unwrap();
+
+        let result = reader.next();
+        assert!(match result {
+            Some(Err(ArrowError::CsvError(e))) => e.contains("got more than"),
+            _ => false,
+        });
+    }
+
+    #[test]
+    fn test_extra_fields_quoted() {
+        // Quoted extra field with commas and newlines
+        let data = "a,b\n1,2,\"3,4,5\n6\",7\n8,9";
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+        ]));
+
+        let mut reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_extra_fields(ExtraFields::Ignore)
+            .build(Cursor::new(data))
+            .unwrap();
+
+        let batch = reader.next().unwrap().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+
+        let col_a = batch.column(0).as_primitive::<Int32Type>();
+        assert_eq!(col_a.value(0), 1);
+        assert_eq!(col_a.value(1), 8);
+    }
+
+    #[test]
+    fn test_extra_fields_across_chunk_boundary() {
+        // We create an extra field that is very long, and use a small BufReader
+        // to force it to cross chunk boundaries multiple times while skipping.
+        let data =
+            "a,b\n1,2,this_is_a_very_long_extra_field_that_will_cross_chunk_boundaries\n3,4\n";
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+        ]));
+
+        // BufReader with only 16 bytes capacity
+        let buf_reader = std::io::BufReader::with_capacity(16, Cursor::new(data));
+
+        let mut reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_extra_fields(ExtraFields::Ignore)
+            .build_buffered(buf_reader)
+            .unwrap();
+
+        let batch = reader.next().unwrap().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+
+        let col_a = batch.column(0).as_primitive::<Int32Type>();
+        assert_eq!(col_a.value(0), 1);
+        assert_eq!(col_a.value(1), 3);
+
+        let col_b = batch.column(1).as_primitive::<Int32Type>();
+        assert_eq!(col_b.value(0), 2);
+        assert_eq!(col_b.value(1), 4);
     }
 
     #[test]

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -2860,6 +2860,128 @@ mod tests {
     }
 
     #[test]
+    fn test_truncated_rows_with_extra_fields() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, true),
+            Field::new("c", DataType::Int32, true),
+        ]));
+
+        let data_short = "a,b,c\n1,2";
+        let data_extra = "a,b,c\n4,5,6,7";
+        let data_mixed = "a,b,c\n1,2\n4,5,6,7";
+
+        // 1. with_truncated_rows(true) + ExtraFields::Ignore
+        // - a row with fewer fields is padded
+        // - a row with extra fields has the extra fields ignored
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_truncated_rows(true)
+            .with_extra_fields(ExtraFields::Ignore)
+            .build(Cursor::new(data_mixed))
+            .unwrap();
+        let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), 2);
+        let col_a = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow_array::Int32Array>()
+            .unwrap();
+        let col_c = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow_array::Int32Array>()
+            .unwrap();
+        assert_eq!(col_a.value(0), 1);
+        assert!(col_c.is_null(0));
+        assert_eq!(col_a.value(1), 4);
+        assert_eq!(col_c.value(1), 6);
+
+        // 2. with_truncated_rows(true) + ExtraFields::Error
+        // - a short row is still padded
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_truncated_rows(true)
+            .with_extra_fields(ExtraFields::Error)
+            .build(Cursor::new(data_short))
+            .unwrap();
+        let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(batches[0].num_rows(), 1);
+
+        // - a row with extra fields still returns the exact field-count error
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_truncated_rows(true)
+            .with_extra_fields(ExtraFields::Error)
+            .build(Cursor::new(data_extra))
+            .unwrap();
+        let err = reader.collect::<Result<Vec<_>, _>>().unwrap_err();
+        assert!(
+            err.to_string().contains("incorrect number of fields")
+                || err.to_string().contains("Expected 3"),
+            "{}",
+            err
+        );
+
+        // 3. with_truncated_rows(false) + ExtraFields::Ignore
+        // - a short row still returns the existing short-row error
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_truncated_rows(false)
+            .with_extra_fields(ExtraFields::Ignore)
+            .build(Cursor::new(data_short))
+            .unwrap();
+        let err = reader.collect::<Result<Vec<_>, _>>().unwrap_err();
+        assert!(
+            err.to_string().contains("incorrect number of fields")
+                || err.to_string().contains("found 2"),
+            "{}",
+            err
+        );
+
+        // - a row with extra fields is successfully decoded with extra fields ignored
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_truncated_rows(false)
+            .with_extra_fields(ExtraFields::Ignore)
+            .build(Cursor::new(data_extra))
+            .unwrap();
+        let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(batches[0].num_rows(), 1);
+
+        // 4. with_truncated_rows(false) + ExtraFields::Error
+        // - preserve existing default behavior (error on both)
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_truncated_rows(false)
+            .with_extra_fields(ExtraFields::Error)
+            .build(Cursor::new(data_short))
+            .unwrap();
+        let err = reader.collect::<Result<Vec<_>, _>>().unwrap_err();
+        assert!(
+            err.to_string().contains("incorrect number of fields")
+                || err.to_string().contains("found 2"),
+            "{}",
+            err
+        );
+
+        let reader = ReaderBuilder::new(schema.clone())
+            .with_header(true)
+            .with_truncated_rows(false)
+            .with_extra_fields(ExtraFields::Error)
+            .build(Cursor::new(data_extra))
+            .unwrap();
+        let err = reader.collect::<Result<Vec<_>, _>>().unwrap_err();
+        assert!(
+            err.to_string().contains("incorrect number of fields")
+                || err.to_string().contains("Expected 3"),
+            "{}",
+            err
+        );
+    }
+
+    #[test]
     fn test_truncated_rows_csv() {
         let file = File::open("test/data/truncated_rows.csv").unwrap();
         let schema = Arc::new(Schema::new(vec![

--- a/arrow-csv/src/reader/mod.rs
+++ b/arrow-csv/src/reader/mod.rs
@@ -436,7 +436,7 @@ impl Format {
     fn build_reader<R: Read>(&self, reader: R) -> csv::Reader<R> {
         let mut builder = csv::ReaderBuilder::new();
         builder.has_headers(self.header);
-        builder.flexible(self.truncated_rows);
+        builder.flexible(self.truncated_rows || self.extra_fields == ExtraFields::Ignore);
 
         if let Some(c) = self.delimiter {
             builder.delimiter(c);
@@ -2720,7 +2720,7 @@ mod tests {
 
         let result = reader.next();
         assert!(match result {
-            Some(Err(ArrowError::CsvError(e))) => e.contains("got more than"),
+            Some(Err(ArrowError::CsvError(e))) => e.contains("got 3"),
             _ => false,
         });
     }
@@ -2741,7 +2741,7 @@ mod tests {
 
         let result = reader.next();
         assert!(match result {
-            Some(Err(ArrowError::CsvError(e))) => e.contains("got more than"),
+            Some(Err(ArrowError::CsvError(e))) => e.contains("got 3"),
             _ => false,
         });
     }
@@ -2799,6 +2799,30 @@ mod tests {
         let col_b = batch.column(1).as_primitive::<Int32Type>();
         assert_eq!(col_b.value(0), 2);
         assert_eq!(col_b.value(1), 4);
+    }
+
+    #[test]
+    fn test_infer_schema_with_extra_fields_ignore() {
+        let data = "a,b\n1,2,3\n4,5\n";
+        let format = Format::default()
+            .with_header(true)
+            .with_extra_fields(ExtraFields::Ignore);
+        let (schema, count) = format.infer_schema(Cursor::new(data), None).unwrap();
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_infer_schema_with_extra_fields_error() {
+        let data = "a,b\n1,2,3\n4,5\n";
+        let format = Format::default()
+            .with_header(true)
+            .with_extra_fields(ExtraFields::Error);
+        let err = format.infer_schema(Cursor::new(data), None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Expected 2 records, found 3 records")
+        );
     }
 
     #[test]

--- a/arrow-csv/src/reader/records.rs
+++ b/arrow-csv/src/reader/records.rs
@@ -118,29 +118,8 @@ impl RecordDecoder {
 
         // Resume skipping extra fields if we were in the middle of it from a previous chunk
         if self.skipping_extra_fields {
-            let mut dummy_data = [0u8; 128];
-            let mut dummy_ends = [0usize; 1];
-            loop {
-                let (res, b_read, _, _) = self.delimiter.read_record(
-                    &input[input_offset..],
-                    &mut dummy_data,
-                    &mut dummy_ends,
-                );
-                input_offset += b_read;
-                match res {
-                    ReadRecordResult::Record => {
-                        self.skipping_extra_fields = false;
-                        read += 1;
-                        self.current_field = 0;
-                        self.line_number += 1;
-                        self.num_rows += 1;
-                        break;
-                    }
-                    ReadRecordResult::OutputFull | ReadRecordResult::OutputEndsFull => {}
-                    ReadRecordResult::End | ReadRecordResult::InputEmpty => {
-                        return Ok((read, input_offset));
-                    }
-                }
+            if !self.skip_extra_fields(input, &mut input_offset, &mut read) {
+                return Ok((read, input_offset));
             }
             if read == to_read || input.len() == input_offset {
                 return Ok((read, input_offset));
@@ -160,7 +139,12 @@ impl RecordDecoder {
 
             // Try to read a record
             loop {
-                let ends_bound = self.offsets_len + (self.num_columns - self.current_field);
+                let ends_bound = match self.extra_fields {
+                    ExtraFields::Ignore => {
+                        self.offsets_len + (self.num_columns - self.current_field)
+                    }
+                    ExtraFields::Error => self.offsets.len(),
+                };
                 let (result, bytes_read, bytes_written, end_positions) =
                     self.delimiter.read_record(
                         &input[input_offset..],
@@ -190,30 +174,8 @@ impl RecordDecoder {
                             }
                             ExtraFields::Ignore => {
                                 self.skipping_extra_fields = true;
-                                let mut dummy_data = [0u8; 128];
-                                let mut dummy_ends = [0usize; 1];
-                                loop {
-                                    let (res, b_read, _, _) = self.delimiter.read_record(
-                                        &input[input_offset..],
-                                        &mut dummy_data,
-                                        &mut dummy_ends,
-                                    );
-                                    input_offset += b_read;
-                                    match res {
-                                        ReadRecordResult::Record => {
-                                            self.skipping_extra_fields = false;
-                                            read += 1;
-                                            self.current_field = 0;
-                                            self.line_number += 1;
-                                            self.num_rows += 1;
-                                            break;
-                                        }
-                                        ReadRecordResult::OutputFull
-                                        | ReadRecordResult::OutputEndsFull => {}
-                                        ReadRecordResult::End | ReadRecordResult::InputEmpty => {
-                                            return Ok((read, input_offset));
-                                        }
-                                    }
+                                if !self.skip_extra_fields(input, &mut input_offset, &mut read) {
+                                    return Ok((read, input_offset));
                                 }
 
                                 if read == to_read || input.len() == input_offset {
@@ -257,6 +219,39 @@ impl RecordDecoder {
                             return Ok((read, input_offset));
                         }
                     }
+                }
+            }
+        }
+    }
+
+    /// Skips extra fields for the current record, returning `true` if it finished skipping
+    fn skip_extra_fields(
+        &mut self,
+        input: &[u8],
+        input_offset: &mut usize,
+        read: &mut usize,
+    ) -> bool {
+        let mut dummy_data = [0u8; 128];
+        let mut dummy_ends = [0usize; 1];
+        loop {
+            let (res, b_read, _, _) = self.delimiter.read_record(
+                &input[*input_offset..],
+                &mut dummy_data,
+                &mut dummy_ends,
+            );
+            *input_offset += b_read;
+            match res {
+                ReadRecordResult::Record => {
+                    self.skipping_extra_fields = false;
+                    *read += 1;
+                    self.current_field = 0;
+                    self.line_number += 1;
+                    self.num_rows += 1;
+                    return true;
+                }
+                ReadRecordResult::OutputFull | ReadRecordResult::OutputEndsFull => {}
+                ReadRecordResult::End | ReadRecordResult::InputEmpty => {
+                    return false;
                 }
             }
         }

--- a/arrow-csv/src/reader/records.rs
+++ b/arrow-csv/src/reader/records.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::reader::ExtraFields;
 use arrow_schema::ArrowError;
 use csv_core::{ReadRecordResult, Reader};
 
@@ -69,10 +70,21 @@ pub struct RecordDecoder {
     /// lifetime of this decoder, i.e. not reset by [`Self::flush`], but reset by
     /// [`Self::clear`] along with the buffered rows it counted
     truncated_row_count: usize,
+
+    /// Whether to ignore extra fields when parsing
+    extra_fields: ExtraFields,
+
+    /// Whether the decoder is currently skipping extra fields from a previous chunk
+    skipping_extra_fields: bool,
 }
 
 impl RecordDecoder {
-    pub fn new(delimiter: Reader, num_columns: usize, truncated_rows: bool) -> Self {
+    pub fn new(
+        delimiter: Reader,
+        num_columns: usize,
+        truncated_rows: bool,
+        extra_fields: ExtraFields,
+    ) -> Self {
         Self {
             delimiter,
             num_columns,
@@ -85,6 +97,8 @@ impl RecordDecoder {
             num_rows: 0,
             truncated_rows,
             truncated_row_count: 0,
+            extra_fields,
+            skipping_extra_fields: false,
         }
     }
 
@@ -96,15 +110,46 @@ impl RecordDecoder {
             return Ok((0, 0));
         }
 
-        // Reserve sufficient capacity in offsets
-        self.offsets
-            .resize(self.offsets_len + to_read * self.num_columns, 0);
-
         // The current offset into `input`
         let mut input_offset = 0;
 
         // The number of rows decoded in this pass
         let mut read = 0;
+
+        // Resume skipping extra fields if we were in the middle of it from a previous chunk
+        if self.skipping_extra_fields {
+            let mut dummy_data = [0u8; 128];
+            let mut dummy_ends = [0usize; 1];
+            loop {
+                let (res, b_read, _, _) = self.delimiter.read_record(
+                    &input[input_offset..],
+                    &mut dummy_data,
+                    &mut dummy_ends,
+                );
+                input_offset += b_read;
+                match res {
+                    ReadRecordResult::Record => {
+                        self.skipping_extra_fields = false;
+                        read += 1;
+                        self.current_field = 0;
+                        self.line_number += 1;
+                        self.num_rows += 1;
+                        break;
+                    }
+                    ReadRecordResult::OutputFull | ReadRecordResult::OutputEndsFull => {}
+                    ReadRecordResult::End | ReadRecordResult::InputEmpty => {
+                        return Ok((read, input_offset));
+                    }
+                }
+            }
+            if read == to_read || input.len() == input_offset {
+                return Ok((read, input_offset));
+            }
+        }
+
+        // Reserve sufficient capacity in offsets
+        self.offsets
+            .resize(self.offsets_len + (to_read - read) * self.num_columns, 0);
 
         loop {
             // Reserve necessary space in output data based on best estimate
@@ -115,11 +160,12 @@ impl RecordDecoder {
 
             // Try to read a record
             loop {
+                let ends_bound = self.offsets_len + (self.num_columns - self.current_field);
                 let (result, bytes_read, bytes_written, end_positions) =
                     self.delimiter.read_record(
                         &input[input_offset..],
                         &mut self.data[self.data_len..],
-                        &mut self.offsets[self.offsets_len..],
+                        &mut self.offsets[self.offsets_len..ends_bound],
                     );
 
                 self.current_field += end_positions;
@@ -135,10 +181,47 @@ impl RecordDecoder {
                     // Need to allocate more capacity
                     ReadRecordResult::OutputFull => break,
                     ReadRecordResult::OutputEndsFull => {
-                        return Err(ArrowError::CsvError(format!(
-                            "incorrect number of fields for line {}, expected {} got more than {}",
-                            self.line_number, self.num_columns, self.current_field
-                        )));
+                        match self.extra_fields {
+                            ExtraFields::Error => {
+                                return Err(ArrowError::CsvError(format!(
+                                    "incorrect number of fields for line {}, expected {} got more than {}",
+                                    self.line_number, self.num_columns, self.current_field
+                                )));
+                            }
+                            ExtraFields::Ignore => {
+                                self.skipping_extra_fields = true;
+                                let mut dummy_data = [0u8; 128];
+                                let mut dummy_ends = [0usize; 1];
+                                loop {
+                                    let (res, b_read, _, _) = self.delimiter.read_record(
+                                        &input[input_offset..],
+                                        &mut dummy_data,
+                                        &mut dummy_ends,
+                                    );
+                                    input_offset += b_read;
+                                    match res {
+                                        ReadRecordResult::Record => {
+                                            self.skipping_extra_fields = false;
+                                            read += 1;
+                                            self.current_field = 0;
+                                            self.line_number += 1;
+                                            self.num_rows += 1;
+                                            break;
+                                        }
+                                        ReadRecordResult::OutputFull
+                                        | ReadRecordResult::OutputEndsFull => {}
+                                        ReadRecordResult::End | ReadRecordResult::InputEmpty => {
+                                            return Ok((read, input_offset));
+                                        }
+                                    }
+                                }
+
+                                if read == to_read || input.len() == input_offset {
+                                    // Read sufficient rows or reached end of input
+                                    return Ok((read, input_offset));
+                                }
+                            }
+                        }
                     }
                     ReadRecordResult::Record => {
                         if self.current_field != self.num_columns {
@@ -333,6 +416,7 @@ impl std::fmt::Display for StringRecord<'_> {
 
 #[cfg(test)]
 mod tests {
+    use crate::reader::ExtraFields;
     use crate::reader::records::RecordDecoder;
     use csv_core::Reader;
     use std::io::{BufRead, BufReader, Cursor};
@@ -356,7 +440,7 @@ mod tests {
         .into_iter();
 
         let mut reader = BufReader::with_capacity(3, Cursor::new(csv.as_bytes()));
-        let mut decoder = RecordDecoder::new(Reader::new(), 3, false);
+        let mut decoder = RecordDecoder::new(Reader::new(), 3, false, ExtraFields::Error);
 
         loop {
             let to_read = 3;
@@ -390,7 +474,7 @@ mod tests {
     #[test]
     fn test_invalid_fields() {
         let csv = "a,b\nb,c\na\n";
-        let mut decoder = RecordDecoder::new(Reader::new(), 2, false);
+        let mut decoder = RecordDecoder::new(Reader::new(), 2, false, ExtraFields::Error);
         let err = decoder.decode(csv.as_bytes(), 4).unwrap_err().to_string();
 
         let expected = "Csv error: incorrect number of fields for line 3, expected 2 got 1";
@@ -398,7 +482,7 @@ mod tests {
         assert_eq!(err, expected);
 
         // Test with initial skip
-        let mut decoder = RecordDecoder::new(Reader::new(), 2, false);
+        let mut decoder = RecordDecoder::new(Reader::new(), 2, false, ExtraFields::Error);
         let (skipped, bytes) = decoder.decode(csv.as_bytes(), 1).unwrap();
         assert_eq!(skipped, 1);
         decoder.clear();
@@ -411,7 +495,7 @@ mod tests {
     #[test]
     fn test_skip_insufficient_rows() {
         let csv = "a\nv\n";
-        let mut decoder = RecordDecoder::new(Reader::new(), 1, false);
+        let mut decoder = RecordDecoder::new(Reader::new(), 1, false, ExtraFields::Error);
         let (read, bytes) = decoder.decode(csv.as_bytes(), 3).unwrap();
         assert_eq!(read, 2);
         assert_eq!(bytes, csv.len());
@@ -420,7 +504,7 @@ mod tests {
     #[test]
     fn test_truncated_rows() {
         let csv = "a,b\nv\n,1\n,2\n,3\n";
-        let mut decoder = RecordDecoder::new(Reader::new(), 2, true);
+        let mut decoder = RecordDecoder::new(Reader::new(), 2, true, ExtraFields::Error);
         let (read, bytes) = decoder.decode(csv.as_bytes(), 5).unwrap();
         assert_eq!(read, 5);
         assert_eq!(bytes, csv.len());
@@ -431,7 +515,7 @@ mod tests {
     #[test]
     fn test_truncated_row_count_not_reset_by_flush() {
         let csv = "a\nb,2\nc\n";
-        let mut decoder = RecordDecoder::new(Reader::new(), 2, true);
+        let mut decoder = RecordDecoder::new(Reader::new(), 2, true, ExtraFields::Error);
 
         let (read, _) = decoder.decode(csv.as_bytes(), 2).unwrap();
         assert_eq!(read, 2);
@@ -449,7 +533,7 @@ mod tests {
     #[test]
     fn test_truncated_row_count_reset_by_clear() {
         let csv = "a\nb,2\n";
-        let mut decoder = RecordDecoder::new(Reader::new(), 2, true);
+        let mut decoder = RecordDecoder::new(Reader::new(), 2, true, ExtraFields::Error);
 
         let (read, _) = decoder.decode(csv.as_bytes(), 2).unwrap();
         assert_eq!(read, 2);
@@ -468,7 +552,7 @@ mod tests {
     /// surfaces the condition as `ArrowError::CsvError`.
     #[test]
     fn test_flush_offset_overflow_returns_csv_error() {
-        let mut decoder = RecordDecoder::new(Reader::new(), 1, false);
+        let mut decoder = RecordDecoder::new(Reader::new(), 1, false, ExtraFields::Error);
         decoder.offsets = vec![0, usize::MAX, 1];
         decoder.offsets_len = 3;
         decoder.num_rows = 2;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #10578.

## Rationale for this change

`arrow-csv` currently supports recovering rows with fewer fields than the
schema through `with_truncated_rows(true)`, but rows with more fields always
return an error.

This change adds an opt-in `ExtraFields::Ignore` mode that keeps the fields
defined by the schema and ignores trailing extra fields.

The default behavior remains `ExtraFields::Error`, preserving existing
behavior.

## What does this PR do?

- Add `ExtraFields::{Error, Ignore}` configuration.
- Add `ReaderBuilder::with_extra_fields()`.
- Limit CSV field-end storage to the expected fields for the current row.
- Ignore trailing fields when `ExtraFields::Ignore` is enabled.
- Add regression tests for extra fields, quoted fields, and chunk
  boundaries.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p arrow-csv`
- `cargo clippy -p arrow-csv --all-targets --all-features -- -D warnings`