### PR TITLE
chore: fix typos in code comments

### DIFF
--- a/arrow-arith/src/arity.rs
+++ b/arrow-arith/src/arity.rs
@@ -69,7 +69,7 @@ where
     array.try_unary_mut(op)
 }
 
-/// Allies a binary infallable function to two [`PrimitiveArray`]s,
+/// Applies a binary infallible function to two [`PrimitiveArray`]s,
 /// producing a new [`PrimitiveArray`]
 ///
 /// # Details

--- a/arrow-ipc/src/writer.rs
+++ b/arrow-ipc/src/writer.rs
@@ -3672,7 +3672,7 @@ mod tests {
         ensure_roundtrip(Arc::new(ls.finish()));
     }
 
-    /// Read/write a record batch to a File and Stream and ensure it is the same at the outout
+    /// Read/write a record batch to a File and Stream and ensure it is the same at the output
     fn ensure_roundtrip(array: ArrayRef) {
         let num_rows = array.len();
         let orig_batch = RecordBatch::try_from_iter(vec![("a", array)]).unwrap();

--- a/arrow-schema/src/extension/mod.rs
+++ b/arrow-schema/src/extension/mod.rs
@@ -207,7 +207,7 @@ pub trait ExtensionType: Sized {
 
     /// The metadata type of this extension type.
     ///
-    /// Implementations can use strongly or loosly typed data structures here
+    /// Implementations can use strongly or loosely typed data structures here
     /// depending on the complexity of the metadata.
     ///
     /// Implementations can also use `Self` here if the extension type can be

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -384,7 +384,7 @@ impl FFI_ArrowSchema {
     ///
     /// Panics if `index` is greater than or equal to the number of children.
     ///
-    /// This is to make sure that the unsafe acces to raw pointer is sound.
+    /// This is to make sure that the unsafe access to raw pointer is sound.
     pub fn child(&self, index: usize) -> &Self {
         assert!(index < self.n_children as usize);
         unsafe { self.children.add(index).as_ref().unwrap().as_ref().unwrap() }

--- a/arrow-schema/src/schema.rs
+++ b/arrow-schema/src/schema.rs
@@ -86,7 +86,7 @@ impl SchemaBuilder {
         &mut self.metadata
     }
 
-    /// Reverse the fileds
+    /// Reverse the fields
     pub fn reverse(&mut self) {
         self.fields.reverse();
     }

--- a/arrow-select/src/union_extract.rs
+++ b/arrow-select/src/union_extract.rs
@@ -188,7 +188,7 @@ fn extract_sparse(
 
                     Ok(make_array(data))
                 } else {
-                    // case 4.2: target can't containt a null mask, zip the values that match with a null value
+                    // case 4.2: target can't contain a null mask, zip the values that match with a null value
                     Ok(crate::zip::zip(
                         &BooleanArray::new(selected, None),
                         target,
@@ -223,7 +223,7 @@ fn extract_dense(
     } else if target.null_count() == target.len() || target.data_type().is_null() {
         // case 3: since all values on our target are null, regardless of selected type ids and offsets, the result is a null array
         match target.len().cmp(&union_array.len()) {
-            // case 3.1: since the target is smaller than the union, allocate a new correclty sized null array
+            // case 3.1: since the target is smaller than the union, allocate a new correctly sized null array
             Ordering::Less => Ok(new_null_array(target.data_type(), union_array.len())),
             // case 3.2: target equals the union len, return it direcly
             Ordering::Equal => Ok(Arc::clone(target)),
@@ -252,7 +252,7 @@ fn extract_dense(
                 // Non empty target without any selected value may happen after slicing the parent union,
                 // since only type_ids and offsets are sliced, not the children
                 match (target.len().cmp(&union_array.len()), layout(target.data_type()).can_contain_null_mask) {
-                    (Ordering::Less, _) // case 5.1A: our target is smaller than the parent union, allocate a new correclty sized null array
+                    (Ordering::Less, _) // case 5.1A: our target is smaller than the parent union, allocate a new correctly sized null array
                     | (_, false) => { // case 5.1B: target array can't contain a null mask
                         Ok(new_null_array(target.data_type(), union_array.len()))
                     }
@@ -312,7 +312,7 @@ fn extract_dense_all_selected(
         // case 2: All offsets are sequential, but our target is bigger than our union, slice it, starting at the first offset
         Ok(target.slice(offsets[0] as usize, union_array.len()))
     } else {
-        // case 3: Since offsets are not sequential, take them from the child to a new sequential and correcly sized array
+        // case 3: Since offsets are not sequential, take them from the child to a new sequential and correctly sized array
         let indices = Int32Array::try_new(offsets.clone(), None)?;
 
         Ok(take(target, &indices, None)?)
@@ -327,7 +327,7 @@ enum BoolValue {
     /// If true, all type_ids matches the target type_id
     /// If false, none type_ids matches the target type_id
     Scalar(bool),
-    /// A mask represeting which type_ids matches the target type_id
+    /// A mask representing which type_ids matches the target type_id
     Buffer(BooleanBuffer),
 }
 

--- a/parquet-variant/src/builder/object.rs
+++ b/parquet-variant/src/builder/object.rs
@@ -758,7 +758,7 @@ mod tests {
 
         let (metadata, value) = builder.finish();
 
-        // note, object fields are now sorted lexigraphically by field name
+        // note, object fields are now sorted lexicographically by field name
         /*
          {
             "a": false,

--- a/parquet-variant/src/utils.rs
+++ b/parquet-variant/src/utils.rs
@@ -102,7 +102,7 @@ pub(crate) fn string_from_slice(
 }
 
 /// Performs a binary search over a range using a fallible key extraction function; a failed key
-/// extraction immediately terminats the search.
+/// extraction immediately terminates the search.
 ///
 /// This is similar to the standard library's `binary_search_by`, but generalized to ranges instead
 /// of slices.

--- a/parquet-variant/src/variant.rs
+++ b/parquet-variant/src/variant.rs
@@ -20,7 +20,7 @@ pub use self::list::VariantList;
 pub use self::metadata::{EMPTY_VARIANT_METADATA, EMPTY_VARIANT_METADATA_BYTES, VariantMetadata};
 pub use self::object::VariantObject;
 
-// Publically export types used in the API
+// Publicly export types used in the API
 pub use half::f16;
 pub use uuid::Uuid;
 

--- a/parquet-variant/src/variant/list.rs
+++ b/parquet-variant/src/variant/list.rs
@@ -157,7 +157,7 @@ impl<'m, 'v> VariantList<'m, 'v> {
         Self::try_new_with_shallow_validation(metadata, value).expect("Invalid variant list value")
     }
 
-    /// Attempts to interpet `metadata` and `value` as a variant array, performing only basic
+    /// Attempts to interpret `metadata` and `value` as a variant array, performing only basic
     /// (constant-cost) [validation].
     ///
     /// [validation]: Self#Validation

--- a/parquet-variant/src/variant/object.rs
+++ b/parquet-variant/src/variant/object.rs
@@ -147,7 +147,7 @@ impl<'m, 'v> VariantObject<'m, 'v> {
         Self::try_new_with_shallow_validation(metadata, value).expect("Invalid variant object")
     }
 
-    /// Attempts to interpet `metadata` and `value` as a variant object.
+    /// Attempts to interpret `metadata` and `value` as a variant object.
     ///
     /// # Validation
     ///
@@ -158,7 +158,7 @@ impl<'m, 'v> VariantObject<'m, 'v> {
         Self::try_new_with_shallow_validation(metadata, value)?.with_full_validation()
     }
 
-    /// Attempts to interpet `metadata` and `value` as a variant object, performing only basic
+    /// Attempts to interpret `metadata` and `value` as a variant object, performing only basic
     /// (constant-cost) [validation].
     ///
     /// [validation]: Self#Validation


### PR DESCRIPTION
# Which issue does this PR close?

N/A — small standalone cleanup.

# Rationale for this change

`codespell` turns up a handful of spelling mistakes in doc comments and inline comments. One of them is slightly more than cosmetic: the doc comment on `arrow_arith::arity::try_binary` reads "Allies a binary infallable function", which should be "Applies a binary infallible function".

# What changes are included in this PR?

Comment-only spelling fixes across `arrow-schema`, `arrow-arith`, `arrow-ipc`, `arrow-select`, and `parquet-variant`. No identifiers, public API, or behaviour changed. Generated sources under `arrow-ipc/src/gen`, changelogs, and test data were left untouched.

# Are these changes tested?

No tests needed — comments only.

# Are there any user-facing changes?

Only rendered rustdoc text.