### PR TITLE
fix(parquet): skip empty data pages in add_data_page

### DIFF
--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -2102,7 +2102,7 @@ mod tests {
     use crate::data_type::AsBytes;
     use crate::file::metadata::{ColumnChunkMetaData, ParquetMetaData, ParquetMetaDataReader};
     use crate::file::properties::{
-        BloomFilterPosition, EnabledStatistics, ReaderProperties, WriterVersion,
+        BloomFilterPosition, CdcOptions, EnabledStatistics, ReaderProperties, WriterVersion,
     };
     use crate::file::serialized_reader::ReadOptionsBuilder;
     use crate::file::{
@@ -6452,5 +6452,103 @@ mod tests {
             crate::basic::Type::INT32
         );
         assert_eq!(parquet_schema.column(1).path().string(), "row.b");
+    }
+
+    /// Content-defined chunking forces a page break at the end of every chunk
+    /// except the last. When the chunk's own values have already filled the
+    /// page, that forced break has nothing left to write.
+    ///
+    /// A `BOOLEAN` column written with `PARQUET_2_0` uses `RleValueEncoder`,
+    /// which creates its inner encoder lazily on the first `put`, so flushing
+    /// an empty page used to panic with "RLE value encoder is not initialized".
+    #[test]
+    fn test_arrow_writer_cdc_boolean_forced_page_break_after_flush() {
+        let num_rows = 500_000;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "flag",
+            ArrowDataType::Boolean,
+            false,
+        )]));
+        let values: Vec<bool> = (0..num_rows).map(|i| i % 7 == 0).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(BooleanArray::from(values.clone())) as _],
+        )
+        .unwrap();
+
+        // A `data_page_size_limit` below `max_chunk_size` is an explicitly
+        // supported configuration; it just produces more, smaller pages.
+        let props = WriterProperties::builder()
+            .set_writer_version(WriterVersion::PARQUET_2_0)
+            .set_data_page_size_limit(1024)
+            .set_content_defined_chunking(Some(CdcOptions {
+                min_chunk_size: 8 * 1024,
+                max_chunk_size: 16 * 1024,
+                norm_level: 0,
+            }))
+            .build();
+
+        let mut writer = ArrowWriter::try_new(Vec::new(), schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        // The column round-trips unchanged.
+        let reader = ParquetRecordBatchReader::try_new(data, 8192).unwrap();
+        let mut read_back = Vec::with_capacity(num_rows);
+        for batch in reader {
+            let batch = batch.unwrap();
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<BooleanArray>()
+                .unwrap();
+            read_back.extend(col.iter().map(|v| v.unwrap()));
+        }
+        assert_eq!(read_back, values);
+    }
+
+    /// The same forced page break on a non-`BOOLEAN` column did not panic, but
+    /// wrote a data page holding zero values. No page should be empty.
+    #[test]
+    fn test_arrow_writer_cdc_writes_no_empty_data_pages() {
+        let num_rows = 500_000;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "a",
+            ArrowDataType::Int32,
+            false,
+        )]));
+        let values: Vec<i32> = (0..num_rows).map(|i| i % 97).collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(values)) as _],
+        )
+        .unwrap();
+
+        let props = WriterProperties::builder()
+            .set_writer_version(WriterVersion::PARQUET_2_0)
+            .set_dictionary_enabled(false)
+            .set_data_page_row_count_limit(128)
+            .set_content_defined_chunking(Some(CdcOptions {
+                min_chunk_size: 8 * 1024,
+                max_chunk_size: 16 * 1024,
+                norm_level: 0,
+            }))
+            .build();
+
+        let mut writer = ArrowWriter::try_new(Vec::new(), schema, Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        let data = Bytes::from(writer.into_inner().unwrap());
+
+        let reader = SerializedFileReader::new(data).unwrap();
+        let mut num_pages = 0;
+        for i in 0..reader.num_row_groups() {
+            let row_group = reader.get_row_group(i).unwrap();
+            let mut pages = row_group.get_column_page_reader(0).unwrap();
+            while let Some(page) = pages.get_next_page().unwrap() {
+                assert_ne!(page.num_values(), 0, "wrote a data page with no values");
+                num_pages += 1;
+            }
+        }
+        assert!(num_pages > 1, "expected the column to span several pages");
     }
 }

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -1399,6 +1399,14 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     /// Adds data page.
     /// Data page is either buffered in case of dictionary encoding or written directly.
     pub(crate) fn add_data_page(&mut self) -> Result<()> {
+        // Nothing has been buffered since the last flush, so there is no page to write.
+        // Returning early keeps zero-value data pages out of the file, and avoids flushing
+        // encoders that build their state lazily on the first value: `RleValueEncoder`
+        // creates its inner encoder in `put`, so flushing before any `put` would panic.
+        if self.page_metrics.num_buffered_values == 0 {
+            return Ok(());
+        }
+
         // Extract encoded values
         let values_data = self.encoder.flush_data_page()?;
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10929.

# Rationale for this change

`GenericColumnWriter::add_data_page` flushes the encoder unconditionally. Its two neighbouring call sites already avoid calling it with an empty page (`should_add_data_page` returns `false` at zero buffered values, and `dict_fallback` / `flush_data_pages` test `num_buffered_values > 0`), but content-defined chunking does not:

```rust
// Add a page break after each chunk except the last
if i + 1 < num_chunks {
    match &mut self.writer {
        ArrowColumnWriterImpl::Column(c) => c.add_data_page()?,
        ArrowColumnWriterImpl::ByteArray(c) => c.add_data_page()?,
    }
}
```

Writing the chunk can already have flushed the page, when the chunk's own values reach `data_page_size_limit` or `data_page_row_count_limit` exactly at the chunk boundary. The forced break then flushes a page with nothing buffered.

For a `BOOLEAN` column that panics. `RleValueEncoder` creates its inner encoder lazily on the first `put` and `flush_buffer` does `.take().expect("RLE value encoder is not initialized")`, so flushing before any `put` panics. `BOOLEAN` resolves to `RleValueEncoder` under `WriterVersion::PARQUET_2_0`, or when `Encoding::RLE` is set explicitly.

For other encodings it does not panic but writes a data page holding zero values.

This is reachable from the public API: `WriterPropertiesBuilder::set_content_defined_chunking` plus `ArrowWriter`. `data_page_size_limit` smaller than `max_chunk_size` is a configuration the `CdcOptions::max_chunk_size` docs explicitly describe as supported.

# What changes are included in this PR?

`add_data_page` returns `Ok(())` when `page_metrics.num_buffered_values == 0`, making a forced page break a no-op when there is nothing to write. This brings it in line with the checks the other call sites already make.

# Are these changes tested?

Yes, two regression tests in `parquet/src/arrow/arrow_writer/mod.rs`, both driving only the public `ArrowWriter` / `WriterProperties` API. Both fail on `main`:

- `test_arrow_writer_cdc_boolean_forced_page_break_after_flush` writes a `BOOLEAN` column with CDC and a small `data_page_size_limit`, and checks the values round-trip. On `main` it panics with `RLE value encoder is not initialized`.
- `test_arrow_writer_cdc_writes_no_empty_data_pages` writes an `INT32` column with CDC and `data_page_row_count_limit`, and asserts no data page reports zero values. On `main` 121 of 611 pages are empty.

# Are there any user-facing changes?

Yes, both are fixes:

- Writing a `BOOLEAN` column with content-defined chunking no longer panics.
- Files written with content-defined chunking no longer contain zero-value data pages.

No public API change, and no change to files written without content-defined chunking.

---

*This PR was written by Claude (Anthropic's AI assistant) working with @adriangb. The tests were run and the results reported above are actual.*
