### PR TITLE
[Parquet] Stop byte array batches before 32 bit offsets overflow

### DIFF
--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -120,6 +120,10 @@ impl<I: OffsetSizeTrait> ArrayReader for ByteArrayReader<I> {
         read_records(&mut self.record_reader, self.pages.as_mut(), batch_size)
     }
 
+    fn stopped_for_capacity(&self) -> bool {
+        self.record_reader.stopped_for_capacity()
+    }
+
     fn consume_batch(&mut self) -> Result<ArrayRef> {
         let buffer = self.record_reader.consume_record_data();
         let null_buffer = self.record_reader.consume_compact_bitmap();
@@ -183,6 +187,11 @@ struct ByteArrayColumnValueDecoder<I: OffsetSizeTrait> {
     dict: Option<OffsetBuffer<I>>,
     decoder: Option<ByteArrayDecoder>,
     validate_utf8: bool,
+    /// The length in bytes of the longest value in `dict`
+    ///
+    /// Lets [`Self::values_capacity`] bound the decoded size of a dictionary
+    /// encoded page without decoding any keys
+    max_dict_value_len: usize,
 }
 
 impl<I: OffsetSizeTrait> ColumnValueDecoder for ByteArrayColumnValueDecoder<I> {
@@ -194,6 +203,7 @@ impl<I: OffsetSizeTrait> ColumnValueDecoder for ByteArrayColumnValueDecoder<I> {
             dict: None,
             decoder: None,
             validate_utf8,
+            max_dict_value_len: 0,
         }
     }
 
@@ -214,7 +224,7 @@ impl<I: OffsetSizeTrait> ColumnValueDecoder for ByteArrayColumnValueDecoder<I> {
             ));
         }
 
-        let mut buffer = OffsetBuffer::with_capacity(0);
+        let mut buffer = OffsetBuffer::<I>::with_capacity(0);
         let mut decoder = ByteArrayDecoderPlain::new(
             buf,
             num_values as usize,
@@ -222,6 +232,12 @@ impl<I: OffsetSizeTrait> ColumnValueDecoder for ByteArrayColumnValueDecoder<I> {
             self.validate_utf8,
         );
         decoder.read(&mut buffer, usize::MAX)?;
+        self.max_dict_value_len = buffer
+            .offsets
+            .windows(2)
+            .map(|w| w[1].as_usize() - w[0].as_usize())
+            .max()
+            .unwrap_or(0);
         self.dict = Some(buffer);
         Ok(())
     }
@@ -259,6 +275,19 @@ impl<I: OffsetSizeTrait> ColumnValueDecoder for ByteArrayColumnValueDecoder<I> {
             .ok_or_else(|| general_err!("no decoder set"))?;
 
         decoder.skip(num_values, self.dict.as_ref())
+    }
+
+    fn values_capacity(&self, out: &Self::Buffer) -> Option<usize> {
+        // 64 bit offsets cannot overflow for any buffer that fits in memory,
+        // and `IS_LARGE` is a constant so this whole method folds to `None`
+        // when monomorphised for `i64`
+        if I::IS_LARGE {
+            return None;
+        }
+        let headroom = I::MAX_OFFSET.saturating_sub(out.values.len());
+        self.decoder
+            .as_ref()?
+            .values_capacity(headroom, self.max_dict_value_len)
     }
 }
 
@@ -322,6 +351,25 @@ impl ByteArrayDecoder {
             }
             ByteArrayDecoder::DeltaLength(d) => d.read(out, len),
             ByteArrayDecoder::DeltaByteArray(d) => d.read(out, len),
+        }
+    }
+
+    /// Returns an upper bound on the number of values that can be decoded from
+    /// the remainder of this page into an [`OffsetBuffer`] with `headroom`
+    /// bytes of offset range left, or `None` if the whole remainder is
+    /// guaranteed to fit
+    ///
+    /// `max_dict_value_len` is the length of the longest value in the
+    /// dictionary and is only read for dictionary encoded pages.
+    ///
+    /// The common case is a single comparison against a bound that is already
+    /// known, no values are decoded and nothing is scanned.
+    pub fn values_capacity(&self, headroom: usize, max_dict_value_len: usize) -> Option<usize> {
+        match self {
+            ByteArrayDecoder::Plain(d) => d.values_capacity(headroom),
+            ByteArrayDecoder::Dictionary(d) => d.values_capacity(headroom, max_dict_value_len),
+            ByteArrayDecoder::DeltaLength(d) => d.values_capacity(headroom),
+            ByteArrayDecoder::DeltaByteArray(d) => d.values_capacity(headroom),
         }
     }
 
@@ -420,6 +468,38 @@ impl ByteArrayDecoderPlain {
             output.check_valid_utf8(initial_values_length)?;
         }
         Ok(to_read)
+    }
+
+    /// See [`ByteArrayDecoder::values_capacity`]
+    fn values_capacity(&self, headroom: usize) -> Option<usize> {
+        if self.max_remaining_values == 0 {
+            return None;
+        }
+        // The bytes left in the page bound the bytes this decoder can still
+        // append, and they include the four byte length prefixes, so this is a
+        // strict over-estimate. One comparison, no scan.
+        let remaining_bytes = self.buf.len() - self.offset;
+        if remaining_bytes <= headroom {
+            return None;
+        }
+
+        // Only reached when the remainder of the page might not fit: walk the
+        // length prefixes to find how many values do.
+        let buf = self.buf.as_ref();
+        let mut offset = self.offset;
+        let mut total = 0usize;
+        let mut count = 0usize;
+        while count < self.max_remaining_values && offset + 4 <= buf.len() {
+            let len_bytes: [u8; 4] = buf[offset..offset + 4].try_into().unwrap();
+            let len = u32::from_le_bytes(len_bytes) as usize;
+            if total + len > headroom {
+                break;
+            }
+            total += len;
+            offset += 4 + len;
+            count += 1;
+        }
+        Some(count)
     }
 
     pub fn skip(&mut self, to_skip: usize) -> Result<usize> {
@@ -523,6 +603,31 @@ impl ByteArrayDecoderDeltaLength {
         Ok(to_read)
     }
 
+    /// See [`ByteArrayDecoder::values_capacity`]
+    fn values_capacity(&self, headroom: usize) -> Option<usize> {
+        if self.length_offset >= self.lengths.len() {
+            return None;
+        }
+        // The value bytes left in the page bound what this decoder can still
+        // append. One comparison, no scan.
+        let remaining_bytes = self.data.len() - self.data_offset;
+        if remaining_bytes <= headroom {
+            return None;
+        }
+
+        let mut total = 0usize;
+        let mut count = 0usize;
+        for length in &self.lengths[self.length_offset..] {
+            let length = (*length).max(0) as usize;
+            if total + length > headroom {
+                break;
+            }
+            total += length;
+            count += 1;
+        }
+        Some(count)
+    }
+
     fn skip(&mut self, to_skip: usize) -> Result<usize> {
         let remain_values = self.lengths.len() - self.length_offset;
         let to_skip = remain_values.min(to_skip);
@@ -568,6 +673,22 @@ impl ByteArrayDecoderDelta {
         Ok(read)
     }
 
+    /// See [`ByteArrayDecoder::values_capacity`]
+    fn values_capacity(&self, headroom: usize) -> Option<usize> {
+        // A DELTA_BYTE_ARRAY value can be longer than the bytes it occupies in
+        // the page because of the shared prefix, so the page length is not a
+        // bound. Use the longest value in the page, which the decoder computed
+        // when it decoded the length arrays.
+        let max_value_len = self.decoder.max_value_len();
+        if max_value_len == 0 {
+            return None;
+        }
+        if self.decoder.remaining().saturating_mul(max_value_len) <= headroom {
+            return None;
+        }
+        Some(headroom / max_value_len)
+    }
+
     fn skip(&mut self, to_skip: usize) -> Result<usize> {
         self.decoder.skip(to_skip)
     }
@@ -602,6 +723,24 @@ impl ByteArrayDecoderDictionary {
         self.decoder.read(len, |keys| {
             output.extend_from_dictionary(keys, dict.offsets.as_slice(), dict.values.as_slice())
         })
+    }
+
+    /// See [`ByteArrayDecoder::values_capacity`]
+    fn values_capacity(&self, headroom: usize, max_dict_value_len: usize) -> Option<usize> {
+        // The keys are not decoded here, so bound the output by the longest
+        // value in the dictionary. One multiply and one comparison.
+        if max_dict_value_len == 0 {
+            return None;
+        }
+        if self
+            .decoder
+            .remaining()
+            .saturating_mul(max_dict_value_len)
+            <= headroom
+        {
+            return None;
+        }
+        Some(headroom / max_dict_value_len)
     }
 
     fn skip<I: OffsetSizeTrait>(
@@ -679,6 +818,48 @@ mod tests {
                     None,
                     None,
                 ]
+            );
+        }
+    }
+
+    #[test]
+    fn test_byte_array_decoder_values_capacity() {
+        // values are 5, 5, 1 and 1 bytes long
+        let (pages, encoded_dictionary) =
+            byte_array_all_encodings(vec!["hello", "world", "a", "b"]);
+
+        let column_desc = utf8_column();
+        let mut decoder = ByteArrayColumnValueDecoder::<i32>::new(&column_desc);
+        decoder
+            .set_dict(encoded_dictionary, 4, Encoding::RLE_DICTIONARY, false)
+            .unwrap();
+        assert_eq!(decoder.max_dict_value_len, 5);
+
+        for (encoding, page) in pages {
+            decoder.set_data(encoding, page, 4, Some(4)).unwrap();
+            let max_dict_value_len = decoder.max_dict_value_len;
+            let inner = decoder.decoder.as_ref().unwrap();
+
+            // Room for everything left in the page, so no cap is reported and
+            // the fast path does not scan
+            assert_eq!(
+                inner.values_capacity(usize::MAX / 2, max_dict_value_len),
+                None,
+                "{encoding}"
+            );
+
+            // Room for the first two values only
+            assert_eq!(
+                inner.values_capacity(10, max_dict_value_len),
+                Some(2),
+                "{encoding}"
+            );
+
+            // No room at all
+            assert_eq!(
+                inner.values_capacity(0, max_dict_value_len),
+                Some(0),
+                "{encoding}"
             );
         }
     }

--- a/parquet/src/arrow/array_reader/cached_array_reader.rs
+++ b/parquet/src/arrow/array_reader/cached_array_reader.rs
@@ -20,7 +20,7 @@
 use crate::arrow::array_reader::row_group_cache::BatchID;
 use crate::arrow::array_reader::{ArrayReader, row_group_cache::RowGroupCache};
 use crate::arrow::arrow_reader::metrics::ArrowReaderMetrics;
-use crate::errors::Result;
+use crate::errors::{ParquetError, Result};
 use arrow_array::{ArrayRef, BooleanArray, new_empty_array};
 use arrow_buffer::BooleanBufferBuilder;
 use arrow_schema::DataType as ArrowType;
@@ -140,6 +140,20 @@ impl CachedArrayReader {
         // columns to batch boundaries, so the batch containing that row is loaded.
         let read = self.inner.read_records(self.batch_size)?;
 
+        // The cache maps row offsets to batches at fixed multiples of
+        // `batch_size`, so a short read that is not end of column would make
+        // every later batch id point at the wrong rows. Refuse instead of
+        // silently returning shifted data.
+        // https://github.com/apache/arrow-rs/issues/7973
+        if read < self.batch_size && self.inner.stopped_for_capacity() {
+            return Err(general_err!(
+                "cannot split a batch inside the predicate cache: a byte array column \
+                 exceeded the 2GB limit of 32 bit offsets after {read} of {} rows. Read this \
+                 column as LargeUtf8, LargeBinary or a view type, or reduce the batch size",
+                self.batch_size
+            ));
+        }
+
         // If there are no remaining records (EOF), return immediately without
         // attempting to cache an empty batch. This prevents inserting zero-length
         // arrays into the cache which can later cause panics when slicing.
@@ -195,6 +209,10 @@ impl ArrayReader for CachedArrayReader {
 
     fn get_data_type(&self) -> &ArrowType {
         self.inner.get_data_type()
+    }
+
+    fn stopped_for_capacity(&self) -> bool {
+        self.inner.stopped_for_capacity()
     }
 
     fn read_records(&mut self, num_records: usize) -> Result<usize> {

--- a/parquet/src/arrow/array_reader/mod.rs
+++ b/parquet/src/arrow/array_reader/mod.rs
@@ -106,6 +106,19 @@ pub trait ArrayReader: Send {
     /// pages is exhausted.
     fn read_records(&mut self, batch_size: usize) -> Result<usize>;
 
+    /// Returns true if the last call to [`ArrayReader::read_records`] returned
+    /// fewer records than requested because the output array could not
+    /// represent more of them, rather than because the column was exhausted.
+    ///
+    /// The motivating case is a `StringArray` or `BinaryArray` whose 32 bit
+    /// offsets cannot address more than `i32::MAX` bytes of values, see
+    /// <https://github.com/apache/arrow-rs/issues/7973>.
+    ///
+    /// Callers that assume a short read means end of column must check this.
+    fn stopped_for_capacity(&self) -> bool {
+        false
+    }
+
     /// Consume all currently stored buffer data
     /// into an arrow array and return it.
     fn consume_batch(&mut self) -> Result<ArrayRef>;
@@ -207,6 +220,15 @@ where
 
         let records_read_once = record_reader.read_records(records_to_read)?;
         records_read += records_read_once;
+
+        // The values buffer cannot accept more data in this batch, e.g. a 32
+        // bit offset buffer that is about to overflow. Emit a short batch
+        // rather than treating this as an exhausted column chunk, which would
+        // advance the page iterator and silently drop the rest of the chunk.
+        // https://github.com/apache/arrow-rs/issues/7973
+        if record_reader.stopped_for_capacity() {
+            break;
+        }
 
         // Record reader exhausted
         if records_read_once < records_to_read {

--- a/parquet/src/arrow/array_reader/struct_array.rs
+++ b/parquet/src/arrow/array_reader/struct_array.rs
@@ -76,6 +76,22 @@ impl ArrayReader for StructArrayReader {
             match read {
                 Some(expected) => {
                     if expected != child_read {
+                        if self.stopped_for_capacity() {
+                            // One column ran out of offset range part way
+                            // through the batch, but the other columns have
+                            // already decoded past that point and cannot be
+                            // rewound. Fail loudly rather than emit misaligned
+                            // columns. Reading such a column on its own works,
+                            // see https://github.com/apache/arrow-rs/issues/7973
+                            return Err(general_err!(
+                                "cannot split a batch across multiple columns: a byte array \
+                                 column exceeded the 2GB limit of 32 bit offsets after {} of \
+                                 {} rows. Read this column as LargeUtf8, LargeBinary or a \
+                                 view type, or reduce the batch size",
+                                child_read.min(expected),
+                                batch_size
+                            ));
+                        }
                         return Err(general_err!(
                             "StructArrayReader out of sync in read_records, expected {} read, got {}",
                             expected,
@@ -87,6 +103,12 @@ impl ArrayReader for StructArrayReader {
             }
         }
         Ok(read.unwrap_or(0))
+    }
+
+    fn stopped_for_capacity(&self) -> bool {
+        self.children
+            .iter()
+            .any(|child| child.stopped_for_capacity())
     }
 
     fn consume_batch(&mut self) -> Result<ArrayRef> {

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -1590,6 +1590,17 @@ fn read_mask_batch(
             ));
         }
         if read != mask_chunk.chunk_rows {
+            if array_reader.stopped_for_capacity() {
+                // The mask has already been built for `chunk_rows` rows and the
+                // cursor has moved past them, so a shorter read cannot be
+                // reconciled here.
+                // https://github.com/apache/arrow-rs/issues/7973
+                return Err(general_err!(
+                    "cannot split a batch under a row filter: a byte array column exceeded                      the 2GB limit of 32 bit offsets after {} of {} rows. Read this column                      as LargeUtf8, LargeBinary or a view type, or reduce the batch size",
+                    read,
+                    mask_chunk.chunk_rows
+                ));
+            }
             return Err(general_err!(
                 "insufficient rows read from array reader - expected {}, got {}",
                 mask_chunk.chunk_rows,
@@ -1692,7 +1703,19 @@ impl ParquetRecordBatchReader {
                     };
                     match self.array_reader.read_records(to_read)? {
                         0 => break,
-                        rec => read_records += rec,
+                        rec => {
+                            read_records += rec;
+                            if rec < to_read && self.array_reader.stopped_for_capacity() {
+                                // The reader stopped part way through this
+                                // selector because the output could not hold
+                                // more, so hand the rows it did not read back
+                                // to the cursor and emit a shorter batch.
+                                // https://github.com/apache/arrow-rs/issues/7973
+                                selectors_cursor
+                                    .return_selector(RowSelector::select(to_read - rec));
+                                break;
+                            }
+                        }
                     }
                 }
             }

--- a/parquet/src/arrow/decoder/delta_byte_array.rs
+++ b/parquet/src/arrow/decoder/delta_byte_array.rs
@@ -29,6 +29,12 @@ pub struct DeltaByteArrayDecoder {
     length_offset: usize,
     data_offset: usize,
     last_value: Vec<u8>,
+    /// The length in bytes of the longest value in this page
+    ///
+    /// Computed once here because a `DELTA_BYTE_ARRAY` value can be longer than
+    /// the bytes it occupies in the page, so the page length is not an upper
+    /// bound on the decoded size. See [`Self::max_value_len`].
+    max_value_len: usize,
 }
 
 impl DeltaByteArrayDecoder {
@@ -56,6 +62,13 @@ impl DeltaByteArrayDecoder {
 
         assert_eq!(prefix_lengths.len(), suffix_lengths.len());
 
+        let max_value_len = prefix_lengths
+            .iter()
+            .zip(&suffix_lengths)
+            .map(|(prefix, suffix)| (*prefix).max(0) as usize + (*suffix).max(0) as usize)
+            .max()
+            .unwrap_or(0);
+
         Ok(Self {
             prefix_lengths,
             suffix_lengths,
@@ -63,7 +76,16 @@ impl DeltaByteArrayDecoder {
             length_offset: 0,
             data_offset: prefix.get_offset() + suffix.get_offset(),
             last_value: vec![],
+            max_value_len,
         })
+    }
+
+    /// Returns the length in bytes of the longest value in this page
+    ///
+    /// Together with [`Self::remaining`] this bounds the number of bytes this
+    /// decoder can still append to an output buffer, without decoding anything.
+    pub fn max_value_len(&self) -> usize {
+        self.max_value_len
     }
 
     /// Returns the number of values remaining

--- a/parquet/src/arrow/decoder/dictionary_index.rs
+++ b/parquet/src/arrow/decoder/dictionary_index.rs
@@ -98,6 +98,14 @@ impl DictIndexDecoder {
         Ok(values_read)
     }
 
+    /// Returns the maximum number of values this decoder can still produce
+    ///
+    /// This is a maximum as the null count is not always known, e.g. value data
+    /// from a v1 data page
+    pub fn remaining(&self) -> usize {
+        self.max_remaining_values
+    }
+
     /// Skip up to `to_skip` values, returning the number of values skipped
     pub fn skip(&mut self, to_skip: usize) -> Result<usize> {
         let to_skip = to_skip.min(self.max_remaining_values);

--- a/parquet/src/arrow/record_reader/mod.rs
+++ b/parquet/src/arrow/record_reader/mod.rs
@@ -154,11 +154,35 @@ where
         loop {
             let records_to_read = num_records - records_read;
             records_read += self.read_one_batch(records_to_read)?;
-            if records_read == num_records || !self.column_reader.as_mut().unwrap().has_next()? {
+            let reader = self.column_reader.as_mut().unwrap();
+            // A short read caused by the values buffer running out of capacity
+            // is not an exhausted column chunk, and reading again would either
+            // spin or overflow. Stop and let the caller emit a shorter batch.
+            // https://github.com/apache/arrow-rs/issues/7973
+            if records_read == num_records || reader.stopped_for_capacity() || !reader.has_next()? {
                 break;
             }
         }
+
+        if records_read == 0 && self.num_values == 0 && self.stopped_for_capacity() {
+            // Nothing is buffered and not even one value fits, so shortening
+            // the batch cannot make progress.
+            return Err(general_err!(
+                "index overflow decoding byte array: a single value is too large to address \
+                 with 32 bit offsets, read this column as LargeUtf8, LargeBinary or a view type"
+            ));
+        }
+
         Ok(records_read)
+    }
+
+    /// Returns true if the last call to [`Self::read_records`] returned fewer
+    /// records than requested because the values buffer could not accept more
+    /// data, rather than because the column chunk was exhausted
+    pub fn stopped_for_capacity(&self) -> bool {
+        self.column_reader
+            .as_ref()
+            .is_some_and(|reader| reader.stopped_for_capacity())
     }
 
     /// Try to skip the next `num_records` rows

--- a/parquet/src/column/reader.rs
+++ b/parquet/src/column/reader.rs
@@ -136,6 +136,11 @@ pub struct GenericColumnReader<R, D, V> {
 
     /// The decoder for the values
     values_decoder: V,
+
+    /// True if the last call to [`Self::read_records`] returned fewer records
+    /// than requested because the values buffer could not accept more data,
+    /// rather than because the column chunk was exhausted
+    stopped_for_capacity: bool,
 }
 
 impl<V> GenericColumnReader<RepetitionLevelDecoderImpl, DefinitionLevelDecoderImpl, V>
@@ -184,6 +189,7 @@ where
             num_decoded_values: 0,
             values_decoder,
             has_record_delimiter: false,
+            stopped_for_capacity: false,
         }
     }
 
@@ -234,9 +240,34 @@ where
         let mut total_levels_read = 0;
         let mut total_values_read = 0;
 
+        self.stopped_for_capacity = false;
+
+        // A repeated column can produce many values for a single record, so a
+        // value budget cannot be turned into a record budget. Only non-repeated
+        // columns are capped.
+        let cap_values = self.rep_level_decoder.is_none();
+
         while total_records_read < max_records && self.has_next()? {
-            let remaining_records = max_records - total_records_read;
+            let mut remaining_records = max_records - total_records_read;
             let remaining_levels = self.num_buffered_values - self.num_decoded_values;
+
+            // `values` may not be able to hold `remaining_records` more values,
+            // e.g. a 32 bit offset buffer whose offsets would overflow. Shorten
+            // the batch here, before any levels are consumed, so that the level
+            // and value streams stay in lockstep. For a non-repeated column a
+            // record contributes at most one value, so capping records by the
+            // value budget is always safe.
+            // https://github.com/apache/arrow-rs/issues/7973
+            if cap_values && let Some(capacity) = self.values_decoder.values_capacity(values) {
+                if capacity == 0 {
+                    self.stopped_for_capacity = true;
+                    break;
+                }
+                if capacity < remaining_records {
+                    remaining_records = capacity;
+                    self.stopped_for_capacity = true;
+                }
+            }
 
             let (records_read, levels_to_read) = match self.rep_level_decoder.as_mut() {
                 Some(reader) => {
@@ -304,6 +335,16 @@ where
         }
 
         Ok((total_records_read, total_values_read, total_levels_read))
+    }
+
+    /// Returns true if the last call to [`Self::read_records`] stopped before
+    /// `max_records` because the values buffer could not accept more data.
+    ///
+    /// Callers must not treat such a short read as an exhausted column chunk.
+    ///
+    /// See [`ColumnValueDecoder::values_capacity`].
+    pub fn stopped_for_capacity(&self) -> bool {
+        self.stopped_for_capacity
     }
 
     /// Skips over `num_records` records, where records are delimited by repetition levels of 0

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -132,6 +132,27 @@ pub trait ColumnValueDecoder {
     ///
     /// Returns the number of values skipped
     fn skip_values(&mut self, num_values: usize) -> Result<usize>;
+
+    /// Returns an upper bound on the number of values that can still be decoded
+    /// into `out` from the current data page, or `None` if the remainder of the
+    /// page is guaranteed to fit.
+    ///
+    /// Some output buffers cannot represent an arbitrary number of values. The
+    /// clearest case is a 32 bit offset buffer, which cannot address more than
+    /// `i32::MAX` bytes of values, see
+    /// <https://github.com/apache/arrow-rs/issues/7973>. Reporting the bound
+    /// here lets the column reader shorten a batch *before* any levels are
+    /// consumed, which keeps the level and value streams in lockstep.
+    ///
+    /// `Some(0)` means not even one more value fits.
+    ///
+    /// This is called at most once per data page per batch and must not decode
+    /// any values. The default implementation returns `None`, and is compiled
+    /// away for decoders that do not override it because the column reader is
+    /// generic over this trait.
+    fn values_capacity(&self, _out: &Self::Buffer) -> Option<usize> {
+        None
+    }
 }
 
 /// Bucket-based storage for decoder instances keyed by `Encoding`.

--- a/parquet/tests/arrow_reader/large_string_overflow.rs
+++ b/parquet/tests/arrow_reader/large_string_overflow.rs
@@ -15,120 +15,136 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Regression tests for <https://github.com/apache/arrow-rs/issues/7973>
+//!
+//! A row group whose byte array column holds more than `i32::MAX` bytes cannot
+//! be decoded into a single `BinaryArray`, because the 32 bit offsets overflow.
+//! The reader must emit shorter batches instead of failing.
+//!
+//! Note the input arrays are written in chunks that each stay under the 2GB
+//! limit, so that the writer side never has to build an oversized
+//! `BinaryArray`. The overflow being tested is on the read side.
+
 use std::sync::Arc;
 
-use arrow_array::builder::BinaryBuilder;
-use arrow_array::{ArrayRef, RecordBatch};
+use arrow_array::{Array, ArrayRef, BinaryArray, RecordBatch};
 use arrow_schema::{DataType, Field, Schema};
 
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::arrow_writer::ArrowWriter;
-use parquet::basic::Encoding;
+use parquet::basic::{Compression, Encoding};
 use parquet::file::properties::WriterProperties;
 
 use tempfile::tempfile;
 
-/// Number of rows written
-const ROWS: usize = 1024;
+/// Number of rows written, all in a single row group
+const ROWS: usize = 700;
 
-/// Size of each binary value (~3MB)
-/// 1024 * 3MB ≈ 3GB total → guaranteed offset overflow for i32
+/// Size of each binary value (3MB)
+///
+/// 700 * 3MB = 2.1GB total, so the i32 offsets overflow at row 683
 const VALUE_SIZE: usize = 3 * 1024 * 1024;
 
-fn make_large_binary_array() -> ArrayRef {
-    let mut builder = BinaryBuilder::new();
+/// Rows written per `RecordBatch`, small enough that no single input array
+/// exceeds the 2GB limit
+const WRITE_CHUNK: usize = 100;
 
-    for _ in 0..ROWS {
-        let data = vec![b'a'; VALUE_SIZE];
-        builder.append_value(&data);
-    }
-
-    Arc::new(builder.finish()) as ArrayRef
-}
-
-fn write_parquet_with_encoding(array: ArrayRef, encoding: Encoding) -> std::fs::File {
-    let schema = Arc::new(Schema::new(vec![Field::new(
+fn schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![Field::new(
         "col",
         DataType::Binary,
         false,
-    )]));
+    )]))
+}
 
-    let batch = RecordBatch::try_new(schema.clone(), vec![array]).unwrap();
+/// The `i`th value, distinct in its first bytes so that mixed up rows are caught
+fn value(i: usize) -> Vec<u8> {
+    let mut data = vec![b'a'; VALUE_SIZE];
+    data[..8].copy_from_slice(&(i as u64).to_le_bytes());
+    data
+}
 
+fn write_parquet_with_encoding(encoding: Encoding) -> std::fs::File {
+    let schema = schema();
     let file = tempfile().unwrap();
 
-    let builder = WriterProperties::builder();
+    let builder = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .set_max_row_group_row_count(Some(ROWS))
+        .set_max_row_group_bytes(None);
     let builder = match encoding {
         Encoding::RLE_DICTIONARY => builder.set_dictionary_enabled(true),
         _ => builder.set_dictionary_enabled(false).set_encoding(encoding),
     };
 
-    let props = builder.build();
+    let mut writer = ArrowWriter::try_new(
+        file.try_clone().unwrap(),
+        schema.clone(),
+        Some(builder.build()),
+    )
+    .unwrap();
 
-    let mut writer = ArrowWriter::try_new(file.try_clone().unwrap(), schema, Some(props)).unwrap();
+    for chunk in (0..ROWS).step_by(WRITE_CHUNK) {
+        let values: Vec<Vec<u8>> = (chunk..(chunk + WRITE_CHUNK).min(ROWS))
+            .map(value)
+            .collect();
+        let array: ArrayRef = Arc::new(BinaryArray::from_iter_values(&values));
+        let batch = RecordBatch::try_new(schema.clone(), vec![array]).unwrap();
+        writer.write(&batch).unwrap();
+    }
 
-    writer.write(&batch).unwrap();
     writer.close().unwrap();
-
     file
 }
 
-#[test]
-// Panics until https://github.com/apache/arrow-rs/issues/7973 is fixed
-#[should_panic(expected = "byte array offset overflow")]
-fn large_binary_plain_encoding_overflow() {
-    let array = make_large_binary_array();
-    let file = write_parquet_with_encoding(array, Encoding::PLAIN);
+/// Read the whole file back and check every value survives, in order, split
+/// across however many batches the reader needs
+fn assert_reads_all_rows(encoding: Encoding) {
+    let file = write_parquet_with_encoding(encoding);
 
-    let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)
         .unwrap()
+        .with_batch_size(ROWS)
         .build()
         .unwrap();
 
-    let _ = reader.next().unwrap();
+    let mut batches = 0;
+    let mut row = 0;
+    for batch in reader {
+        let batch = batch.unwrap();
+        batches += 1;
+        let column = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        for i in 0..column.len() {
+            let v = column.value(i);
+            assert_eq!(v.len(), VALUE_SIZE, "row {row} has the wrong length");
+            assert_eq!(
+                u64::from_le_bytes(v[..8].try_into().unwrap()),
+                row as u64,
+                "row {row} is out of order"
+            );
+            row += 1;
+        }
+    }
+
+    assert_eq!(row, ROWS, "{encoding}: lost rows while splitting batches");
+    assert!(
+        batches > 1,
+        "{encoding}: expected the reader to split the row group into more than one batch"
+    );
 }
 
+/// All four byte array encodings, in one test so the encodings run one after
+/// another. Each one holds a little over 2GB while it decodes, and running them
+/// as four separate tests lets the harness run them in parallel, which needs
+/// four times the memory.
 #[test]
-// Panics until https://github.com/apache/arrow-rs/issues/7973 is fixed
-#[should_panic(expected = "byte array offset overflow")]
-fn large_binary_delta_length_encoding_overflow() {
-    let array = make_large_binary_array();
-    let file = write_parquet_with_encoding(array, Encoding::DELTA_LENGTH_BYTE_ARRAY);
-
-    let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)
-        .unwrap()
-        .build()
-        .unwrap();
-
-    let _ = reader.next().unwrap();
-}
-
-#[test]
-// Panics until https://github.com/apache/arrow-rs/issues/7973 is fixed
-#[should_panic(expected = "byte array offset overflow")]
-fn large_binary_delta_byte_array_encoding_overflow() {
-    let array = make_large_binary_array();
-    let file = write_parquet_with_encoding(array, Encoding::DELTA_BYTE_ARRAY);
-
-    let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)
-        .unwrap()
-        .build()
-        .unwrap();
-
-    let _ = reader.next().unwrap();
-}
-
-#[test]
-// Panics until https://github.com/apache/arrow-rs/issues/7973 is fixed
-#[should_panic(expected = "byte array offset overflow")]
-fn large_binary_rle_dictionary_encoding_overflow() {
-    let array = make_large_binary_array();
-    let file = write_parquet_with_encoding(array, Encoding::RLE_DICTIONARY);
-
-    let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)
-        .unwrap()
-        .build()
-        .unwrap();
-
-    let _ = reader.next().unwrap();
+fn large_binary_offset_overflow() {
+    assert_reads_all_rows(Encoding::PLAIN);
+    assert_reads_all_rows(Encoding::DELTA_LENGTH_BYTE_ARRAY);
+    assert_reads_all_rows(Encoding::DELTA_BYTE_ARRAY);
+    assert_reads_all_rows(Encoding::RLE_DICTIONARY);
 }


### PR DESCRIPTION
Part of #7973.

Byte array columns break once the values in one batch exceed i32::MAX. At the default batch size of 8192 that caps the average value around 256KB. The 5MB rows in the issue only get about 409 into a batch before OffsetBuffer::try_push errors. DELTA_LENGTH_BYTE_ARRAY is worse and panics outright, because that path builds offsets with expect instead of try_push.

Three earlier attempts, #9362, #9369 and #9504, all tried to stop inside the byte array decoder and return a short count. That cannot work from there. The definition levels are already consumed by the time the values decoder runs, so there is nothing left to unwind. A short read that is not end-of-chunk gets treated as an exhausted chunk and silently drops the rest. And a decoder returning zero while the page still has data spins forever.

So the cap has to be applied before any levels are read. This adds ColumnValueDecoder::values_capacity, defaulting to None, which reports how many more values fit in the output buffer. The column reader checks it before consuming levels.

Single-column reads are correct with this. Multi-column needs a structural decision I would rather agree with you before building. Separately, the regression tests currently on main do not actually exercise the overflow.

Parts of this were written with AI assistance. I have reviewed and debugged all of it and can explain any part of it.
