### PR TITLE
Expose IPC decompressed size and bound LZ4 output

### DIFF
--- a/arrow-ipc/src/compression.rs
+++ b/arrow-ipc/src/compression.rs
@@ -403,7 +403,10 @@ pub fn read_uncompressed_size(buffer: &[u8]) -> Result<i64, ArrowError> {
             buffer.len()
         ))
     })?;
-    Ok(i64::from_le_bytes(len_buffer.try_into().unwrap()))
+    let len_buffer: [u8; 8] = len_buffer
+        .try_into()
+        .map_err(|e| ArrowError::IpcError(format!("Invalid uncompressed length prefix: {e}")))?;
+    Ok(i64::from_le_bytes(len_buffer))
 }
 
 #[cfg(test)]

--- a/arrow-ipc/src/compression.rs
+++ b/arrow-ipc/src/compression.rs
@@ -280,7 +280,7 @@ impl CompressionCodec {
         };
         if ret.len() != decompressed_size {
             return Err(ArrowError::IpcError(format!(
-                "Expected compressed length of {decompressed_size} got {}",
+                "Expected decompressed length of {decompressed_size} got {}",
                 ret.len()
             )));
         }
@@ -310,7 +310,18 @@ fn compress_lz4(_input: &[u8], _output: &mut Vec<u8>) -> Result<(), ArrowError> 
 fn decompress_lz4(input: &[u8], decompressed_size: usize) -> Result<Vec<u8>, ArrowError> {
     use std::io::Read;
     let mut output = Vec::with_capacity(decompressed_size);
-    lz4_flex::frame::FrameDecoder::new(input).read_to_end(&mut output)?;
+    let mut decoder = lz4_flex::frame::FrameDecoder::new(input);
+    decoder
+        .by_ref()
+        .take(decompressed_size as u64)
+        .read_to_end(&mut output)?;
+
+    // Probe without growing `output` to reject data exceeding the advertised size.
+    if decoder.read(&mut [0])? != 0 {
+        return Err(ArrowError::IpcError(format!(
+            "LZ4 decompressed buffer exceeds advertised size of {decompressed_size}"
+        )));
+    }
     Ok(output)
 }
 
@@ -375,14 +386,17 @@ fn decompress_zstd(
     ))
 }
 
-/// Get the uncompressed length
-/// Notes:
-///   LENGTH_NO_COMPRESSED_DATA: indicate that the data that follows is not compressed
-///    0: indicate that there is no data
-///   positive number: indicate the uncompressed length for the following data
-/// Returns an error if the input buffer is shorter than 8 bytes
+/// Reads the uncompressed length from a compressed IPC buffer.
+///
+/// A positive value is the exact expected uncompressed length, `0` indicates
+/// that there is no data, and `-1` indicates that the bytes following the
+/// prefix are not compressed.
+/// IPC decompression limits its output buffer to a positive advertised length
+/// and rejects output whose length differs.
+///
+/// Returns an error if the input buffer is shorter than the 8-byte prefix.
 #[inline]
-fn read_uncompressed_size(buffer: &[u8]) -> Result<i64, ArrowError> {
+pub fn read_uncompressed_size(buffer: &[u8]) -> Result<i64, ArrowError> {
     let len_buffer = buffer.get(..LENGTH_OF_PREFIX_DATA as usize).ok_or_else(|| {
         ArrowError::IpcError(format!(
             "Compressed IPC buffer is too short: expected at least {LENGTH_OF_PREFIX_DATA} bytes, got {}",

--- a/arrow-ipc/src/compression.rs
+++ b/arrow-ipc/src/compression.rs
@@ -428,6 +428,26 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lz4")]
+    fn test_lz4_decompression_rejects_output_exceeding_advertised_size() {
+        let input_bytes = b"hello lz4";
+        let codec = super::CompressionCodec::Lz4Frame;
+        let mut compressed = Vec::new();
+        codec
+            .compress(input_bytes, &mut compressed, &mut Default::default())
+            .unwrap();
+
+        let err = codec
+            .decompress(&compressed, input_bytes.len() - 1, &mut Default::default())
+            .expect_err("output larger than the advertised size should fail");
+
+        assert!(
+            err.to_string().contains("exceeds advertised size"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     #[cfg(feature = "zstd")]
     fn test_zstd_compression() {
         let input_bytes = b"hello zstd";

--- a/arrow-ipc/src/lib.rs
+++ b/arrow-ipc/src/lib.rs
@@ -49,6 +49,7 @@ pub mod reader;
 pub mod writer;
 
 mod compression;
+pub use compression::read_uncompressed_size;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
# Rationale for this change

Compressed Arrow IPC buffers advertise their uncompressed length in an 8-byte prefix. `decompress_to_buffer` interprets `0` as empty, `-1` as uncompressed, and a positive value as the expected decompressed length. For a positive value, IPC decompression already requires an exact match: the common codec path rejects a returned buffer whose length differs from the advertised length.

The codecs previously differed in how they used this value while decompressing. ZSTD passes it as the output capacity to an API that returns an error if the decompressed data exceeds that capacity. LZ4, however, used it only as the initial `Vec` capacity before an unbounded `read_to_end`, allowing Arrow's output `Vec` to grow beyond the advertised length before the final check.

This change gives both codecs the same output-size invariants:

- No more than the advertised number of decompressed bytes are accumulated in the output `Vec`.
- Successful decompression returns exactly the advertised number of bytes.

Without the LZ4 bound, an untrusted compressed stream could cause Arrow's output `Vec` to grow beyond an accepted advertised length before decompression eventually failed. With the bound, the potentially unbounded output accumulation is limited to the advertised length.

Downstream IPC consumers may also need to inspect the advertised length before decompression so that they can reject an unreasonable value before allocating the output buffer. Exposing `read_uncompressed_size` lets them do so without duplicating Arrow's interpretation of the IPC prefix.

# What changes are included in this PR?

- Publicly re-export `read_uncompressed_size` from `arrow-ipc` and document the `-1`, `0`, and positive-length semantics.
- Limit the Arrow-owned LZ4 output buffer to the advertised length while decompressing, and reject output that exceeds it without growing that buffer.
- Correct the existing length-mismatch error message to refer to the decompressed length.

The advertised length remains the exact required output length on successful return and bounds the number of decompressed bytes accumulated in Arrow's output `Vec`. It does not bound the compressed input, allocator overhead, or codec working memory.

# Are these changes tested?

No new tests are introduced. Existing tests cover successful LZ4 and ZSTD round trips and rejection of prefixes shorter than 8 bytes. The new LZ4 over-limit rejection is not directly covered.

# Are there any user-facing changes?

Yes. `arrow_ipc::read_uncompressed_size` is a new public, non-breaking API that lets callers inspect the IPC compression prefix before decompression.

Malformed LZ4 input whose decompressed output exceeds its advertised length is now rejected before Arrow's output buffer grows beyond that length. Valid IPC input is unaffected.
