### PR TITLE
Remove `force_validate` feature from `arrow-cast`

### DIFF
--- a/arrow-cast/Cargo.toml
+++ b/arrow-cast/Cargo.toml
@@ -37,7 +37,6 @@ all-features = true
 
 [features]
 prettyprint = ["comfy-table"]
-force_validate = []
 
 [dependencies]
 arrow-array = { workspace = true }

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -3027,7 +3027,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "force_validate"))]
     #[should_panic(
         expected = "Cannot cast to Decimal128(20, 3). Overflowing on 57896044618658097711785492504343953926634992332820282019728792003956564819967"
     )]
@@ -3064,7 +3063,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "force_validate"))]
     fn test_cast_decimal_to_decimal_round() {
         let array = vec![
             Some(1123454),


### PR DESCRIPTION
This was added back in

- https://github.com/apache/arrow-rs/pull/6116

However theres no actual code (other than test code) that uses this feature; I'm assuming it was an artifact from some old code that was never removed.

Alternatively we could forward that feature to enable `force_validate` in `arrow-data` and `arrow-array`, if we want to maintain it.