### PR TITLE
perf(arrow-cast): speed up infallible numeric casts

### DIFF
--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2554,9 +2554,16 @@ fn cast_numeric_arrays<FROM, TO>(
 where
     FROM: ArrowPrimitiveType,
     TO: ArrowPrimitiveType,
-    FROM::Native: NumCast,
+    FROM::Native: NumCast + AsPrimitive<TO::Native>,
     TO::Native: NumCast,
 {
+    if is_infallible_numeric_cast(&FROM::DATA_TYPE, &TO::DATA_TYPE) {
+        return Ok(Arc::new(
+            from.as_primitive::<FROM>()
+                .unary::<_, TO>(|value| value.as_()),
+        ));
+    }
+
     if cast_options.safe {
         // If the value can't be casted to the `TO::Native`, return null
         Ok(Arc::new(numeric_cast::<FROM, TO>(
@@ -2568,6 +2575,25 @@ where
             from.as_primitive::<FROM>(),
         )?))
     }
+}
+
+/// Returns true when every value of `from` can be cast to `to`.
+fn is_infallible_numeric_cast(from: &DataType, to: &DataType) -> bool {
+    use DataType::*;
+    matches!(
+        (from, to),
+        (Int8, Int16 | Int32 | Int64 | Float32 | Float64)
+            | (Int16, Int32 | Int64 | Float32 | Float64)
+            | (Int32, Int64 | Float32 | Float64)
+            | (Int64 | UInt64, Float32 | Float64)
+            | (
+                UInt8,
+                UInt16 | UInt32 | UInt64 | Int16 | Int32 | Int64 | Float32 | Float64
+            )
+            | (UInt16, UInt32 | UInt64 | Int32 | Int64 | Float32 | Float64)
+            | (UInt32, UInt64 | Int64 | Float32 | Float64)
+            | (Float32, Float64)
+    )
 }
 
 // Natural cast between numeric types
@@ -2938,6 +2964,81 @@ mod tests {
             assert_eq!($OUTPUT_TYPE, result.data_type());
             assert_eq!(result.as_ref(), &output);
         };
+    }
+
+    macro_rules! assert_infallible_numeric_pair {
+        ($from:ty, $to:ty, $from_type:expr, $to_type:expr) => {{
+            assert!(is_infallible_numeric_cast(&$from_type, &$to_type));
+
+            for value in [<$from>::MIN, <$from>::MAX, 0, 1] {
+                assert_eq!(num_cast::<$from, $to>(value), Some(value as $to));
+            }
+
+            let mut state = 0x9e37_79b9_7f4a_7c15_u64;
+            for _ in 0..65 {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                let value: $from = state.as_();
+                assert_eq!(num_cast::<$from, $to>(value), Some(value as $to));
+            }
+        }};
+    }
+
+    #[test]
+    fn test_infallible_numeric_casts() {
+        assert_infallible_numeric_pair!(i8, i16, Int8, Int16);
+        assert_infallible_numeric_pair!(i8, i32, Int8, Int32);
+        assert_infallible_numeric_pair!(i8, i64, Int8, Int64);
+        assert_infallible_numeric_pair!(i8, f32, Int8, Float32);
+        assert_infallible_numeric_pair!(i8, f64, Int8, Float64);
+        assert_infallible_numeric_pair!(i16, i32, Int16, Int32);
+        assert_infallible_numeric_pair!(i16, i64, Int16, Int64);
+        assert_infallible_numeric_pair!(i16, f32, Int16, Float32);
+        assert_infallible_numeric_pair!(i16, f64, Int16, Float64);
+        assert_infallible_numeric_pair!(i32, i64, Int32, Int64);
+        assert_infallible_numeric_pair!(i32, f32, Int32, Float32);
+        assert_infallible_numeric_pair!(i32, f64, Int32, Float64);
+        assert_infallible_numeric_pair!(i64, f32, Int64, Float32);
+        assert_infallible_numeric_pair!(i64, f64, Int64, Float64);
+
+        assert_infallible_numeric_pair!(u8, u16, UInt8, UInt16);
+        assert_infallible_numeric_pair!(u8, u32, UInt8, UInt32);
+        assert_infallible_numeric_pair!(u8, u64, UInt8, UInt64);
+        assert_infallible_numeric_pair!(u8, i16, UInt8, Int16);
+        assert_infallible_numeric_pair!(u8, i32, UInt8, Int32);
+        assert_infallible_numeric_pair!(u8, i64, UInt8, Int64);
+        assert_infallible_numeric_pair!(u8, f32, UInt8, Float32);
+        assert_infallible_numeric_pair!(u8, f64, UInt8, Float64);
+        assert_infallible_numeric_pair!(u16, u32, UInt16, UInt32);
+        assert_infallible_numeric_pair!(u16, u64, UInt16, UInt64);
+        assert_infallible_numeric_pair!(u16, i32, UInt16, Int32);
+        assert_infallible_numeric_pair!(u16, i64, UInt16, Int64);
+        assert_infallible_numeric_pair!(u16, f32, UInt16, Float32);
+        assert_infallible_numeric_pair!(u16, f64, UInt16, Float64);
+        assert_infallible_numeric_pair!(u32, u64, UInt32, UInt64);
+        assert_infallible_numeric_pair!(u32, i64, UInt32, Int64);
+        assert_infallible_numeric_pair!(u32, f32, UInt32, Float32);
+        assert_infallible_numeric_pair!(u32, f64, UInt32, Float64);
+        assert_infallible_numeric_pair!(u64, f32, UInt64, Float32);
+        assert_infallible_numeric_pair!(u64, f64, UInt64, Float64);
+
+        assert!(is_infallible_numeric_cast(&Float32, &Float64));
+        for value in [
+            f32::MIN,
+            f32::MAX,
+            0.0,
+            -0.0,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+        ] {
+            assert_eq!(num_cast::<f32, f64>(value), Some(value as f64));
+        }
+        assert!(num_cast::<f32, f64>(f32::NAN).unwrap().is_nan());
+
+        assert!(!is_infallible_numeric_cast(&Int64, &Int32));
+        assert_eq!(num_cast::<i64, i32>(i64::MAX), None);
+        assert_eq!(i64::MAX as i32, -1);
     }
 
     fn run_decimal_cast_test_case<I, O>(t: DecimalCastTestConfig)

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -3236,10 +3236,22 @@ mod tests {
                     if input.is_null(index) {
                         continue;
                     }
-                    // bitwise, so that NaN and the sign of zero are checked too
+                    let value = input.value(index);
+                    if value.is_nan() {
+                        // Only NaN-ness is guaranteed: the sign and payload a
+                        // float conversion produces for a NaN are unspecified,
+                        // and Miri deliberately randomises them, so comparing
+                        // bit patterns here would be testing an accident.
+                        assert!(
+                            output.value(index).is_nan(),
+                            "at index {index} of offset {offset}"
+                        );
+                        continue;
+                    }
+                    // bitwise everywhere else, so the sign of zero is checked too
                     assert_eq!(
                         output.value(index).to_bits(),
-                        (input.value(index) as f64).to_bits(),
+                        (value as f64).to_bits(),
                         "at index {index} of offset {offset}"
                     );
                 }

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -3028,12 +3028,9 @@ mod tests {
         }};
     }
 
-    /// Runs a fast-path pair end to end through the public `cast_with_options`
+    /// Runs one fast-path pair end to end through the public `cast_with_options`
     /// entry point and compares every element against a per-element `num_cast`
     /// reference, under both `safe` settings and at several array offsets.
-    ///
-    /// The property test above only checks the numbers; this checks that the
-    /// `unary` substitution preserves length, validity and offsets as well.
     macro_rules! assert_fast_path_matches_reference {
         ($from_type:ty, $from:ty, $to_type:ty, $to:ty) => {{
             let mut values: Vec<Option<$from>> = vec![
@@ -3154,51 +3151,26 @@ mod tests {
         assert_eq!(i64::MAX as i32, -1);
     }
 
-    /// Every fast path pair with an integer source, driven end to end through
-    /// `cast_with_options` and compared against a per-element `num_cast`
-    /// reference. `Float32 -> Float64` is covered separately below because it
-    /// needs float specific inputs.
+    /// One pair per conversion class, driven end to end through
+    /// `cast_with_options`. The property test above already covers all 35 pairs
+    /// numerically; this checks the parts `unary` could get wrong instead --
+    /// length, validity, and array offsets -- so a representative sample is
+    /// enough rather than repeating the whole matrix.
     #[test]
     fn test_infallible_numeric_cast_fast_path_matches_reference() {
-        assert_fast_path_matches_reference!(Int8Type, i8, Int16Type, i16);
-        assert_fast_path_matches_reference!(Int8Type, i8, Int32Type, i32);
-        assert_fast_path_matches_reference!(Int8Type, i8, Int64Type, i64);
-        assert_fast_path_matches_reference!(Int8Type, i8, Float32Type, f32);
-        assert_fast_path_matches_reference!(Int8Type, i8, Float64Type, f64);
-        assert_fast_path_matches_reference!(Int16Type, i16, Int32Type, i32);
-        assert_fast_path_matches_reference!(Int16Type, i16, Int64Type, i64);
-        assert_fast_path_matches_reference!(Int16Type, i16, Float32Type, f32);
-        assert_fast_path_matches_reference!(Int16Type, i16, Float64Type, f64);
+        // signed widening, the motivating case
         assert_fast_path_matches_reference!(Int32Type, i32, Int64Type, i64);
-        assert_fast_path_matches_reference!(Int32Type, i32, Float32Type, f32);
-        assert_fast_path_matches_reference!(Int32Type, i32, Float64Type, f64);
-        assert_fast_path_matches_reference!(Int64Type, i64, Float32Type, f32);
-        assert_fast_path_matches_reference!(Int64Type, i64, Float64Type, f64);
-
-        assert_fast_path_matches_reference!(UInt8Type, u8, UInt16Type, u16);
-        assert_fast_path_matches_reference!(UInt8Type, u8, UInt32Type, u32);
-        assert_fast_path_matches_reference!(UInt8Type, u8, UInt64Type, u64);
-        assert_fast_path_matches_reference!(UInt8Type, u8, Int16Type, i16);
-        assert_fast_path_matches_reference!(UInt8Type, u8, Int32Type, i32);
-        assert_fast_path_matches_reference!(UInt8Type, u8, Int64Type, i64);
-        assert_fast_path_matches_reference!(UInt8Type, u8, Float32Type, f32);
-        assert_fast_path_matches_reference!(UInt8Type, u8, Float64Type, f64);
-        assert_fast_path_matches_reference!(UInt16Type, u16, UInt32Type, u32);
-        assert_fast_path_matches_reference!(UInt16Type, u16, UInt64Type, u64);
-        assert_fast_path_matches_reference!(UInt16Type, u16, Int32Type, i32);
-        assert_fast_path_matches_reference!(UInt16Type, u16, Int64Type, i64);
-        assert_fast_path_matches_reference!(UInt16Type, u16, Float32Type, f32);
-        assert_fast_path_matches_reference!(UInt16Type, u16, Float64Type, f64);
+        // signed to float, including a source narrower than the target
+        assert_fast_path_matches_reference!(Int8Type, i8, Float32Type, f32);
+        // unsigned widening
         assert_fast_path_matches_reference!(UInt32Type, u32, UInt64Type, u64);
-        assert_fast_path_matches_reference!(UInt32Type, u32, Int64Type, i64);
-        assert_fast_path_matches_reference!(UInt32Type, u32, Float32Type, f32);
-        assert_fast_path_matches_reference!(UInt32Type, u32, Float64Type, f64);
-        assert_fast_path_matches_reference!(UInt64Type, u64, Float32Type, f32);
+        // unsigned to a strictly wider signed target
+        assert_fast_path_matches_reference!(UInt16Type, u16, Int32Type, i32);
+        // unsigned to float, at the width where the value exceeds the mantissa
         assert_fast_path_matches_reference!(UInt64Type, u64, Float64Type, f64);
-    }
 
-    #[test]
-    fn test_infallible_float32_to_float64_cast_matches_reference() {
+        // Float32 -> Float64 is the one float source, and needs its own inputs:
+        // NaN, the infinities and a signed zero have no integer counterpart.
         let values = vec![
             Some(f32::MIN),
             Some(f32::MAX),
@@ -3206,22 +3178,20 @@ mod tests {
             Some(0.0),
             Some(-0.0),
             Some(1.5),
-            Some(-1.5),
             Some(f32::INFINITY),
             Some(f32::NEG_INFINITY),
             Some(f32::NAN),
             None,
         ];
         let array = Arc::new(Float32Array::from(values)) as ArrayRef;
-        let options = [
+
+        for cast_options in [
             CastOptions::default(),
             CastOptions {
                 safe: false,
                 ..Default::default()
             },
-        ];
-
-        for cast_options in options {
+        ] {
             for offset in [0, 1, 3] {
                 let input = array.slice(offset, array.len() - offset);
                 let output = cast_with_options(&input, &Float64, &cast_options).unwrap();

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -2558,6 +2558,15 @@ where
     TO::Native: NumCast,
 {
     if is_infallible_numeric_cast(&FROM::DATA_TYPE, &TO::DATA_TYPE) {
+        // `unary` applies the conversion to every slot, including null ones, and
+        // reuses the input's null buffer instead of rebuilding it. That is what
+        // lets the loop vectorize.
+        //
+        // As a consequence the values buffer underneath a null slot now holds the
+        // converted input value rather than the zero left there by `unary_opt` /
+        // `try_unary`. Values under a null slot are undefined by the Arrow
+        // specification, and this matches the other `unary`-based kernels, but it
+        // does change the bytes an IPC writer emits for those positions.
         return Ok(Arc::new(
             from.as_primitive::<FROM>()
                 .unary::<_, TO>(|value| value.as_()),
@@ -2577,7 +2586,27 @@ where
     }
 }
 
-/// Returns true when every value of `from` can be cast to `to`.
+/// Returns `true` when the per-element checked conversion can be replaced by a
+/// plain widening conversion, that is when
+///
+/// ```text
+/// num_cast::<FROM, TO>(v) == Some(v.as_())
+/// ```
+///
+/// holds for *every* value of `FROM`.
+///
+/// Note that the required invariant is agreement with [`AsPrimitive::as_`], not
+/// merely that `num_cast` is total; a pair belongs here only if it also has a
+/// case in `test_infallible_numeric_casts`, which asserts exactly that equality.
+///
+/// The match is fail-closed: an unlisted pair keeps the existing checked path, so
+/// an omission costs performance and never correctness. The set is deliberately
+/// conservative and does not attempt to be exhaustive. In particular `Float16` is
+/// excluded, because `f16` has no primitive `as` conversion and so needs separate
+/// correctness reasoning.
+///
+/// Called with associated constants, so each monomorphisation folds this to a
+/// constant and the branch disappears.
 fn is_infallible_numeric_cast(from: &DataType, to: &DataType) -> bool {
     use DataType::*;
     matches!(
@@ -2966,12 +2995,27 @@ mod tests {
         };
     }
 
+    /// Asserts the property `is_infallible_numeric_cast` relies on: `num_cast`
+    /// never rejects a value of `$from`, *and* agrees with the conversion the
+    /// fast path actually performs, [`AsPrimitive::as_`].
+    ///
+    /// This also pins the behaviour of `num_traits` itself. Totality of these
+    /// conversions is an assumption the fast path bakes in; if a future version
+    /// made any of them fallible, the fast path would silently diverge from the
+    /// checked path and this test is what would catch it.
     macro_rules! assert_infallible_numeric_pair {
         ($from:ty, $to:ty, $from_type:expr, $to_type:expr) => {{
             assert!(is_infallible_numeric_cast(&$from_type, &$to_type));
 
+            let assert_value = |value: $from| {
+                let expected = value as $to;
+                let as_primitive: $to = value.as_();
+                assert_eq!(as_primitive, expected, "AsPrimitive disagrees with `as`");
+                assert_eq!(num_cast::<$from, $to>(value), Some(expected));
+            };
+
             for value in [<$from>::MIN, <$from>::MAX, 0, 1] {
-                assert_eq!(num_cast::<$from, $to>(value), Some(value as $to));
+                assert_value(value);
             }
 
             let mut state = 0x9e37_79b9_7f4a_7c15_u64;
@@ -2979,8 +3023,72 @@ mod tests {
                 state ^= state << 13;
                 state ^= state >> 7;
                 state ^= state << 17;
-                let value: $from = state.as_();
-                assert_eq!(num_cast::<$from, $to>(value), Some(value as $to));
+                assert_value(state.as_());
+            }
+        }};
+    }
+
+    /// Runs a fast-path pair end to end through the public `cast_with_options`
+    /// entry point and compares every element against a per-element `num_cast`
+    /// reference, under both `safe` settings and at several array offsets.
+    ///
+    /// The property test above only checks the numbers; this checks that the
+    /// `unary` substitution preserves length, validity and offsets as well.
+    macro_rules! assert_fast_path_matches_reference {
+        ($from_type:ty, $from:ty, $to_type:ty, $to:ty) => {{
+            let mut values: Vec<Option<$from>> = vec![
+                Some(<$from>::MIN),
+                Some(<$from>::MAX),
+                Some(0),
+                Some(1),
+                None,
+            ];
+            let mut state = 0x9e37_79b9_7f4a_7c15_u64;
+            for _ in 0..65 {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                values.push(Some(state.as_()));
+                values.push(None);
+            }
+
+            let array = Arc::new(PrimitiveArray::<$from_type>::from(values)) as ArrayRef;
+            let to_data_type = <$to_type as ArrowPrimitiveType>::DATA_TYPE;
+            let options = [
+                CastOptions::default(),
+                CastOptions {
+                    safe: false,
+                    ..Default::default()
+                },
+            ];
+
+            for cast_options in options {
+                for offset in [0, 1, 3] {
+                    let input = array.slice(offset, array.len() - offset);
+                    let output = cast_with_options(&input, &to_data_type, &cast_options).unwrap();
+
+                    let input = input.as_primitive::<$from_type>();
+                    let output = output.as_primitive::<$to_type>();
+                    assert_eq!(output.len(), input.len());
+                    assert_eq!(output.null_count(), input.null_count());
+
+                    for index in 0..output.len() {
+                        assert_eq!(output.is_null(index), input.is_null(index));
+                        if input.is_null(index) {
+                            continue;
+                        }
+                        let value = input.value(index);
+                        let expected = num_cast::<$from, $to>(value)
+                            .expect("num_cast must be total for a fast path pair");
+                        assert_eq!(
+                            output.value(index),
+                            expected,
+                            "{} -> {} at index {index} of offset {offset}",
+                            stringify!($from),
+                            stringify!($to),
+                        );
+                    }
+                }
             }
         }};
     }
@@ -3027,18 +3135,143 @@ mod tests {
         for value in [
             f32::MIN,
             f32::MAX,
+            f32::MIN_POSITIVE,
             0.0,
             -0.0,
             f32::INFINITY,
             f32::NEG_INFINITY,
         ] {
-            assert_eq!(num_cast::<f32, f64>(value), Some(value as f64));
+            let expected = value as f64;
+            let as_primitive: f64 = value.as_();
+            assert_eq!(as_primitive.to_bits(), expected.to_bits());
+            assert_eq!(num_cast::<f32, f64>(value), Some(expected));
         }
         assert!(num_cast::<f32, f64>(f32::NAN).unwrap().is_nan());
+        assert!(AsPrimitive::<f64>::as_(f32::NAN).is_nan());
 
         assert!(!is_infallible_numeric_cast(&Int64, &Int32));
         assert_eq!(num_cast::<i64, i32>(i64::MAX), None);
         assert_eq!(i64::MAX as i32, -1);
+    }
+
+    /// Every fast path pair with an integer source, driven end to end through
+    /// `cast_with_options` and compared against a per-element `num_cast`
+    /// reference. `Float32 -> Float64` is covered separately below because it
+    /// needs float specific inputs.
+    #[test]
+    fn test_infallible_numeric_cast_fast_path_matches_reference() {
+        assert_fast_path_matches_reference!(Int8Type, i8, Int16Type, i16);
+        assert_fast_path_matches_reference!(Int8Type, i8, Int32Type, i32);
+        assert_fast_path_matches_reference!(Int8Type, i8, Int64Type, i64);
+        assert_fast_path_matches_reference!(Int8Type, i8, Float32Type, f32);
+        assert_fast_path_matches_reference!(Int8Type, i8, Float64Type, f64);
+        assert_fast_path_matches_reference!(Int16Type, i16, Int32Type, i32);
+        assert_fast_path_matches_reference!(Int16Type, i16, Int64Type, i64);
+        assert_fast_path_matches_reference!(Int16Type, i16, Float32Type, f32);
+        assert_fast_path_matches_reference!(Int16Type, i16, Float64Type, f64);
+        assert_fast_path_matches_reference!(Int32Type, i32, Int64Type, i64);
+        assert_fast_path_matches_reference!(Int32Type, i32, Float32Type, f32);
+        assert_fast_path_matches_reference!(Int32Type, i32, Float64Type, f64);
+        assert_fast_path_matches_reference!(Int64Type, i64, Float32Type, f32);
+        assert_fast_path_matches_reference!(Int64Type, i64, Float64Type, f64);
+
+        assert_fast_path_matches_reference!(UInt8Type, u8, UInt16Type, u16);
+        assert_fast_path_matches_reference!(UInt8Type, u8, UInt32Type, u32);
+        assert_fast_path_matches_reference!(UInt8Type, u8, UInt64Type, u64);
+        assert_fast_path_matches_reference!(UInt8Type, u8, Int16Type, i16);
+        assert_fast_path_matches_reference!(UInt8Type, u8, Int32Type, i32);
+        assert_fast_path_matches_reference!(UInt8Type, u8, Int64Type, i64);
+        assert_fast_path_matches_reference!(UInt8Type, u8, Float32Type, f32);
+        assert_fast_path_matches_reference!(UInt8Type, u8, Float64Type, f64);
+        assert_fast_path_matches_reference!(UInt16Type, u16, UInt32Type, u32);
+        assert_fast_path_matches_reference!(UInt16Type, u16, UInt64Type, u64);
+        assert_fast_path_matches_reference!(UInt16Type, u16, Int32Type, i32);
+        assert_fast_path_matches_reference!(UInt16Type, u16, Int64Type, i64);
+        assert_fast_path_matches_reference!(UInt16Type, u16, Float32Type, f32);
+        assert_fast_path_matches_reference!(UInt16Type, u16, Float64Type, f64);
+        assert_fast_path_matches_reference!(UInt32Type, u32, UInt64Type, u64);
+        assert_fast_path_matches_reference!(UInt32Type, u32, Int64Type, i64);
+        assert_fast_path_matches_reference!(UInt32Type, u32, Float32Type, f32);
+        assert_fast_path_matches_reference!(UInt32Type, u32, Float64Type, f64);
+        assert_fast_path_matches_reference!(UInt64Type, u64, Float32Type, f32);
+        assert_fast_path_matches_reference!(UInt64Type, u64, Float64Type, f64);
+    }
+
+    #[test]
+    fn test_infallible_float32_to_float64_cast_matches_reference() {
+        let values = vec![
+            Some(f32::MIN),
+            Some(f32::MAX),
+            Some(f32::MIN_POSITIVE),
+            Some(0.0),
+            Some(-0.0),
+            Some(1.5),
+            Some(-1.5),
+            Some(f32::INFINITY),
+            Some(f32::NEG_INFINITY),
+            Some(f32::NAN),
+            None,
+        ];
+        let array = Arc::new(Float32Array::from(values)) as ArrayRef;
+        let options = [
+            CastOptions::default(),
+            CastOptions {
+                safe: false,
+                ..Default::default()
+            },
+        ];
+
+        for cast_options in options {
+            for offset in [0, 1, 3] {
+                let input = array.slice(offset, array.len() - offset);
+                let output = cast_with_options(&input, &Float64, &cast_options).unwrap();
+
+                let input = input.as_primitive::<Float32Type>();
+                let output = output.as_primitive::<Float64Type>();
+                assert_eq!(output.len(), input.len());
+                assert_eq!(output.null_count(), input.null_count());
+
+                for index in 0..output.len() {
+                    assert_eq!(output.is_null(index), input.is_null(index));
+                    if input.is_null(index) {
+                        continue;
+                    }
+                    // bitwise, so that NaN and the sign of zero are checked too
+                    assert_eq!(
+                        output.value(index).to_bits(),
+                        (input.value(index) as f64).to_bits(),
+                        "at index {index} of offset {offset}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The fast path must not swallow a conversion that can overflow: those keep
+    /// returning null under `safe` and an error under `safe: false`.
+    #[test]
+    fn test_fallible_numeric_casts_remain_checked() {
+        let unchecked = CastOptions {
+            safe: false,
+            ..Default::default()
+        };
+
+        // narrowing
+        let array = Arc::new(Int64Array::from(vec![Some(i64::MAX), Some(1)])) as ArrayRef;
+        let output = cast(&array, &Int32).unwrap();
+        assert!(output.is_null(0));
+        assert_eq!(output.as_primitive::<Int32Type>().value(1), 1);
+        assert!(cast_with_options(&array, &Int32, &unchecked).is_err());
+
+        // unsigned to signed of the same width
+        let array = Arc::new(UInt32Array::from(vec![Some(u32::MAX)])) as ArrayRef;
+        assert!(cast(&array, &Int32).unwrap().is_null(0));
+        assert!(cast_with_options(&array, &Int32, &unchecked).is_err());
+
+        // signed to unsigned
+        let array = Arc::new(Int8Array::from(vec![Some(-1i8)])) as ArrayRef;
+        assert!(cast(&array, &UInt8).unwrap().is_null(0));
+        assert!(cast_with_options(&array, &UInt8, &unchecked).is_err());
     }
 
     fn run_decimal_cast_test_case<I, O>(t: DecimalCastTestConfig)

--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -17,7 +17,7 @@
 
 #[macro_use]
 extern crate criterion;
-use criterion::Criterion;
+use criterion::{BenchmarkId, Criterion, Throughput};
 use rand::RngExt;
 use rand::distr::{Distribution, StandardUniform, Uniform};
 use std::hint;
@@ -26,7 +26,7 @@ use chrono::DateTime;
 use std::sync::Arc;
 
 use arrow::array::*;
-use arrow::compute::cast;
+use arrow::compute::{CastOptions, cast, cast_with_options};
 use arrow::datatypes::*;
 use arrow::util::bench_util::*;
 use arrow::util::test_util::seedable_rng;
@@ -257,7 +257,49 @@ fn cast_array(array: &ArrayRef, to_type: DataType) {
     hint::black_box(cast(hint::black_box(array), hint::black_box(&to_type)).unwrap());
 }
 
+fn benchmark_infallible_numeric_cast(c: &mut Criterion) {
+    const SIZE: usize = 100_000;
+    let mut group = c.benchmark_group("infallible numeric cast i32 to i64");
+    group.throughput(Throughput::Elements(SIZE as u64));
+
+    for null_density in [0.0, 0.1] {
+        let array = Arc::new(create_primitive_array::<Int32Type>(SIZE, null_density)) as ArrayRef;
+        let input = array.as_primitive::<Int32Type>();
+
+        group.bench_with_input(
+            BenchmarkId::new("cast safe", null_density),
+            &array,
+            |b, array| b.iter(|| cast_array(array, DataType::Int64)),
+        );
+
+        let options = CastOptions {
+            safe: false,
+            ..Default::default()
+        };
+        group.bench_with_input(
+            BenchmarkId::new("cast safe=false", null_density),
+            &array,
+            |b, array| {
+                b.iter(|| {
+                    hint::black_box(cast_with_options(array, &DataType::Int64, &options).unwrap())
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("unary", null_density),
+            input,
+            |b, input| {
+                b.iter(|| hint::black_box(input.unary::<_, Int64Type>(|value| value as i64)))
+            },
+        );
+    }
+    group.finish();
+}
+
 fn add_benchmark(c: &mut Criterion) {
+    benchmark_infallible_numeric_cast(c);
+
     let i32_array = build_array::<Int32Type>(512);
     let i64_array = build_array::<Int64Type>(512);
     let f32_array = build_array::<Float32Type>(512);

--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -286,6 +286,8 @@ fn benchmark_infallible_numeric_cast(c: &mut Criterion) {
             },
         );
 
+        // Reference arm: the cost of the conversion with no dispatch and no
+        // per-element check, i.e. the floor the `cast` arms above should reach.
         group.bench_with_input(
             BenchmarkId::new("unary", null_density),
             input,

--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -252,6 +252,9 @@ fn build_string_dict_array(size: usize, distinct: usize) -> ArrayRef {
     ))
 }
 
+/// Array lengths the primitive to primitive cast benchmarks are run at.
+const NUMERIC_CAST_SIZES: [usize; 4] = [512, 1_024, 8_192, 65_536];
+
 // cast array from specified primitive array type to desired data type
 fn cast_array(array: &ArrayRef, to_type: DataType) {
     hint::black_box(cast(hint::black_box(array), hint::black_box(&to_type)).unwrap());
@@ -302,7 +305,6 @@ fn benchmark_infallible_numeric_cast(c: &mut Criterion) {
 fn add_benchmark(c: &mut Criterion) {
     benchmark_infallible_numeric_cast(c);
 
-    let i32_array = build_array::<Int32Type>(512);
     let i64_array = build_array::<Int64Type>(512);
     let f32_array = build_array::<Float32Type>(512);
     let f32_utf8_array = cast(&build_array::<Float32Type>(512), &DataType::Utf8).unwrap();
@@ -348,33 +350,48 @@ fn add_benchmark(c: &mut Criterion) {
     let float64_array_cast_to_decimal = build_float64_array_for_cast_to_decimal(8_000, 0.1);
     let invalid_float64_array_to_decimal = build_float64_array_invalid_items(8_000, 0.1);
 
-    c.bench_function("cast int32 to int32 512", |b| {
-        b.iter(|| cast_array(&i32_array, DataType::Int32))
-    });
-    c.bench_function("cast int32 to uint32 512", |b| {
-        b.iter(|| cast_array(&i32_array, DataType::UInt32))
-    });
-    c.bench_function("cast int32 to float32 512", |b| {
-        b.iter(|| cast_array(&i32_array, DataType::Float32))
-    });
-    c.bench_function("cast int32 to float64 512", |b| {
-        b.iter(|| cast_array(&i32_array, DataType::Float64))
-    });
-    c.bench_function("cast int32 to int64 512", |b| {
-        b.iter(|| cast_array(&i32_array, DataType::Int64))
-    });
-    c.bench_function("cast float32 to int32 512", |b| {
-        b.iter(|| cast_array(&f32_array, DataType::Int32))
-    });
-    c.bench_function("cast float64 to float32 512", |b| {
-        b.iter(|| cast_array(&f64_array, DataType::Float32))
-    });
-    c.bench_function("cast float64 to uint64 512", |b| {
-        b.iter(|| cast_array(&f64_array, DataType::UInt64))
-    });
-    c.bench_function("cast int64 to int32 512", |b| {
-        b.iter(|| cast_array(&i64_array, DataType::Int32))
-    });
+    // The primitive to primitive casts are swept over several array sizes. At
+    // 512 the arrays are a couple of KiB and the measurement is dominated by
+    // dispatch; the larger sizes expose the per-element cost, which is what the
+    // numeric cast kernels actually control. The inputs carry 10% nulls, as
+    // `build_array` has always produced, so the null path is covered too.
+    //
+    // The 512 names are deliberately unchanged, so those rows stay comparable
+    // with historical runs.
+    for size in NUMERIC_CAST_SIZES {
+        let i32s = build_array::<Int32Type>(size);
+        let i64s = build_array::<Int64Type>(size);
+        let f32s = build_array::<Float32Type>(size);
+        let f64s = build_array::<Float64Type>(size);
+
+        c.bench_function(&format!("cast int32 to int32 {size}"), |b| {
+            b.iter(|| cast_array(&i32s, DataType::Int32))
+        });
+        c.bench_function(&format!("cast int32 to uint32 {size}"), |b| {
+            b.iter(|| cast_array(&i32s, DataType::UInt32))
+        });
+        c.bench_function(&format!("cast int32 to float32 {size}"), |b| {
+            b.iter(|| cast_array(&i32s, DataType::Float32))
+        });
+        c.bench_function(&format!("cast int32 to float64 {size}"), |b| {
+            b.iter(|| cast_array(&i32s, DataType::Float64))
+        });
+        c.bench_function(&format!("cast int32 to int64 {size}"), |b| {
+            b.iter(|| cast_array(&i32s, DataType::Int64))
+        });
+        c.bench_function(&format!("cast float32 to int32 {size}"), |b| {
+            b.iter(|| cast_array(&f32s, DataType::Int32))
+        });
+        c.bench_function(&format!("cast float64 to float32 {size}"), |b| {
+            b.iter(|| cast_array(&f64s, DataType::Float32))
+        });
+        c.bench_function(&format!("cast float64 to uint64 {size}"), |b| {
+            b.iter(|| cast_array(&f64s, DataType::UInt64))
+        });
+        c.bench_function(&format!("cast int64 to int32 {size}"), |b| {
+            b.iter(|| cast_array(&i64s, DataType::Int32))
+        });
+    }
     c.bench_function("cast int64 to decimal32(9, 0) 512", |b| {
         b.iter(|| cast_array(&i64_array, DataType::Decimal32(9, 0)))
     });

--- a/arrow/benches/cast_kernels.rs
+++ b/arrow/benches/cast_kernels.rs
@@ -17,7 +17,7 @@
 
 #[macro_use]
 extern crate criterion;
-use criterion::{BenchmarkId, Criterion, Throughput};
+use criterion::Criterion;
 use rand::RngExt;
 use rand::distr::{Distribution, StandardUniform, Uniform};
 use std::hint;
@@ -26,7 +26,7 @@ use chrono::DateTime;
 use std::sync::Arc;
 
 use arrow::array::*;
-use arrow::compute::{CastOptions, cast, cast_with_options};
+use arrow::compute::cast;
 use arrow::datatypes::*;
 use arrow::util::bench_util::*;
 use arrow::util::test_util::seedable_rng;
@@ -260,51 +260,7 @@ fn cast_array(array: &ArrayRef, to_type: DataType) {
     hint::black_box(cast(hint::black_box(array), hint::black_box(&to_type)).unwrap());
 }
 
-fn benchmark_infallible_numeric_cast(c: &mut Criterion) {
-    const SIZE: usize = 100_000;
-    let mut group = c.benchmark_group("infallible numeric cast i32 to i64");
-    group.throughput(Throughput::Elements(SIZE as u64));
-
-    for null_density in [0.0, 0.1] {
-        let array = Arc::new(create_primitive_array::<Int32Type>(SIZE, null_density)) as ArrayRef;
-        let input = array.as_primitive::<Int32Type>();
-
-        group.bench_with_input(
-            BenchmarkId::new("cast safe", null_density),
-            &array,
-            |b, array| b.iter(|| cast_array(array, DataType::Int64)),
-        );
-
-        let options = CastOptions {
-            safe: false,
-            ..Default::default()
-        };
-        group.bench_with_input(
-            BenchmarkId::new("cast safe=false", null_density),
-            &array,
-            |b, array| {
-                b.iter(|| {
-                    hint::black_box(cast_with_options(array, &DataType::Int64, &options).unwrap())
-                })
-            },
-        );
-
-        // Reference arm: the cost of the conversion with no dispatch and no
-        // per-element check, i.e. the floor the `cast` arms above should reach.
-        group.bench_with_input(
-            BenchmarkId::new("unary", null_density),
-            input,
-            |b, input| {
-                b.iter(|| hint::black_box(input.unary::<_, Int64Type>(|value| value as i64)))
-            },
-        );
-    }
-    group.finish();
-}
-
 fn add_benchmark(c: &mut Criterion) {
-    benchmark_infallible_numeric_cast(c);
-
     let i64_array = build_array::<Int64Type>(512);
     let f32_array = build_array::<Float32Type>(512);
     let f32_utf8_array = cast(&build_array::<Float32Type>(512), &DataType::Utf8).unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10955.

# Rationale for this change

`cast_numeric_arrays` currently sends every numeric pair through `num_cast`, including total conversions such as `Int32 -> Int64`. The safe path rebuilds validity through `unary_opt`; the unsafe path retains a fallible operation and walks valid indices. Both prevent the straight-line widening loop used by `PrimitiveArray::unary`.

# What changes are included in this PR?

- Identify the 35 numeric pairs for which `num_cast` is total and agrees with `AsPrimitive::as_`, and route them through `unary`.
- Keep every narrowing or otherwise fallible conversion on the existing checked paths. The match is fail-closed, so an omitted pair only misses an optimization.
- Add a correctness matrix covering every fast-path pair, edge values, spread samples, floating-point special values, and negative controls.
- Add end-to-end coverage through `cast_with_options`, under both `safe` settings and at several array offsets, for one pair per conversion class.
- Sweep the existing primitive cast benchmarks over 512, 1024, 8192 and 65536 elements instead of only 512.

Float16 conversions are intentionally left out of the fast path because they cannot use a primitive `as` cast and need separate correctness reasoning. The pair set is deliberately conservative rather than exhaustive; because the match is fail-closed, anything left out simply keeps the checked path.

# Are these changes tested?

Yes. `cargo test -p arrow-cast --lib` (381 passed), `cargo fmt --all -- --check`, `cargo clippy -p arrow-cast --lib --tests -- -D warnings`, `cargo clippy -p arrow --bench cast_kernels --features test_utils -- -D warnings`.

Two layers of tests:

- `test_infallible_numeric_casts` asserts the numeric property the fast path rests on: for every listed pair, `num_cast::<FROM, TO>(v) == Some(v as TO)` and `AsPrimitive::as_` agrees with `as`. This also pins `num_traits` behaviour that the fast path assumes; if a future version made any of these conversions fallible, the fast path would silently diverge from the checked path and this test is what would catch it.
- `test_infallible_numeric_cast_fast_path_matches_reference` and `test_fallible_numeric_casts_remain_checked` drive the public `cast_with_options` entry point, so length, validity, array offsets and the untouched checked paths are covered as well. Since the pairs are already covered numerically above, this runs one pair per conversion class rather than repeating the matrix. `Float32 -> Float64` is compared bitwise, except for NaN, whose sign and payload are unspecified across a float conversion.

Offline, the property was additionally verified exhaustively over every value of every 8-bit and 16-bit source (23 of the 35 pairs), over all 2^32 `f32` bit patterns for `Float32 -> Float64`, and over edge values plus 2M random samples per pair for the 32-bit and 64-bit sources. Negative controls confirm the excluded pairs (`i64 -> i32`, `u32 -> i32`, `i8 -> u8`, `i8 -> u16`, `u8 -> i8`, `u64 -> i64`) really are not total.

## Benchmarks

The primitive to primitive cast benchmarks were fixed at 512 elements, about 2 KiB, where dispatch dominates. They now run at 512, 1024, 8192 and 65536. The `512` names are unchanged, so those rows stay comparable with historical runs, and the inputs keep the 10% null density `build_array` has always produced.

Ratios below are main / branch, so higher is faster. Apple arm64, Criterion with 2 s warm-up and 4 s measurement:

| cast | 512 | 1024 | 8192 |
|---|---:|---:|---:|
| `int32 -> float32` | 4.89x | 7.13x | **12.81x** |
| `int32 -> float64` | 3.65x | 5.34x | **7.41x** |
| `int32 -> int64` | 2.48x | 4.97x | **7.37x** |
| `float32 -> int32` (checked) | 0.98x | 1.01x | 1.00x |
| `float64 -> float32` (checked) | 0.79x | 0.97x | 0.99x |
| `float64 -> uint64` (checked) | 0.99x | 0.99x | 1.01x |
| `int32 -> uint32` (checked) | 0.94x | 1.00x | 1.00x |
| `int64 -> int32` (checked) | 0.99x | 1.00x | 1.00x |

The gain peaks at 8192, DataFusion's default batch size: `int32 -> int64` goes from 5.22 us to 707.7 ns. Every pair that stays on the checked path is flat within noise, which is the control for the change being confined to the listed pairs. The 65536 column is not listed above because it was added after these numbers were taken; a comparison run on the PR will produce it.

The earlier run on this PR, on neutral hardware, showed the same shape at the one size it could compare: 4.06x, 3.88x and 3.35x for `int32 -> float32`, `int32 -> int64` and `int32 -> float64` at 512.

A DataFusion 55 reproduction over 9,994,240 rows improves `SUM(Int32)` from 7.40 ms to 3.08 ms (2.40x), while the `SUM(Int64)` control stays at 2.14 ms.

# Are there any user-facing changes?

No API changes, and no change to any logical value produced by `cast`.

There is one observable difference at the buffer level. `PrimitiveArray::unary` applies the conversion to every slot and reuses the input null buffer, so for the 35 fast-path pairs the values buffer underneath a **null** slot now holds the converted input value instead of the zero previously written by `unary_opt` / `try_unary`:

```text
i32 -> i64 (fast path)  values: [1, 111111, -7, 222222]   // was [1, 0, -7, 0]
i32 -> i16 (checked)    values: [1, 0, -7, 0]
```

Values under a null slot are undefined by the Arrow specification and this matches the other `unary`-based kernels in arrow-rs, but it does change what `PrimitiveArray::values()` returns at those positions and the bytes an IPC writer emits for them. Noted here in case anyone compares buffers byte for byte, or relied on the cast to mask data under nulls.
