### PR TITLE
feat: merge dictionary values for view types, dedup exactly on overflow

### DIFF
--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -1709,6 +1709,124 @@ mod tests {
     }
 
     #[test]
+    fn concat_string_view_dictionary_merges_duplicate_values() {
+        // Two independently-built `Dictionary<UInt8, Utf8View>` arrays holding the
+        // same 200 distinct values. Naively concatenating their dictionaries yields
+        // 400 entries, which overflows the u8 key range, but the distinct values do
+        // fit -- so the values must be merged and deduplicated instead. This mirrors
+        // a `Dictionary<UInt16, Utf8View>` column read in several partitions, each
+        // building its own dictionary, and then combined.
+        let dict = |offset: usize| {
+            let values: StringViewArray = (0..200).map(|i| Some(format!("v{i}"))).collect();
+            let keys = UInt8Array::from_iter_values((0..200).map(|i| (i + offset) as u8 % 200));
+            DictionaryArray::<UInt8Type>::new(keys, Arc::new(values))
+        };
+        let (a, b) = (dict(0), dict(7));
+
+        let combined = concat(&[&a, &b]).unwrap();
+        let combined = combined.as_dictionary::<UInt8Type>();
+
+        assert_eq!(combined.len(), 400);
+        assert_eq!(combined.values().data_type(), &DataType::Utf8View);
+        assert!(combined.values().len() < 400);
+
+        let values = combined.values().as_string_view();
+        let actual: Vec<_> = combined
+            .keys()
+            .values()
+            .iter()
+            .map(|k| values.value(*k as usize))
+            .collect();
+        let expected: Vec<_> = [&a, &b]
+            .iter()
+            .flat_map(|d| {
+                let v = d.values().as_string_view();
+                d.keys()
+                    .values()
+                    .iter()
+                    .map(|k| v.value(*k as usize))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn concat_binary_view_dictionary_merges_duplicate_values() {
+        // Same as `concat_string_view_dictionary_merges_duplicate_values`, for the
+        // other view-typed dictionary value layout.
+        let dict = || {
+            let values: BinaryViewArray = (0..200u32)
+                .map(|i| Some(i.to_le_bytes().to_vec()))
+                .collect();
+            let keys = UInt8Array::from_iter_values(0..200);
+            DictionaryArray::<UInt8Type>::new(keys, Arc::new(values))
+        };
+
+        let combined = concat(&[&dict(), &dict()]).unwrap();
+        let combined = combined.as_dictionary::<UInt8Type>();
+
+        assert_eq!(combined.len(), 400);
+        assert_eq!(combined.values().data_type(), &DataType::BinaryView);
+        assert!(combined.values().len() < 400);
+
+        let values = combined.values().as_binary_view();
+        let actual: Vec<_> = combined
+            .keys()
+            .values()
+            .iter()
+            .map(|k| values.value(*k as usize))
+            .collect();
+        let expected: Vec<_> = (0..2)
+            .flat_map(|_| (0..200u32).map(|i| i.to_le_bytes().to_vec()))
+            .collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn concat_dictionary_merges_values_of_many_arrays() {
+        // Four dictionaries over the same 200 distinct values. Concatenating
+        // their values would need 800 keys, well past the u8 key range, so this
+        // only succeeds if the merge deduplicates them.
+        let dicts: Vec<_> = (0..4)
+            .map(|d| {
+                let values: StringArray = (0..200).map(|i| Some(format!("v{i}"))).collect();
+                let keys = UInt8Array::from_iter_values((0..200).map(|i| (i + d * 17) as u8 % 200));
+                DictionaryArray::<UInt8Type>::new(keys, Arc::new(values))
+            })
+            .collect();
+        let refs: Vec<&dyn Array> = dicts.iter().map(|d| d as &dyn Array).collect();
+
+        let combined = concat(&refs).unwrap();
+        let combined = combined.as_dictionary::<UInt8Type>();
+
+        assert_eq!(combined.len(), 800);
+        // Every key is addressable; how far below 200 the merge gets depends on
+        // whether the best-effort interner sufficed or the exact retry ran
+        assert!(u8::try_from(combined.values().len()).is_ok());
+
+        let values = combined.values().as_string::<i32>();
+        let actual: Vec<_> = combined
+            .keys()
+            .values()
+            .iter()
+            .map(|k| values.value(*k as usize))
+            .collect();
+        let expected: Vec<_> = dicts
+            .iter()
+            .flat_map(|d| {
+                let v = d.values().as_string::<i32>();
+                d.keys()
+                    .values()
+                    .iter()
+                    .map(|k| v.value(*k as usize))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn concat_dictionary_list_array_simple() {
         let scalars = [
             create_single_row_list_of_dict(vec![Some("a")]),

--- a/arrow-select/src/concat.rs
+++ b/arrow-select/src/concat.rs
@@ -1713,9 +1713,7 @@ mod tests {
         // Two independently-built `Dictionary<UInt8, Utf8View>` arrays holding the
         // same 200 distinct values. Naively concatenating their dictionaries yields
         // 400 entries, which overflows the u8 key range, but the distinct values do
-        // fit -- so the values must be merged and deduplicated instead. This mirrors
-        // a `Dictionary<UInt16, Utf8View>` column read in several partitions, each
-        // building its own dictionary, and then combined.
+        // fit -- so the values must be merged and deduplicated instead.
         let dict = |offset: usize| {
             let values: StringViewArray = (0..200).map(|i| Some(format!("v{i}"))).collect();
             let keys = UInt8Array::from_iter_values((0..200).map(|i| (i + offset) as u8 % 200));
@@ -1728,7 +1726,10 @@ mod tests {
 
         assert_eq!(combined.len(), 400);
         assert_eq!(combined.values().data_type(), &DataType::Utf8View);
-        assert!(combined.values().len() < 400);
+        // Merged down to something the key type can address. Two dictionaries
+        // stay within reach of the best-effort interner, so a few duplicates
+        // survive and the count is not exactly 200
+        assert!(u8::try_from(combined.values().len()).is_ok());
 
         let values = combined.values().as_string_view();
         let actual: Vec<_> = combined
@@ -1768,7 +1769,7 @@ mod tests {
 
         assert_eq!(combined.len(), 400);
         assert_eq!(combined.values().data_type(), &DataType::BinaryView);
-        assert!(combined.values().len() < 400);
+        assert!(u8::try_from(combined.values().len()).is_ok());
 
         let values = combined.values().as_binary_view();
         let actual: Vec<_> = combined
@@ -1801,9 +1802,10 @@ mod tests {
         let combined = combined.as_dictionary::<UInt8Type>();
 
         assert_eq!(combined.len(), 800);
-        // Every key is addressable; how far below 200 the merge gets depends on
-        // whether the best-effort interner sufficed or the exact retry ran
-        assert!(u8::try_from(combined.values().len()).is_ok());
+        // Four dictionaries leave the best-effort interner with more duplicates
+        // than the key type can address, so the exact retry runs and the merged
+        // values end up one per distinct value
+        assert_eq!(combined.values().len(), 200);
 
         let values = combined.values().as_string::<i32>();
         let actual: Vec<_> = combined

--- a/arrow-select/src/dictionary.rs
+++ b/arrow-select/src/dictionary.rs
@@ -464,22 +464,21 @@ mod tests {
     use arrow_buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer};
     use std::sync::Arc;
 
-    use arrow_array::types::UInt16Type;
-    use arrow_array::{StringViewArray, UInt16Array};
+    use arrow_array::types::UInt8Type;
+    use arrow_array::{StringViewArray, UInt8Array};
 
     #[test]
-    #[cfg_attr(miri, ignore)] // Takes too long
     fn merge_string_view_dictionaries_deduplicates_exactly() {
-        // Four dictionaries over the same values: 60000 distinct strings, an
-        // empty string and a null. Concatenating them would need 240008 keys,
-        // far past the UInt16 range, while the distinct values leave room to
-        // spare -- so the merge has to deduplicate them exactly. At this
-        // cardinality the best-effort interner alone leaves thousands of
-        // duplicates behind and overflows, which forces the exact retry.
-        const DISTINCT: usize = 60000;
+        // Four dictionaries over the same values: 200 distinct strings, an
+        // empty string and a null. Concatenating them would need 808 keys, far
+        // past the u8 range, while the distinct values leave room to spare --
+        // so the merge has to deduplicate them exactly. At this cardinality the
+        // best-effort interner alone leaves enough duplicates behind to
+        // overflow, which forces the exact retry.
+        const DISTINCT: usize = 200;
         let len = DISTINCT + 2;
 
-        let dictionaries: Vec<DictionaryArray<UInt16Type>> = (0..4)
+        let dictionaries: Vec<DictionaryArray<UInt8Type>> = (0..4)
             .map(|d| {
                 let values: StringViewArray = (0..DISTINCT)
                     .map(|i| Some(format!("value_{i:06}")))
@@ -488,12 +487,12 @@ mod tests {
                 // Offset the keys per dictionary so the merge can't rely on the
                 // arrays being laid out the same way
                 let keys =
-                    UInt16Array::from_iter_values((0..len).map(|i| ((i + d * 7919) % len) as u16));
-                DictionaryArray::<UInt16Type>::new(keys, Arc::new(values))
+                    UInt8Array::from_iter_values((0..len).map(|i| ((i + d * 7919) % len) as u8));
+                DictionaryArray::<UInt8Type>::new(keys, Arc::new(values))
             })
             .collect();
 
-        let refs: Vec<&DictionaryArray<UInt16Type>> = dictionaries.iter().collect();
+        let refs: Vec<&DictionaryArray<UInt8Type>> = dictionaries.iter().collect();
         let merged = merge_dictionary_values(&refs, None).unwrap();
 
         // One key per distinct value, null and empty string kept apart

--- a/arrow-select/src/dictionary.rs
+++ b/arrow-select/src/dictionary.rs
@@ -17,6 +17,8 @@
 
 //! Dictionary utilities for Arrow arrays
 
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
 use crate::filter::filter;
@@ -24,12 +26,12 @@ use crate::interleave::interleave;
 use ahash::RandomState;
 use arrow_array::builder::BooleanBufferBuilder;
 use arrow_array::types::{
-    ArrowDictionaryKeyType, ArrowPrimitiveType, BinaryType, ByteArrayType, LargeBinaryType,
-    LargeUtf8Type, Utf8Type,
+    ArrowDictionaryKeyType, ArrowPrimitiveType, BinaryType, ByteArrayType, ByteViewType,
+    LargeBinaryType, LargeUtf8Type, Utf8Type,
 };
 use arrow_array::{
     AnyDictionaryArray, Array, ArrayRef, ArrowNativeTypeOp, BooleanArray, DictionaryArray,
-    GenericByteArray, PrimitiveArray, downcast_dictionary_array,
+    GenericByteArray, GenericByteViewArray, PrimitiveArray, downcast_dictionary_array,
 };
 use arrow_array::{cast::AsArray, downcast_primitive};
 use arrow_buffer::{ArrowNativeType, BooleanBuffer, ScalarBuffer, ToByteSlice};
@@ -140,6 +142,10 @@ impl<'a, V> Interner<'a, V> {
     }
 }
 
+/// For each referenced value of a dictionary, its index within that dictionary's
+/// values and its bytes (`None` for a null value)
+type MaskedValues<'a> = Vec<(usize, Option<&'a [u8]>)>;
+
 pub(crate) struct MergedDictionaries<K: ArrowDictionaryKeyType> {
     /// Provides `key_mappings[`array_idx`][`old_key`] -> new_key`
     pub key_mappings: Vec<Vec<K::Native>>,
@@ -187,6 +193,9 @@ pub(crate) fn should_merge_dictionary_values<K: ArrowDictionaryKeyType>(
         LargeUtf8 => bytes_ptr_eq::<LargeUtf8Type>,
         Binary => bytes_ptr_eq::<BinaryType>,
         LargeBinary => bytes_ptr_eq::<LargeBinaryType>,
+        // View arrays are compared through their `ArrayData`, which covers both
+        // the views buffer and the data buffers they point into
+        Utf8View | BinaryView => |a, b| a.to_data().ptr_eq(&b.to_data()),
         dt => {
             if !dt.is_primitive() {
                 return (
@@ -257,13 +266,84 @@ pub(crate) fn merge_dictionary_values<K: ArrowDictionaryKeyType>(
         values_arrays.push(values)
     }
 
-    // Map from value to new index
-    let mut interner = Interner::new(num_values);
     // Interleave indices for new values array
     let mut indices = Vec::with_capacity(num_values);
 
-    // Compute the mapping for each dictionary
-    let key_mappings = dictionaries
+    // Map from value to new index, best-effort: a hash collision evicts the
+    // previous occupant, so the same value may be assigned more than one key
+    let mut interner = Interner::new(num_values);
+    let interned = compute_key_mappings(
+        dictionaries,
+        &value_slices,
+        |dictionary_idx, value_idx, value| {
+            interner
+                .intern(value, || match K::Native::from_usize(indices.len()) {
+                    Some(idx) => {
+                        indices.push((dictionary_idx, value_idx));
+                        Ok(idx)
+                    }
+                    None => Err(ArrowError::DictionaryKeyOverflowError),
+                })
+                .copied()
+        },
+    );
+
+    let key_mappings = match interned {
+        Ok(key_mappings) => key_mappings,
+        // The duplicates left behind by the interner's hash collisions can push
+        // the output past what the key type can address even though the distinct
+        // values would have fit. Retry with exact deduplication, which allocates
+        // exactly one key per distinct value at the cost of a hash map.
+        //
+        // Dictionaries don't promise unique values, so there is no cheap way to
+        // tell this case apart from a genuine overflow beforehand: when the
+        // distinct values really don't fit, this second pass runs in full and
+        // returns the same error the first pass did.
+        Err(ArrowError::DictionaryKeyOverflowError) => {
+            indices.clear();
+            // Left unsized: it holds at most one entry per addressable key, which
+            // is far fewer than `num_values` whenever this path is reached
+            let mut seen: HashMap<Option<&[u8]>, K::Native, RandomState> =
+                HashMap::with_hasher(RandomState::with_seeds(0, 0, 0, 0));
+            compute_key_mappings(
+                dictionaries,
+                &value_slices,
+                |dictionary_idx, value_idx, value| match seen.entry(value) {
+                    Entry::Occupied(entry) => Ok(*entry.get()),
+                    Entry::Vacant(entry) => {
+                        let idx = K::Native::from_usize(indices.len())
+                            .ok_or(ArrowError::DictionaryKeyOverflowError)?;
+                        indices.push((dictionary_idx, value_idx));
+                        Ok(*entry.insert(idx))
+                    }
+                },
+            )?
+        }
+        Err(e) => return Err(e),
+    };
+
+    Ok(MergedDictionaries {
+        key_mappings,
+        values: interleave(&values_arrays, &indices)?,
+    })
+}
+
+/// Assign a key in the merged values array to every referenced value of every
+/// dictionary, returning `key_mappings[array_idx][old_key] -> new_key`.
+///
+/// `assign_key` is called once per referenced value with its dictionary index,
+/// its index within that dictionary's values, and its bytes, and returns the key
+/// that value takes in the merged output.
+fn compute_key_mappings<'a, K, F>(
+    dictionaries: &[&DictionaryArray<K>],
+    value_slices: &[MaskedValues<'a>],
+    mut assign_key: F,
+) -> Result<Vec<Vec<K::Native>>, ArrowError>
+where
+    K: ArrowDictionaryKeyType,
+    F: FnMut(usize, usize, Option<&'a [u8]>) -> Result<K::Native, ArrowError>,
+{
+    dictionaries
         .iter()
         .enumerate()
         .zip(value_slices)
@@ -272,23 +352,11 @@ pub(crate) fn merge_dictionary_values<K: ArrowDictionaryKeyType>(
             let mut mapping = vec![zero; dictionary.values().len()];
 
             for (value_idx, value) in values {
-                mapping[value_idx] =
-                    *interner.intern(value, || match K::Native::from_usize(indices.len()) {
-                        Some(idx) => {
-                            indices.push((dictionary_idx, value_idx));
-                            Ok(idx)
-                        }
-                        None => Err(ArrowError::DictionaryKeyOverflowError),
-                    })?;
+                mapping[*value_idx] = assign_key(dictionary_idx, *value_idx, *value)?;
             }
             Ok(mapping)
         })
-        .collect::<Result<Vec<_>, ArrowError>>()?;
-
-    Ok(MergedDictionaries {
-        key_mappings,
-        values: interleave(&values_arrays, &indices)?,
-    })
+        .collect()
 }
 
 /// Return a mask identifying the values that are referenced by keys in `dictionary`
@@ -338,27 +406,43 @@ macro_rules! masked_primitive_to_bytes_helper {
 }
 
 /// Return a Vec containing for each set index in `mask`, the index and byte value of that index
-fn get_masked_values<'a>(
-    array: &'a dyn Array,
-    mask: &BooleanBuffer,
-) -> Vec<(usize, Option<&'a [u8]>)> {
+fn get_masked_values<'a>(array: &'a dyn Array, mask: &BooleanBuffer) -> MaskedValues<'a> {
     downcast_primitive! {
         array.data_type() => (masked_primitive_to_bytes_helper, array, mask),
         DataType::Utf8 => masked_bytes(array.as_string::<i32>(), mask),
         DataType::LargeUtf8 => masked_bytes(array.as_string::<i64>(), mask),
         DataType::Binary => masked_bytes(array.as_binary::<i32>(), mask),
         DataType::LargeBinary => masked_bytes(array.as_binary::<i64>(), mask),
+        DataType::Utf8View => masked_byte_views(array.as_string_view(), mask),
+        DataType::BinaryView => masked_byte_views(array.as_binary_view(), mask),
         _ => unimplemented!("Dictionary merging for type {} is not implemented", array.data_type()),
     }
 }
 
 /// Compute [`get_masked_values`] for a [`GenericByteArray`]
 ///
-/// Note: this does not check the null mask and will return values contained in null slots
+/// Note: values in null slots are reported as `None`, not as their contents
 fn masked_bytes<'a, T: ByteArrayType>(
     array: &'a GenericByteArray<T>,
     mask: &BooleanBuffer,
-) -> Vec<(usize, Option<&'a [u8]>)> {
+) -> MaskedValues<'a> {
+    let mut out = Vec::with_capacity(mask.count_set_bits());
+    for idx in mask.set_indices() {
+        out.push((
+            idx,
+            array.is_valid(idx).then_some(array.value(idx).as_ref()),
+        ))
+    }
+    out
+}
+
+/// Compute [`get_masked_values`] for a [`GenericByteViewArray`]
+///
+/// Note: values in null slots are reported as `None`, not as their contents
+fn masked_byte_views<'a, T: ByteViewType>(
+    array: &'a GenericByteViewArray<T>,
+    mask: &BooleanBuffer,
+) -> MaskedValues<'a> {
     let mut out = Vec::with_capacity(mask.count_set_bits());
     for idx in mask.set_indices() {
         out.push((
@@ -379,6 +463,58 @@ mod tests {
     use arrow_array::{DictionaryArray, Int8Array, Int32Array, StringArray};
     use arrow_buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer};
     use std::sync::Arc;
+
+    use arrow_array::types::UInt16Type;
+    use arrow_array::{StringViewArray, UInt16Array};
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // Takes too long
+    fn merge_string_view_dictionaries_deduplicates_exactly() {
+        // Four dictionaries over the same values: 60000 distinct strings, an
+        // empty string and a null. Concatenating them would need 240008 keys,
+        // far past the UInt16 range, while the distinct values leave room to
+        // spare -- so the merge has to deduplicate them exactly. At this
+        // cardinality the best-effort interner alone leaves thousands of
+        // duplicates behind and overflows, which forces the exact retry.
+        const DISTINCT: usize = 60000;
+        let len = DISTINCT + 2;
+
+        let dictionaries: Vec<DictionaryArray<UInt16Type>> = (0..4)
+            .map(|d| {
+                let values: StringViewArray = (0..DISTINCT)
+                    .map(|i| Some(format!("value_{i:06}")))
+                    .chain([Some(String::new()), None])
+                    .collect();
+                // Offset the keys per dictionary so the merge can't rely on the
+                // arrays being laid out the same way
+                let keys =
+                    UInt16Array::from_iter_values((0..len).map(|i| ((i + d * 7919) % len) as u16));
+                DictionaryArray::<UInt16Type>::new(keys, Arc::new(values))
+            })
+            .collect();
+
+        let refs: Vec<&DictionaryArray<UInt16Type>> = dictionaries.iter().collect();
+        let merged = merge_dictionary_values(&refs, None).unwrap();
+
+        // One key per distinct value, null and empty string kept apart
+        assert_eq!(merged.values.len(), len);
+        assert_eq!(merged.values.data_type(), &DataType::Utf8View);
+        assert_eq!(merged.values.null_count(), 1);
+
+        // Every key still resolves to the value it started out with
+        let merged_values = merged.values.as_string_view();
+        for (dictionary, mapping) in dictionaries.iter().zip(&merged.key_mappings) {
+            let values = dictionary.values().as_string_view();
+            for key in dictionary.keys().values() {
+                let old_key = key.as_usize();
+                let new_key = mapping[old_key].as_usize();
+                assert_eq!(values.is_null(old_key), merged_values.is_null(new_key));
+                if values.is_valid(old_key) {
+                    assert_eq!(values.value(old_key), merged_values.value(new_key));
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_garbage_collect_i32_dictionary() {

--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -1552,6 +1552,46 @@ mod tests {
     }
 
     #[test]
+    fn test_interleave_string_view_dictionary_merges_duplicate_values() {
+        // Two independently-built `Dictionary<UInt8, Utf8View>` arrays holding the
+        // same 200 distinct values. Naively concatenating their dictionaries yields
+        // 400 entries, which overflows the u8 key range, but the distinct values do
+        // fit -- so the values must be merged and deduplicated instead.
+        let dict = |offset: usize| {
+            let values: StringViewArray = (0..200).map(|i| Some(format!("v{i}"))).collect();
+            let keys = UInt8Array::from_iter_values((0..200).map(|i| (i + offset) as u8 % 200));
+            DictionaryArray::<UInt8Type>::new(keys, Arc::new(values))
+        };
+        let (a, b) = (dict(0), dict(7));
+        let indices: Vec<_> = (0..200).flat_map(|i| [(0, i), (1, i)]).collect();
+
+        let merged = interleave(&[&a, &b], &indices).unwrap();
+        let merged = merged.as_dictionary::<UInt8Type>();
+
+        assert_eq!(merged.len(), 400);
+        assert_eq!(merged.values().data_type(), &DataType::Utf8View);
+        assert!(merged.values().len() < 400);
+
+        let values = merged.values().as_string_view();
+        let actual: Vec<_> = merged
+            .keys()
+            .values()
+            .iter()
+            .map(|k| values.value(*k as usize))
+            .collect();
+        let expected: Vec<_> = indices
+            .iter()
+            .map(|(array_idx, row)| {
+                let d = [&a, &b][*array_idx];
+                d.values()
+                    .as_string_view()
+                    .value(d.keys().value(*row) as usize)
+            })
+            .collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn test_interleave_views() {
         let values = StringArray::from_iter_values([
             "hello",


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10925.

# Rationale for this change

Combining `DictionaryArray`s whose dictionaries were built independently has to merge their values. `merge_dictionary_values` deduplicates, so the merged dictionary only holds the distinct referenced values; the `MutableArrayData` fallback in `concat`/`interleave` concatenates them and can therefore exceed what the key type addresses even when the distinct values fit it comfortably.

Two gaps kept that merge from happening:

- `should_merge_dictionary_values` returned `false` for any value type that is neither primitive nor an offset-based byte array, so `Dictionary(_, Utf8View)` and `Dictionary(_, BinaryView)` always took the non-deduplicating fallback. Reaching the merge path would then have hit `unimplemented!()` in `get_masked_values`, which has no arm for the view layouts either. The two are indistinguishable to a caller: identical data merges as `Utf8` and fails as `Utf8View`.

- The `Interner` backing the merge is best-effort by design: a hash collision evicts the previous occupant, so one value can be handed several keys. Merging 4 dictionaries of 60k distinct values under a `UInt16` key left ~40% duplicates and overflowed anyway. This affects `Utf8` dictionaries too, it is simply less visible there.

# What changes are included in this PR?

All of the logic is in `arrow-select/src/dictionary.rs`; `concat.rs` and `interleave.rs` gain tests only.

- `should_merge_dictionary_values`: compare `Utf8View`/`BinaryView` values through `ArrayData::ptr_eq`, which covers the views buffer and the data buffers behind it.
- `get_masked_values`: extract masked values for both view layouts, through a new `masked_byte_views`.
- `merge_dictionary_values`: keep the interner fast path, and on `DictionaryKeyOverflowError` retry the key assignment with exact deduplication, which allocates exactly one key per distinct value. The shared loop moves into `compute_key_mappings`, parameterised by the key-assignment closure.

With both, merging 16 dictionaries of 60k distinct values under a `UInt16` key yields a 60k-value dictionary instead of failing.

# Are these changes tested?

Yes, five new tests:

- `concat_string_view_dictionary_merges_duplicate_values` and `test_interleave_string_view_dictionary_merges_duplicate_values` cover the first gap: two `Dictionary(UInt8, Utf8View)` arrays over the same 200 distinct values, which fail to combine without the fix. Both check that every key still resolves to the value it started out with.
- `concat_binary_view_dictionary_merges_duplicate_values` covers the other view layout.
- `merge_string_view_dictionaries_deduplicates_exactly` covers the second gap deterministically, at a cardinality where the interner alone cannot succeed: four `Dictionary(UInt8, Utf8View)` arrays over 200 distinct values plus an empty string and a null. It asserts exactly one key per distinct value, that null and empty string stay apart, and that every mapping preserves its value.
- `concat_dictionary_merges_values_of_many_arrays` covers four dictionaries whose concatenated values would need 800 keys under a `UInt8` key.

The existing `*_overflow_returns_err` tests continue to pin the genuine-overflow behaviour.

# Are there any user-facing changes?

No API changes. Cases that previously returned `ArrowError::DictionaryKeyOverflowError` may now succeed.

A genuine overflow, where there really are more distinct values than the key type can address, still errors — but only after the retry pass has run in full. Dictionaries make no uniqueness guarantee, so there is no cheap way to tell the two apart in advance.

