### PR TITLE
Fix take on zero-width FixedSizeListArray

### DIFF
--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -863,7 +863,13 @@ fn take_fixed_size_list<IndexType: ArrowPrimitiveType, const CHECKED: bool>(
         take_impl::<UInt32Type, CHECKED>(child.as_ref(), &list_indices)?
     };
 
-    FixedSizeListArray::try_new(field.clone(), length as i32, taken_child, nulls)
+    FixedSizeListArray::try_new_with_length(
+        field.clone(),
+        length as i32,
+        taken_child,
+        nulls,
+        indices.len(),
+    )
 }
 
 #[inline(never)]
@@ -3213,5 +3219,22 @@ mod tests {
         assert!(child.is_null(3));
         assert_eq!(child.value(4), 1);
         assert_eq!(child.value(5), 2);
+    }
+
+    #[test]
+    fn test_take_zero_sized_fixed_size_list() {
+        let input = FixedSizeListArray::try_new_with_length(
+            Field::new_list_field(DataType::Int32, true).into(),
+            0,
+            Arc::new(Int32Array::new_null(0)),
+            None,
+            3,
+        )
+        .unwrap();
+
+        let indices = UInt32Array::from(vec![2, 0]);
+        let result = take(&input, &indices, None).unwrap();
+
+        assert_eq!(result.len(), 2);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes https://github.com/apache/arrow-rs/issues/10914.

# Rationale for this change

`take` returns no rows for a non-nullable `FixedSizeListArray` whose list size
is zero, regardless of how many indices were requested. With a three-row input
and indices `[2, 0]`, the result has length 0 instead of 2.

The take kernel rebuilt the result with `FixedSizeListArray::try_new`. That
constructor cannot infer a row count from an empty child array when there is no
null buffer, so it defaults to zero.

# What changes are included in this PR?

The kernel now passes `indices.len()` to
`FixedSizeListArray::try_new_with_length`. For nonzero list sizes this is the
same length previously derived from the child array. A regression test covers
the zero-width case.

# Are these changes tested?

Yes.

<details>
<summary>Raw test output</summary>

```text
$ git rev-parse HEAD
cbbb56bba13c85f36505453b08f22f8ab71b5794
$ cargo test -p arrow-select --test issue_10914
test take_preserves_zero_width_fixed_size_list_length ... FAILED
assertion `left == right` failed
  left: 0
 right: 2

$ git rev-parse HEAD
b9dac7cfd239766b5d77dfbcb18ca9524bfbeba1
$ cargo test -p arrow-select
test result: ok. 418 passed; 0 failed
test result: ok. 17 passed; 0 failed
```

</details>

# Are there any user-facing changes?

`take` now preserves one output row per requested index for zero-width
`FixedSizeListArray` values. No public API changes.
