### PR TITLE
chore(arrow-flight-sql): deprecate register_sql_info from FlightSqlService

### DIFF
--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -734,8 +734,6 @@ impl FlightSqlService for FlightSqlServiceImpl {
     ) -> Result<ActionCancelQueryResult, Status> {
         Err(Status::unimplemented("Implement do_action_cancel_query"))
     }
-
-    async fn register_sql_info(&self, _id: i32, _result: &SqlInfo) {}
 }
 
 /// This example shows how to run a FlightSql server

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -572,7 +572,7 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
     /// Register a new SqlInfo result, making it available when calling GetSqlInfo.
     #[deprecated(
         since = "59.4.0",
-        note = "takes no value to register and has no effect. Use `SqlInfoDataBuilder::append` instead"
+        note = "Not used in request handling and doesn't accept a value to register. Use `SqlInfoDataBuilder::append` instead"
     )]
     async fn register_sql_info(&self, _id: i32, _result: &SqlInfo) {}
 }

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -571,7 +571,7 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
 
     /// Register a new SqlInfo result, making it available when calling GetSqlInfo.
     #[deprecated(
-        since = "59.4.0",
+        since = "60.0.0",
         note = "Not used in request handling and doesn't accept a value to register. Use `SqlInfoDataBuilder::append` instead"
     )]
     async fn register_sql_info(&self, _id: i32, _result: &SqlInfo) {}

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -31,7 +31,7 @@ use super::{
     CommandGetXdbcTypeInfo, CommandPreparedStatementQuery, CommandPreparedStatementUpdate,
     CommandStatementIngest, CommandStatementQuery, CommandStatementSubstraitPlan,
     CommandStatementUpdate, DoPutPreparedStatementResult, DoPutUpdateResult, ProstMessageExt,
-    SqlInfo, TicketStatementQuery,
+    TicketStatementQuery,
 };
 use crate::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
@@ -568,9 +568,6 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
     ) -> Result<Response<<Self as FlightService>::DoExchangeStream>, Status> {
         Err(Status::unimplemented("Not yet implemented"))
     }
-
-    /// Register a new SqlInfo result, making it available when calling GetSqlInfo.
-    async fn register_sql_info(&self, id: i32, result: &SqlInfo);
 }
 
 /// Implements the lower level interface to handle FlightSQL

--- a/arrow-flight/src/sql/server.rs
+++ b/arrow-flight/src/sql/server.rs
@@ -31,7 +31,7 @@ use super::{
     CommandGetXdbcTypeInfo, CommandPreparedStatementQuery, CommandPreparedStatementUpdate,
     CommandStatementIngest, CommandStatementQuery, CommandStatementSubstraitPlan,
     CommandStatementUpdate, DoPutPreparedStatementResult, DoPutUpdateResult, ProstMessageExt,
-    TicketStatementQuery,
+    SqlInfo, TicketStatementQuery,
 };
 use crate::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
@@ -568,6 +568,13 @@ pub trait FlightSqlService: Sync + Send + Sized + 'static {
     ) -> Result<Response<<Self as FlightService>::DoExchangeStream>, Status> {
         Err(Status::unimplemented("Not yet implemented"))
     }
+
+    /// Register a new SqlInfo result, making it available when calling GetSqlInfo.
+    #[deprecated(
+        since = "59.4.0",
+        note = "takes no value to register and has no effect. Use `SqlInfoDataBuilder::append` instead"
+    )]
+    async fn register_sql_info(&self, _id: i32, _result: &SqlInfo) {}
 }
 
 /// Implements the lower level interface to handle FlightSQL

--- a/arrow-flight/tests/flight_sql_client.rs
+++ b/arrow-flight/tests/flight_sql_client.rs
@@ -29,7 +29,7 @@ use arrow_flight::sql::client::FlightSqlServiceClient;
 use arrow_flight::sql::server::{FlightSqlService, PeekableFlightDataStream};
 use arrow_flight::sql::{
     ActionBeginTransactionRequest, ActionBeginTransactionResult, ActionEndTransactionRequest,
-    CommandStatementIngest, EndTransaction, FallibleRequestStream, ProstMessageExt, SqlInfo,
+    CommandStatementIngest, EndTransaction, FallibleRequestStream, ProstMessageExt,
     TableDefinitionOptions, TableExistsOption, TableNotExistOption,
 };
 use arrow_flight::{Action, FlightData, FlightDescriptor};
@@ -280,8 +280,6 @@ impl FlightSqlService for FlightSqlServiceImpl {
         }
         Ok(())
     }
-
-    async fn register_sql_info(&self, _id: i32, _result: &SqlInfo) {}
 
     async fn do_put_statement_ingest(
         &self,

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -31,7 +31,7 @@ use arrow_flight::{
         ActionCreatePreparedStatementRequest, ActionCreatePreparedStatementResult, Any,
         CommandGetCatalogs, CommandGetDbSchemas, CommandGetTableTypes, CommandGetTables,
         CommandPreparedStatementQuery, CommandStatementQuery, DoPutPreparedStatementResult,
-        ProstMessageExt, SqlInfo,
+        ProstMessageExt,
         server::{FlightSqlService, PeekableFlightDataStream},
     },
     utils::batches_to_flight_data,
@@ -749,8 +749,6 @@ impl FlightSqlService for FlightSqlServiceImpl {
         Self::create_fake_prepared_stmt()
             .map_err(|e| Status::internal(format!("Unable to serialize schema: {e}")))
     }
-
-    async fn register_sql_info(&self, _id: i32, _result: &SqlInfo) {}
 }
 
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

N/A

# Rationale for this change

`FlightSqlService::register_sql_info` appears to be stale artefact and it is effectively a no-op in the trait definition. It appears to be carried over from Go's [`BaseServer` implementation](https://github.com/apache/arrow-go/blob/main/arrow/flight/flightsql/server.go#L594). 

Since `FlightSqlService` intends to represent Go's [`Server` implementation](https://github.com/apache/arrow-go/blob/main/arrow/flight/flightsql/server.go#L594-L720) instead it makes sense to remove this method from `FlightSqlService`.

Note: An alternative to removal of this method is change in its signature to `FlightSqlService::register_sql_info(id: SqlInfo, result: SqlInfoValue)`. I can implement that instead as well but it deviates from what `FlightSqlService` trait should be doing.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Remove `register_sql_info` from `FlightSqlService`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Tested via - 
```
cargo test -p arrow-flight --all-features
```
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?

Yes. This removes a public trait method. Implementors that currently define `register_sql_info` as part of their `FlightSqlService` implementation must remove it.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
