### PR TITLE
Add `ARROW_VERSION` const to arrow-array

### DIFF
--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -229,6 +229,9 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]
 
+/// Arrow crate version
+pub const ARROW_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub mod array;
 pub use array::*;
 


### PR DESCRIPTION
# Rationale for this change

The top-level `arrow` crate already exposes `ARROW_VERSION` via `env!("CARGO_PKG_VERSION")` (see #6379). Dependents that only use `arrow-array` (common for Rust ADBC drivers that need a lean dependency set) currently have no equivalent API, so they may need to fall back to invoking `cargo metadata` in a build script to report `DriverArrowVersion`.

That approach is fragile for non-Cargo build systems and adds unnecessary clean-build overhead. Exposing the same constant from `arrow-array` makes version reporting trivial for everyone implementing Rust ADBC drivers (and any other crate that depends on `arrow-array` without the umbrella `arrow` crate).

# What changes are included in this PR?

* Add `pub const ARROW_VERSION: &str = env!("CARGO_PKG_VERSION")` to `arrow-array`, matching the existing constant on the top-level `arrow` crate.

# Are there any user-facing changes?

Yes: a new public constant on `arrow-array`. No breaking changes.

Usage:

```rust
use arrow_array::ARROW_VERSION;
```