### PR TITLE
perf: Optimize `RowSelection::and_then` for dense masks

### DIFF
--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -29,11 +29,9 @@ const MASK_RUN_LENGTHS: &[usize] = &[1, 4, 16, 32, 48, 64, 96, 128];
 const MASK_ALGEBRA_ROWS: usize = 3_000_000;
 
 const MASK_AND_THEN_ROWS: usize = 8192;
-const MASK_AND_THEN_OUTER_SELECTIVITY: &[usize] = &[50, 60, 70, 75, 80, 85, 90, 95, 99];
-const MASK_AND_THEN_INNER_SELECTIVITY: &[usize] = &[1, 5, 10, 20, 50, 80, 99];
-const MASK_AND_THEN_LENGTHS: &[usize] = &[
-    64, 128, 256, 512, 1024, 2048, 4096, 8192, 16_384, 32_768, 65_536,
-];
+const MASK_AND_THEN_OUTER_SELECTIVITY: &[usize] = &[70, 75, 80, 99];
+const MASK_AND_THEN_INNER_SELECTIVITY: &[usize] = &[1, 5, 10, 99];
+const MASK_AND_THEN_LENGTHS: &[usize] = &[64, 4096, 8192, 16_384, 65_536];
 
 /// Operand length pairs. Unequal lengths pass the longer side's tail through unchanged,
 /// so the ratio decides how much of the work is the bitwise combine versus the tail.
@@ -186,7 +184,7 @@ fn bench_mask_and_then_sweeps(c: &mut Criterion) {
     }
     clustered.finish();
 
-    for &(outer_percent, inner_percent) in &[(75, 1), (75, 5), (90, 5), (99, 5), (99, 99)] {
+    for &(outer_percent, inner_percent) in &[(75, 5), (99, 5), (99, 99)] {
         let mut lengths = c.benchmark_group(format!(
             "mask_and_then_length/outer_{outer_percent:02}_inner_{inner_percent:02}"
         ));

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -20,18 +20,13 @@ use arrow_buffer::BooleanBuffer;
 use criterion::*;
 use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
 use rand::RngExt;
-use std::{hint, time::Duration};
+use std::hint;
 
 /// Run lengths for the mask conversion benchmarks. Shorter runs mean more
 /// [`RowSelector`]s per row, so the RLE encoding dominates.
 const MASK_RUN_LENGTHS: &[usize] = &[1, 4, 16, 32, 48, 64, 96, 128];
 
 const MASK_ALGEBRA_ROWS: usize = 3_000_000;
-
-const MASK_AND_THEN_ROWS: usize = 8192;
-const MASK_AND_THEN_OUTER_SELECTIVITY: &[usize] = &[70, 75, 80, 99];
-const MASK_AND_THEN_INNER_SELECTIVITY: &[usize] = &[1, 5, 10, 99];
-const MASK_AND_THEN_LENGTHS: &[usize] = &[64, 4096, 8192, 16_384, 65_536];
 
 /// Operand length pairs. Unequal lengths pass the longer side's tail through unchanged,
 /// so the ratio decides how much of the work is the bitwise combine versus the tail.
@@ -82,142 +77,6 @@ fn mask_algebra_operand(len: usize, offset: usize, selection_ratio: f64) -> RowS
         .map(|_| rng.random_bool(selection_ratio))
         .collect();
     RowSelection::from_boolean_buffer(BooleanBuffer::from(bits).slice(offset, len))
-}
-
-fn pseudo_random_mask(len: usize, selection_percent: usize, seed: u64) -> BooleanBuffer {
-    assert!(len > 1);
-    assert!(selection_percent <= 100);
-    let selected = (len * selection_percent / 100).clamp(1, len - 1);
-    let mut ranked = (0..len)
-        .map(|row| {
-            let mut value = (row as u64).wrapping_add(seed);
-            value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
-            value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
-            value ^= value >> 31;
-            (value, row)
-        })
-        .collect::<Vec<_>>();
-    ranked.select_nth_unstable_by_key(selected, |(value, _)| *value);
-
-    let mut bits = vec![false; len];
-    for (_, row) in &ranked[..selected] {
-        bits[*row] = true;
-    }
-    BooleanBuffer::from(bits)
-}
-
-fn clustered_mask(len: usize, selection_percent: usize, seed: usize) -> BooleanBuffer {
-    assert!(len > 1);
-    assert!(selection_percent <= 100);
-    let selected = (len * selection_percent / 100).clamp(1, len - 1);
-    let start = seed % len;
-    let mut bits = vec![false; len];
-    for row in 0..selected {
-        bits[(start + row) % len] = true;
-    }
-    BooleanBuffer::from(bits)
-}
-
-fn mask_and_then_operands(
-    rows: usize,
-    outer_percent: usize,
-    inner_percent: usize,
-) -> (RowSelection, RowSelection) {
-    let outer = pseudo_random_mask(rows, outer_percent, 0x517c_c1b7_2722_0a95);
-    let inner = pseudo_random_mask(outer.count_set_bits(), inner_percent, 0x6eed_0e9d_a4d9_4a4f);
-    (
-        RowSelection::from_boolean_buffer(outer),
-        RowSelection::from_boolean_buffer(inner),
-    )
-}
-
-fn clustered_mask_and_then_operands(
-    rows: usize,
-    outer_percent: usize,
-    inner_percent: usize,
-) -> (RowSelection, RowSelection) {
-    let outer = clustered_mask(rows, outer_percent, 17);
-    let inner = clustered_mask(outer.count_set_bits(), inner_percent, 31);
-    (
-        RowSelection::from_boolean_buffer(outer),
-        RowSelection::from_boolean_buffer(inner),
-    )
-}
-
-/// Sweeps the inputs that decide whether the word-at-a-time mask expansion is
-/// faster than the set-index implementation. Short measurement times keep the
-/// full matrix practical while still providing many iterations per sample.
-fn bench_mask_and_then_sweeps(c: &mut Criterion) {
-    let mut selectivity = c.benchmark_group("mask_and_then_selectivity/8192");
-    selectivity
-        .warm_up_time(Duration::from_millis(500))
-        .measurement_time(Duration::from_secs(1))
-        .sample_size(30);
-
-    for &outer_percent in MASK_AND_THEN_OUTER_SELECTIVITY {
-        for &inner_percent in MASK_AND_THEN_INNER_SELECTIVITY {
-            let (outer, inner) =
-                mask_and_then_operands(MASK_AND_THEN_ROWS, outer_percent, inner_percent);
-            selectivity.bench_function(
-                format!("outer_{outer_percent:02}_inner_{inner_percent:02}"),
-                |b| b.iter(|| hint::black_box(outer.and_then(&inner))),
-            );
-        }
-    }
-    selectivity.finish();
-
-    let mut clustered = c.benchmark_group("mask_and_then_clustered_selectivity/8192");
-    clustered
-        .warm_up_time(Duration::from_millis(500))
-        .measurement_time(Duration::from_secs(1))
-        .sample_size(30);
-
-    for &outer_percent in MASK_AND_THEN_OUTER_SELECTIVITY {
-        for &inner_percent in MASK_AND_THEN_INNER_SELECTIVITY {
-            let (outer, inner) =
-                clustered_mask_and_then_operands(MASK_AND_THEN_ROWS, outer_percent, inner_percent);
-            clustered.bench_function(
-                format!("outer_{outer_percent:02}_inner_{inner_percent:02}"),
-                |b| b.iter(|| hint::black_box(outer.and_then(&inner))),
-            );
-        }
-    }
-    clustered.finish();
-
-    for &(outer_percent, inner_percent) in &[(75, 5), (99, 5), (99, 99)] {
-        let mut lengths = c.benchmark_group(format!(
-            "mask_and_then_length/outer_{outer_percent:02}_inner_{inner_percent:02}"
-        ));
-        lengths
-            .warm_up_time(Duration::from_millis(500))
-            .measurement_time(Duration::from_secs(1))
-            .sample_size(30);
-
-        for &rows in MASK_AND_THEN_LENGTHS {
-            let (outer, inner) = mask_and_then_operands(rows, outer_percent, inner_percent);
-            lengths.bench_function(rows.to_string(), |b| {
-                b.iter(|| hint::black_box(outer.and_then(&inner)))
-            });
-        }
-        lengths.finish();
-
-        let mut clustered_lengths = c.benchmark_group(format!(
-            "mask_and_then_clustered_length/outer_{outer_percent:02}_inner_{inner_percent:02}"
-        ));
-        clustered_lengths
-            .warm_up_time(Duration::from_millis(500))
-            .measurement_time(Duration::from_secs(1))
-            .sample_size(30);
-
-        for &rows in MASK_AND_THEN_LENGTHS {
-            let (outer, inner) =
-                clustered_mask_and_then_operands(rows, outer_percent, inner_percent);
-            clustered_lengths.bench_function(rows.to_string(), |b| {
-                b.iter(|| hint::black_box(outer.and_then(&inner)))
-            });
-        }
-        clustered_lengths.finish();
-    }
 }
 
 /// Benchmarks the bitwise `intersection`/`union` path, taken when both operands are
@@ -342,8 +201,6 @@ fn criterion_benchmark(c: &mut Criterion) {
             hint::black_box(result);
         })
     });
-
-    bench_mask_and_then_sweeps(c);
 
     bench_mask_backed_algebra(c, selection_ratio);
     bench_mask_backed_conversion(c, total_rows, selection_ratio);

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -353,20 +353,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let composed = outer.and_then(&inner);
     let third_mask = BooleanBuffer::from_iter((0..composed.row_count()).map(|i| i % 100 != 0));
     let third = RowSelection::from_boolean_buffer(third_mask);
-    c.bench_function("mask_and_then/8192/kept_99_100", |b| {
-        b.iter(|| hint::black_box(outer.and_then(&inner)))
-    });
-    c.bench_function("mask_and_then/8192/kept_99_100_twice", |b| {
+    c.bench_function("mask_and_then/8192/precomposed_outer_98_inner_99", |b| {
         b.iter(|| hint::black_box(composed.and_then(&third)))
-    });
-
-    let outer_mask = BooleanBuffer::from_iter((0..8192).map(|i| i % 20 != 0));
-    let inner_mask =
-        BooleanBuffer::from_iter((0..outer_mask.count_set_bits()).map(|i| i % 100 != 0));
-    let outer = RowSelection::from_boolean_buffer(outer_mask);
-    let inner = RowSelection::from_boolean_buffer(inner_mask);
-    c.bench_function("mask_and_then/8192/outer_95_inner_99", |b| {
-        b.iter(|| hint::black_box(outer.and_then(&inner)))
     });
 
     bench_mask_and_then_sweeps(c);

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -30,8 +30,10 @@ const MASK_ALGEBRA_ROWS: usize = 3_000_000;
 
 const MASK_AND_THEN_ROWS: usize = 8192;
 const MASK_AND_THEN_OUTER_SELECTIVITY: &[usize] = &[50, 60, 70, 75, 80, 85, 90, 95, 99];
-const MASK_AND_THEN_INNER_SELECTIVITY: &[usize] = &[1, 50, 99];
-const MASK_AND_THEN_LENGTHS: &[usize] = &[64, 128, 256, 512, 1024, 2048, 4096, 8192];
+const MASK_AND_THEN_INNER_SELECTIVITY: &[usize] = &[1, 5, 10, 20, 50, 80, 99];
+const MASK_AND_THEN_LENGTHS: &[usize] = &[
+    64, 128, 256, 512, 1024, 2048, 4096, 8192, 16_384, 32_768, 65_536,
+];
 
 /// Operand length pairs. Unequal lengths pass the longer side's tail through unchanged,
 /// so the ratio decides how much of the work is the bitwise combine versus the tail.
@@ -106,6 +108,18 @@ fn pseudo_random_mask(len: usize, selection_percent: usize, seed: u64) -> Boolea
     BooleanBuffer::from(bits)
 }
 
+fn clustered_mask(len: usize, selection_percent: usize, seed: usize) -> BooleanBuffer {
+    assert!(len > 1);
+    assert!(selection_percent <= 100);
+    let selected = (len * selection_percent / 100).clamp(1, len - 1);
+    let start = seed % len;
+    let mut bits = vec![false; len];
+    for row in 0..selected {
+        bits[(start + row) % len] = true;
+    }
+    BooleanBuffer::from(bits)
+}
+
 fn mask_and_then_operands(
     rows: usize,
     outer_percent: usize,
@@ -113,6 +127,19 @@ fn mask_and_then_operands(
 ) -> (RowSelection, RowSelection) {
     let outer = pseudo_random_mask(rows, outer_percent, 0x517c_c1b7_2722_0a95);
     let inner = pseudo_random_mask(outer.count_set_bits(), inner_percent, 0x6eed_0e9d_a4d9_4a4f);
+    (
+        RowSelection::from_boolean_buffer(outer),
+        RowSelection::from_boolean_buffer(inner),
+    )
+}
+
+fn clustered_mask_and_then_operands(
+    rows: usize,
+    outer_percent: usize,
+    inner_percent: usize,
+) -> (RowSelection, RowSelection) {
+    let outer = clustered_mask(rows, outer_percent, 17);
+    let inner = clustered_mask(outer.count_set_bits(), inner_percent, 31);
     (
         RowSelection::from_boolean_buffer(outer),
         RowSelection::from_boolean_buffer(inner),
@@ -141,7 +168,25 @@ fn bench_mask_and_then_sweeps(c: &mut Criterion) {
     }
     selectivity.finish();
 
-    for &(outer_percent, inner_percent) in &[(75, 1), (99, 99)] {
+    let mut clustered = c.benchmark_group("mask_and_then_clustered_selectivity/8192");
+    clustered
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(1))
+        .sample_size(30);
+
+    for &outer_percent in MASK_AND_THEN_OUTER_SELECTIVITY {
+        for &inner_percent in MASK_AND_THEN_INNER_SELECTIVITY {
+            let (outer, inner) =
+                clustered_mask_and_then_operands(MASK_AND_THEN_ROWS, outer_percent, inner_percent);
+            clustered.bench_function(
+                format!("outer_{outer_percent:02}_inner_{inner_percent:02}"),
+                |b| b.iter(|| hint::black_box(outer.and_then(&inner))),
+            );
+        }
+    }
+    clustered.finish();
+
+    for &(outer_percent, inner_percent) in &[(75, 1), (75, 5), (90, 5), (99, 5), (99, 99)] {
         let mut lengths = c.benchmark_group(format!(
             "mask_and_then_length/outer_{outer_percent:02}_inner_{inner_percent:02}"
         ));
@@ -157,6 +202,23 @@ fn bench_mask_and_then_sweeps(c: &mut Criterion) {
             });
         }
         lengths.finish();
+
+        let mut clustered_lengths = c.benchmark_group(format!(
+            "mask_and_then_clustered_length/outer_{outer_percent:02}_inner_{inner_percent:02}"
+        ));
+        clustered_lengths
+            .warm_up_time(Duration::from_millis(500))
+            .measurement_time(Duration::from_secs(1))
+            .sample_size(30);
+
+        for &rows in MASK_AND_THEN_LENGTHS {
+            let (outer, inner) =
+                clustered_mask_and_then_operands(rows, outer_percent, inner_percent);
+            clustered_lengths.bench_function(rows.to_string(), |b| {
+                b.iter(|| hint::black_box(outer.and_then(&inner)))
+            });
+        }
+        clustered_lengths.finish();
     }
 }
 

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -345,18 +345,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    let outer_mask = BooleanBuffer::from_iter((0..8192).map(|i| i % 100 != 0));
-    let inner_mask =
-        BooleanBuffer::from_iter((0..outer_mask.count_set_bits()).map(|i| i % 100 != 0));
-    let outer = RowSelection::from_boolean_buffer(outer_mask);
-    let inner = RowSelection::from_boolean_buffer(inner_mask);
-    let composed = outer.and_then(&inner);
-    let third_mask = BooleanBuffer::from_iter((0..composed.row_count()).map(|i| i % 100 != 0));
-    let third = RowSelection::from_boolean_buffer(third_mask);
-    c.bench_function("mask_and_then/8192/precomposed_outer_98_inner_99", |b| {
-        b.iter(|| hint::black_box(composed.and_then(&third)))
-    });
-
     bench_mask_and_then_sweeps(c);
 
     bench_mask_backed_algebra(c, selection_ratio);

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -20,13 +20,18 @@ use arrow_buffer::BooleanBuffer;
 use criterion::*;
 use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
 use rand::RngExt;
-use std::hint;
+use std::{hint, time::Duration};
 
 /// Run lengths for the mask conversion benchmarks. Shorter runs mean more
 /// [`RowSelector`]s per row, so the RLE encoding dominates.
 const MASK_RUN_LENGTHS: &[usize] = &[1, 4, 16, 32, 48, 64, 96, 128];
 
 const MASK_ALGEBRA_ROWS: usize = 3_000_000;
+
+const MASK_AND_THEN_ROWS: usize = 8192;
+const MASK_AND_THEN_OUTER_SELECTIVITY: &[usize] = &[50, 60, 70, 75, 80, 85, 90, 95, 99];
+const MASK_AND_THEN_INNER_SELECTIVITY: &[usize] = &[1, 50, 99];
+const MASK_AND_THEN_LENGTHS: &[usize] = &[64, 128, 256, 512, 1024, 2048, 4096, 8192];
 
 /// Operand length pairs. Unequal lengths pass the longer side's tail through unchanged,
 /// so the ratio decides how much of the work is the bitwise combine versus the tail.
@@ -77,6 +82,82 @@ fn mask_algebra_operand(len: usize, offset: usize, selection_ratio: f64) -> RowS
         .map(|_| rng.random_bool(selection_ratio))
         .collect();
     RowSelection::from_boolean_buffer(BooleanBuffer::from(bits).slice(offset, len))
+}
+
+fn pseudo_random_mask(len: usize, selection_percent: usize, seed: u64) -> BooleanBuffer {
+    assert!(len > 1);
+    assert!(selection_percent <= 100);
+    let selected = (len * selection_percent / 100).clamp(1, len - 1);
+    let mut ranked = (0..len)
+        .map(|row| {
+            let mut value = (row as u64).wrapping_add(seed);
+            value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            value ^= value >> 31;
+            (value, row)
+        })
+        .collect::<Vec<_>>();
+    ranked.select_nth_unstable_by_key(selected, |(value, _)| *value);
+
+    let mut bits = vec![false; len];
+    for (_, row) in &ranked[..selected] {
+        bits[*row] = true;
+    }
+    BooleanBuffer::from(bits)
+}
+
+fn mask_and_then_operands(
+    rows: usize,
+    outer_percent: usize,
+    inner_percent: usize,
+) -> (RowSelection, RowSelection) {
+    let outer = pseudo_random_mask(rows, outer_percent, 0x517c_c1b7_2722_0a95);
+    let inner = pseudo_random_mask(outer.count_set_bits(), inner_percent, 0x6eed_0e9d_a4d9_4a4f);
+    (
+        RowSelection::from_boolean_buffer(outer),
+        RowSelection::from_boolean_buffer(inner),
+    )
+}
+
+/// Sweeps the inputs that decide whether the word-at-a-time mask expansion is
+/// faster than the set-index implementation. Short measurement times keep the
+/// full matrix practical while still providing many iterations per sample.
+fn bench_mask_and_then_sweeps(c: &mut Criterion) {
+    let mut selectivity = c.benchmark_group("mask_and_then_selectivity/8192");
+    selectivity
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(1))
+        .sample_size(30);
+
+    for &outer_percent in MASK_AND_THEN_OUTER_SELECTIVITY {
+        for &inner_percent in MASK_AND_THEN_INNER_SELECTIVITY {
+            let (outer, inner) =
+                mask_and_then_operands(MASK_AND_THEN_ROWS, outer_percent, inner_percent);
+            selectivity.bench_function(
+                format!("outer_{outer_percent:02}_inner_{inner_percent:02}"),
+                |b| b.iter(|| hint::black_box(outer.and_then(&inner))),
+            );
+        }
+    }
+    selectivity.finish();
+
+    for &(outer_percent, inner_percent) in &[(75, 1), (99, 99)] {
+        let mut lengths = c.benchmark_group(format!(
+            "mask_and_then_length/outer_{outer_percent:02}_inner_{inner_percent:02}"
+        ));
+        lengths
+            .warm_up_time(Duration::from_millis(500))
+            .measurement_time(Duration::from_secs(1))
+            .sample_size(30);
+
+        for &rows in MASK_AND_THEN_LENGTHS {
+            let (outer, inner) = mask_and_then_operands(rows, outer_percent, inner_percent);
+            lengths.bench_function(rows.to_string(), |b| {
+                b.iter(|| hint::black_box(outer.and_then(&inner)))
+            });
+        }
+        lengths.finish();
+    }
 }
 
 /// Benchmarks the bitwise `intersection`/`union` path, taken when both operands are
@@ -225,6 +306,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("mask_and_then/8192/outer_95_inner_99", |b| {
         b.iter(|| hint::black_box(outer.and_then(&inner)))
     });
+
+    bench_mask_and_then_sweeps(c);
 
     bench_mask_backed_algebra(c, selection_ratio);
     bench_mask_backed_conversion(c, total_rows, selection_ratio);

--- a/parquet/benches/row_selector.rs
+++ b/parquet/benches/row_selector.rs
@@ -202,6 +202,30 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
+    let outer_mask = BooleanBuffer::from_iter((0..8192).map(|i| i % 100 != 0));
+    let inner_mask =
+        BooleanBuffer::from_iter((0..outer_mask.count_set_bits()).map(|i| i % 100 != 0));
+    let outer = RowSelection::from_boolean_buffer(outer_mask);
+    let inner = RowSelection::from_boolean_buffer(inner_mask);
+    let composed = outer.and_then(&inner);
+    let third_mask = BooleanBuffer::from_iter((0..composed.row_count()).map(|i| i % 100 != 0));
+    let third = RowSelection::from_boolean_buffer(third_mask);
+    c.bench_function("mask_and_then/8192/kept_99_100", |b| {
+        b.iter(|| hint::black_box(outer.and_then(&inner)))
+    });
+    c.bench_function("mask_and_then/8192/kept_99_100_twice", |b| {
+        b.iter(|| hint::black_box(composed.and_then(&third)))
+    });
+
+    let outer_mask = BooleanBuffer::from_iter((0..8192).map(|i| i % 20 != 0));
+    let inner_mask =
+        BooleanBuffer::from_iter((0..outer_mask.count_set_bits()).map(|i| i % 100 != 0));
+    let outer = RowSelection::from_boolean_buffer(outer_mask);
+    let inner = RowSelection::from_boolean_buffer(inner_mask);
+    c.bench_function("mask_and_then/8192/outer_95_inner_99", |b| {
+        b.iter(|| hint::black_box(outer.and_then(&inner)))
+    });
+
     bench_mask_backed_algebra(c, selection_ratio);
     bench_mask_backed_conversion(c, total_rows, selection_ratio);
 }

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -27,8 +27,21 @@ use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, MutableBuffer, bit_util}
 use std::cmp::Ordering;
 use std::iter::Peekable;
 
-// Dense expansion has a fixed per-word cost. Require a sufficiently large,
-// dense outer mask and enough inner survivors to amortize that cost.
+// Policy for the word-at-a-time expansion in `and_then_dense_masks`.
+//
+// The dense path costs a fixed amount per 64-bit output word, independent of
+// how many inner rows survive. The set-index path instead walks the outer set
+// bits up to the last inner survivor and appends each survivor individually,
+// so it wins when the outer mask is sparse, or when only a few inner rows
+// survive and they sit near the start of the selection (for example, a
+// clustered page-level filter). The thresholds below keep the set-index path
+// for those inputs:
+//
+// - `MIN_LEN`: the outer mask must have at least this many rows.
+// - `MAX_DROPPED_FRACTION` is a divisor: at most `1 / 4` of the outer rows may
+//   be unset, i.e. roughly 75% outer selectivity or more.
+// - `MIN_INNER_FRACTION` is a divisor: at least `1 / 20` of the selected rows
+//   must survive the inner selection, i.e. roughly 5% inner selectivity or more.
 const AND_THEN_DENSE_MASK_MIN_LEN: usize = 8192;
 const AND_THEN_DENSE_MASK_MAX_DROPPED_FRACTION: usize = 4;
 const AND_THEN_DENSE_MASK_MIN_INNER_FRACTION: usize = 20;
@@ -440,6 +453,10 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
     builder.finish()
 }
 
+/// Returns whether `and_then_masks` should take the dense path for an outer
+/// mask of `mask_len` rows with `selected_count` set bits, given that
+/// `other_true_count` of those rows survive the inner selection. See the
+/// `AND_THEN_DENSE_MASK_*` constants for the rationale behind each threshold.
 #[inline]
 fn should_use_dense_mask(mask_len: usize, selected_count: usize, other_true_count: usize) -> bool {
     mask_len >= AND_THEN_DENSE_MASK_MIN_LEN
@@ -448,7 +465,11 @@ fn should_use_dense_mask(mask_len: usize, selected_count: usize, other_true_coun
 }
 
 /// Expands `other` into the set positions of a dense `mask`, processing one
-/// output word at a time. This is the inverse operation of bitmap compression.
+/// output word at a time. Each output word takes the next
+/// `mask_word.count_ones()` bits of `other` and scatters them into the set
+/// positions of `mask_word`, so this is the inverse of compressing `mask` down
+/// to its selected rows. Callers must have validated that `other.len()` equals
+/// the number of set bits in `mask`.
 #[inline(never)]
 fn and_then_dense_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer {
     let mut other_chunks = other.bit_chunks().iter_padded();

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -27,10 +27,11 @@ use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, MutableBuffer, bit_util}
 use std::cmp::Ordering;
 use std::iter::Peekable;
 
-// The benchmark sweep crosses over at 4K rows when the outer mask keeps 75%
-// and the inner mask keeps 1%; denser masks and inner masks benefit more.
-const AND_THEN_DENSE_MASK_MIN_LEN: usize = 4096;
+// Dense expansion has a fixed per-word cost. Require a sufficiently large,
+// dense outer mask and enough inner survivors to amortize that cost.
+const AND_THEN_DENSE_MASK_MIN_LEN: usize = 8192;
 const AND_THEN_DENSE_MASK_MAX_DROPPED_FRACTION: usize = 4;
+const AND_THEN_DENSE_MASK_MIN_INNER_FRACTION: usize = 20;
 
 /// Applies `second` to the rows selected by `first`, both selector-backed.
 pub(super) fn and_then_row_selections(
@@ -414,12 +415,7 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
         return mask.clone();
     }
 
-    if mask.len() >= AND_THEN_DENSE_MASK_MIN_LEN
-        && mask.len() - selected_count
-            <= mask
-                .len()
-                .div_ceil(AND_THEN_DENSE_MASK_MAX_DROPPED_FRACTION)
-    {
+    if should_use_dense_mask(mask.len(), selected_count, other_true_count) {
         return and_then_dense_masks(mask, other);
     }
 
@@ -448,8 +444,16 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
     builder.finish()
 }
 
+#[inline]
+fn should_use_dense_mask(mask_len: usize, selected_count: usize, other_true_count: usize) -> bool {
+    mask_len >= AND_THEN_DENSE_MASK_MIN_LEN
+        && mask_len - selected_count <= mask_len.div_ceil(AND_THEN_DENSE_MASK_MAX_DROPPED_FRACTION)
+        && other_true_count >= selected_count / AND_THEN_DENSE_MASK_MIN_INNER_FRACTION
+}
+
 /// Expands `other` into the set positions of a dense `mask`, processing one
 /// output word at a time. This is the inverse operation of bitmap compression.
+#[inline(never)]
 fn and_then_dense_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer {
     let mut other_chunks = other.bit_chunks().iter_padded();
     let mut other_remaining = other.len();
@@ -861,6 +865,18 @@ mod tests {
             let actual = outer.and_then(&inner);
             assert_eq!(actual.as_mask().unwrap(), &expected);
         }
+    }
+
+    #[test]
+    fn test_dense_mask_and_then_policy() {
+        let len = 8192;
+        let selected = len * 3 / 4;
+        let min_inner = selected / AND_THEN_DENSE_MASK_MIN_INNER_FRACTION;
+
+        assert!(!should_use_dense_mask(len - 1, selected, min_inner));
+        assert!(!should_use_dense_mask(len, selected - 1, min_inner));
+        assert!(!should_use_dense_mask(len, selected, min_inner - 1));
+        assert!(should_use_dense_mask(len, selected, min_inner));
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -27,8 +27,10 @@ use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, MutableBuffer, bit_util}
 use std::cmp::Ordering;
 use std::iter::Peekable;
 
-const AND_THEN_DENSE_MASK_MIN_LEN: usize = 512;
-const AND_THEN_DENSE_MASK_MAX_DROPPED_FRACTION: usize = 20;
+// The benchmark sweep crosses over at 4K rows when the outer mask keeps 75%
+// and the inner mask keeps 1%; denser masks and inner masks benefit more.
+const AND_THEN_DENSE_MASK_MIN_LEN: usize = 4096;
+const AND_THEN_DENSE_MASK_MAX_DROPPED_FRACTION: usize = 4;
 
 /// Applies `second` to the rows selected by `first`, both selector-backed.
 pub(super) fn and_then_row_selections(
@@ -830,7 +832,7 @@ mod tests {
 
     #[test]
     fn test_dense_mask_and_then_mask_with_offsets() {
-        for outer_stride in [100, 20] {
+        for outer_stride in [100, 20, 4] {
             let len = 10_000;
             let outer_offset = 3;
             let outer = BooleanBuffer::from_iter(

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -27,6 +27,9 @@ use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, MutableBuffer, bit_util}
 use std::cmp::Ordering;
 use std::iter::Peekable;
 
+const AND_THEN_DENSE_MASK_MIN_LEN: usize = 512;
+const AND_THEN_DENSE_MASK_MAX_DROPPED_FRACTION: usize = 20;
+
 /// Applies `second` to the rows selected by `first`, both selector-backed.
 pub(super) fn and_then_row_selections(
     first: &[RowSelector],
@@ -397,12 +400,25 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
         Ordering::Equal => {}
     }
 
+    if selected_count == mask.len() {
+        return other.clone();
+    }
+
     let other_true_count = other.count_set_bits();
     if other_true_count == 0 {
         return BooleanBuffer::new_unset(mask.len());
     }
     if other_true_count == selected_count {
         return mask.clone();
+    }
+
+    if mask.len() >= AND_THEN_DENSE_MASK_MIN_LEN
+        && mask.len() - selected_count
+            <= mask
+                .len()
+                .div_ceil(AND_THEN_DENSE_MASK_MAX_DROPPED_FRACTION)
+    {
+        return and_then_dense_masks(mask, other);
     }
 
     let mut builder = BooleanBufferBuilder::new(mask.len());
@@ -428,6 +444,90 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
     }
 
     builder.finish()
+}
+
+/// Expands `other` into the set positions of a dense `mask`, processing one
+/// output word at a time. This is the inverse operation of bitmap compression.
+fn and_then_dense_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer {
+    let mut other_chunks = other.bit_chunks().iter_padded();
+    let mut other_remaining = other.len();
+    let mut pending = 0_u128;
+    let mut pending_len = 0;
+    let mut output = MutableBuffer::with_capacity(mask.len().div_ceil(8));
+
+    for mask_word in mask
+        .bit_chunks()
+        .iter_padded()
+        .take(mask.len().div_ceil(64))
+    {
+        let selected = mask_word.count_ones() as usize;
+        while pending_len < selected {
+            let chunk = other_chunks
+                .next()
+                .expect("validated other length matches selected row count");
+            let chunk_len = other_remaining.min(64);
+            pending |= (chunk as u128) << pending_len;
+            pending_len += chunk_len;
+            other_remaining -= chunk_len;
+        }
+
+        let values = pending as u64;
+        output.extend_from_slice(&deposit_u64(values, mask_word).to_le_bytes());
+        pending >>= selected;
+        pending_len -= selected;
+    }
+
+    debug_assert_eq!(other_remaining, 0);
+    debug_assert_eq!(pending_len, 0);
+    output.truncate(mask.len().div_ceil(8));
+    BooleanBuffer::new(output.into(), 0, mask.len())
+}
+
+/// Deposits the least-significant bits of `values` into the set positions of `mask`.
+#[inline]
+fn deposit_u64(mut values: u64, mask: u64) -> u64 {
+    if mask == u64::MAX {
+        return values;
+    }
+
+    if mask.count_ones() == 63 {
+        let dropped = (!mask).trailing_zeros();
+        let lower_mask = ((1_u128 << dropped) - 1) as u64;
+        return (values & lower_mask) | ((values & !lower_mask) << 1);
+    }
+
+    let mut output = 0;
+    for byte_offset in (0..64).step_by(8) {
+        let byte_mask = (mask >> byte_offset) as u8;
+        let selected = byte_mask.count_ones() as usize;
+        output |= (deposit_u8(values as u8, byte_mask, selected) as u64) << byte_offset;
+        values >>= selected;
+    }
+    output
+}
+
+#[inline]
+fn deposit_u8(values: u8, mask: u8, selected: usize) -> u8 {
+    if selected == 8 {
+        return values;
+    }
+
+    if selected == 7 {
+        let dropped = (!mask).trailing_zeros();
+        let lower_mask = ((1_u16 << dropped) - 1) as u8;
+        return (values & lower_mask) | ((values & !lower_mask) << 1);
+    }
+
+    let mut output = 0;
+    let mut input_idx = 0;
+    let mut remaining = mask;
+    while remaining != 0 {
+        let output_idx = remaining.trailing_zeros();
+        output |= ((values >> input_idx) & 1) << output_idx;
+        input_idx += 1;
+        remaining &= remaining - 1;
+    }
+    output
 }
 
 #[cfg(test)]
@@ -726,6 +826,57 @@ mod tests {
             actual_bits,
             vec![false, false, true, false, false, false, true, false]
         );
+    }
+
+    #[test]
+    fn test_dense_mask_and_then_mask_with_offsets() {
+        for outer_stride in [100, 20] {
+            let len = 10_000;
+            let outer_offset = 3;
+            let outer = BooleanBuffer::from_iter(
+                (0..len + outer_offset).map(|i| (i + 1) % outer_stride != 0),
+            )
+            .slice(outer_offset, len);
+
+            let inner_offset = 5;
+            let inner_len = outer.count_set_bits();
+            let inner =
+                BooleanBuffer::from_iter((0..inner_len + inner_offset).map(|i| (i + 2) % 97 != 0))
+                    .slice(inner_offset, inner_len);
+
+            let mut inner_idx = 0;
+            let expected = BooleanBuffer::from_iter((0..len).map(|i| {
+                if !outer.value(i) {
+                    return false;
+                }
+                let value = inner.value(inner_idx);
+                inner_idx += 1;
+                value
+            }));
+
+            let outer = RowSelection::from_boolean_buffer(outer);
+            let inner = RowSelection::from_boolean_buffer(inner);
+            let actual = outer.and_then(&inner);
+            assert_eq!(actual.as_mask().unwrap(), &expected);
+        }
+    }
+
+    #[test]
+    fn test_deposit_u8() {
+        for mask in u8::MIN..=u8::MAX {
+            let selected = mask.count_ones() as usize;
+            for values in u8::MIN..=u8::MAX {
+                let mut expected = 0;
+                let mut input_idx = 0;
+                for output_idx in 0..8 {
+                    if mask & (1 << output_idx) != 0 {
+                        expected |= ((values >> input_idx) & 1) << output_idx;
+                        input_idx += 1;
+                    }
+                }
+                assert_eq!(deposit_u8(values, mask, selected), expected);
+            }
+        }
     }
 
     #[test]

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -506,51 +506,35 @@ fn and_then_dense_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanB
     BooleanBuffer::new(output.into(), 0, mask.len())
 }
 
-/// Deposits the least-significant bits of `values` into the set positions of `mask`.
+/// Deposits the least-significant bits of `values` into the set positions of
+/// `mask`, i.e. a software `pdep`. Bits of `values` above the
+/// `mask.count_ones()` meaningful ones are ignored.
+///
+/// Iterates over whichever side of `mask` has fewer bits: for a dense mask,
+/// insert a zero bit at each unset position, lowest first; otherwise scatter
+/// the low bits of `values` to each set position, lowest first.
 #[inline]
 fn deposit_u64(mut values: u64, mask: u64) -> u64 {
-    if mask == u64::MAX {
-        return values;
+    let mut zeros = !mask;
+    if zeros.count_ones() <= 32 {
+        // Inserting a zero shifts the bits above it up by one, so the garbage
+        // bits above the meaningful ones fall off the top.
+        while zeros != 0 {
+            let lower = (1_u64 << zeros.trailing_zeros()) - 1;
+            values = (values & lower) | ((values & !lower) << 1);
+            zeros &= zeros - 1;
+        }
+        values
+    } else {
+        let mut output = 0;
+        let mut ones = mask;
+        while ones != 0 {
+            output |= (values & 1) << ones.trailing_zeros();
+            values >>= 1;
+            ones &= ones - 1;
+        }
+        output
     }
-
-    if mask.count_ones() == 63 {
-        let dropped = (!mask).trailing_zeros();
-        let lower_mask = ((1_u128 << dropped) - 1) as u64;
-        return (values & lower_mask) | ((values & !lower_mask) << 1);
-    }
-
-    let mut output = 0;
-    for byte_offset in (0..64).step_by(8) {
-        let byte_mask = (mask >> byte_offset) as u8;
-        let selected = byte_mask.count_ones() as usize;
-        output |= (deposit_u8(values as u8, byte_mask, selected) as u64) << byte_offset;
-        values >>= selected;
-    }
-    output
-}
-
-#[inline]
-fn deposit_u8(values: u8, mask: u8, selected: usize) -> u8 {
-    if selected == 8 {
-        return values;
-    }
-
-    if selected == 7 {
-        let dropped = (!mask).trailing_zeros();
-        let lower_mask = ((1_u16 << dropped) - 1) as u8;
-        return (values & lower_mask) | ((values & !lower_mask) << 1);
-    }
-
-    let mut output = 0;
-    let mut input_idx = 0;
-    let mut remaining = mask;
-    while remaining != 0 {
-        let output_idx = remaining.trailing_zeros();
-        output |= ((values >> input_idx) & 1) << output_idx;
-        input_idx += 1;
-        remaining &= remaining - 1;
-    }
-    output
 }
 
 #[cfg(test)]
@@ -942,20 +926,47 @@ mod tests {
     }
 
     #[test]
-    fn test_deposit_u8() {
-        for mask in u8::MIN..=u8::MAX {
-            let selected = mask.count_ones() as usize;
-            for values in u8::MIN..=u8::MAX {
-                let mut expected = 0;
-                let mut input_idx = 0;
-                for output_idx in 0..8 {
-                    if mask & (1 << output_idx) != 0 {
-                        expected |= ((values >> input_idx) & 1) << output_idx;
-                        input_idx += 1;
-                    }
+    fn test_deposit_u64() {
+        fn reference(values: u64, mask: u64) -> u64 {
+            let mut expected = 0;
+            let mut input_idx = 0;
+            for output_idx in 0..64 {
+                if mask & (1 << output_idx) != 0 {
+                    expected |= ((values >> input_idx) & 1) << output_idx;
+                    input_idx += 1;
                 }
-                assert_eq!(deposit_u8(values, mask, selected), expected);
             }
+            expected
+        }
+
+        let mut rng = StdRng::seed_from_u64(0x2b7e_1516_28ae_d2a6);
+
+        // Masks with at most one unset bit or at most one set bit
+        for bit in 0..64 {
+            for mask in [u64::MAX, !(1 << bit), 1 << bit, 0] {
+                for _ in 0..16 {
+                    let values = rng.random::<u64>();
+                    assert_eq!(
+                        deposit_u64(values, mask),
+                        reference(values, mask),
+                        "{mask:#x}"
+                    );
+                }
+            }
+        }
+
+        // Masks across the full density range, exercising both loops
+        for _ in 0..20_000 {
+            let density = rng.random_range(0.0..=1.0);
+            let mask = (0..64).fold(0_u64, |mask, bit| {
+                mask | ((rng.random_bool(density) as u64) << bit)
+            });
+            let values = rng.random::<u64>();
+            assert_eq!(
+                deposit_u64(values, mask),
+                reference(values, mask),
+                "{mask:#x}"
+            );
         }
     }
 

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -536,7 +536,7 @@ fn deposit_u8(values: u8, mask: u8, selected: usize) -> u8 {
 mod tests {
     use super::*;
     use arrow_array::BooleanArray;
-    use rand::{RngExt, rng};
+    use rand::{RngExt, SeedableRng, rng, rngs::StdRng};
 
     #[test]
     fn test_and() {
@@ -832,19 +832,64 @@ mod tests {
 
     #[test]
     fn test_dense_mask_and_then_mask_with_offsets() {
-        for outer_stride in [100, 20, 4] {
-            let len = 10_000;
-            let outer_offset = 3;
-            let outer = BooleanBuffer::from_iter(
-                (0..len + outer_offset).map(|i| (i + 1) % outer_stride != 0),
-            )
-            .slice(outer_offset, len);
+        for len in [8192, 8193, 10_000] {
+            for outer_stride in [100, 20, 4] {
+                let outer_offset = 3;
+                let outer = BooleanBuffer::from_iter(
+                    (0..len + outer_offset).map(|i| (i + 1) % outer_stride != 0),
+                )
+                .slice(outer_offset, len);
 
-            let inner_offset = 5;
+                let inner_offset = 5;
+                let inner_len = outer.count_set_bits();
+                let inner = BooleanBuffer::from_iter(
+                    (0..inner_len + inner_offset).map(|i| (i + 2) % 97 != 0),
+                )
+                .slice(inner_offset, inner_len);
+
+                assert!(should_use_dense_mask(
+                    outer.len(),
+                    inner.len(),
+                    inner.count_set_bits()
+                ));
+
+                let mut inner_idx = 0;
+                let expected = BooleanBuffer::from_iter((0..len).map(|i| {
+                    if !outer.value(i) {
+                        return false;
+                    }
+                    let value = inner.value(inner_idx);
+                    inner_idx += 1;
+                    value
+                }));
+
+                let outer = RowSelection::from_boolean_buffer(outer);
+                let inner = RowSelection::from_boolean_buffer(inner);
+                let actual = outer.and_then(&inner);
+                assert_eq!(actual.as_mask().unwrap(), &expected);
+            }
+        }
+    }
+
+    #[test]
+    fn test_dense_mask_and_then_mask_randomized_word_boundaries() {
+        let mut rng = StdRng::seed_from_u64(0x67e4_a91b_239d_c805);
+
+        for (len, outer_offset, inner_offset) in [(8192, 0, 0), (8192, 3, 5), (8193, 7, 1)] {
+            let outer =
+                BooleanBuffer::from_iter((0..len + outer_offset).map(|_| rng.random_bool(0.8)))
+                    .slice(outer_offset, len);
             let inner_len = outer.count_set_bits();
-            let inner =
-                BooleanBuffer::from_iter((0..inner_len + inner_offset).map(|i| (i + 2) % 97 != 0))
-                    .slice(inner_offset, inner_len);
+            let inner = BooleanBuffer::from_iter(
+                (0..inner_len + inner_offset).map(|_| rng.random_bool(0.5)),
+            )
+            .slice(inner_offset, inner_len);
+
+            assert!(should_use_dense_mask(
+                outer.len(),
+                inner.len(),
+                inner.count_set_bits()
+            ));
 
             let mut inner_idx = 0;
             let expected = BooleanBuffer::from_iter((0..len).map(|i| {

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -403,10 +403,6 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
         Ordering::Equal => {}
     }
 
-    if selected_count == mask.len() {
-        return other.clone();
-    }
-
     let other_true_count = other.count_set_bits();
     if other_true_count == 0 {
         return BooleanBuffer::new_unset(mask.len());

--- a/parquet/src/arrow/arrow_reader/selection/algebra.rs
+++ b/parquet/src/arrow/arrow_reader/selection/algebra.rs
@@ -27,21 +27,10 @@ use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, MutableBuffer, bit_util}
 use std::cmp::Ordering;
 use std::iter::Peekable;
 
-// Policy for the word-at-a-time expansion in `and_then_dense_masks`.
-//
-// The dense path costs a fixed amount per 64-bit output word, independent of
-// how many inner rows survive. The set-index path instead walks the outer set
-// bits up to the last inner survivor and appends each survivor individually,
-// so it wins when the outer mask is sparse, or when only a few inner rows
-// survive and they sit near the start of the selection (for example, a
-// clustered page-level filter). The thresholds below keep the set-index path
-// for those inputs:
-//
-// - `MIN_LEN`: the outer mask must have at least this many rows.
-// - `MAX_DROPPED_FRACTION` is a divisor: at most `1 / 4` of the outer rows may
-//   be unset, i.e. roughly 75% outer selectivity or more.
-// - `MIN_INNER_FRACTION` is a divisor: at least `1 / 20` of the selected rows
-//   must survive the inner selection, i.e. roughly 5% inner selectivity or more.
+// Use word-at-a-time expansion for masks with at least 8192 rows, roughly
+// 75% outer selectivity and 5% inner selectivity. Smaller or sparser inputs
+// use set indices to avoid scanning every output word.
+// The selectivity constants are divisors: at most 1/4 dropped, at least 1/20 kept.
 const AND_THEN_DENSE_MASK_MIN_LEN: usize = 8192;
 const AND_THEN_DENSE_MASK_MAX_DROPPED_FRACTION: usize = 4;
 const AND_THEN_DENSE_MASK_MIN_INNER_FRACTION: usize = 20;
@@ -453,10 +442,7 @@ fn and_then_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer 
     builder.finish()
 }
 
-/// Returns whether `and_then_masks` should take the dense path for an outer
-/// mask of `mask_len` rows with `selected_count` set bits, given that
-/// `other_true_count` of those rows survive the inner selection. See the
-/// `AND_THEN_DENSE_MASK_*` constants for the rationale behind each threshold.
+/// Checks the length and selectivity thresholds for dense expansion.
 #[inline]
 fn should_use_dense_mask(mask_len: usize, selected_count: usize, other_true_count: usize) -> bool {
     mask_len >= AND_THEN_DENSE_MASK_MIN_LEN
@@ -464,12 +450,8 @@ fn should_use_dense_mask(mask_len: usize, selected_count: usize, other_true_coun
         && other_true_count >= selected_count / AND_THEN_DENSE_MASK_MIN_INNER_FRACTION
 }
 
-/// Expands `other` into the set positions of a dense `mask`, processing one
-/// output word at a time. Each output word takes the next
-/// `mask_word.count_ones()` bits of `other` and scatters them into the set
-/// positions of `mask_word`, so this is the inverse of compressing `mask` down
-/// to its selected rows. Callers must have validated that `other.len()` equals
-/// the number of set bits in `mask`.
+/// Scatters the next `mask_word.count_ones()` bits of `other` into each mask word.
+/// Requires `other.len() == mask.count_set_bits()`.
 #[inline(never)]
 fn and_then_dense_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanBuffer {
     let mut other_chunks = other.bit_chunks().iter_padded();
@@ -506,19 +488,17 @@ fn and_then_dense_masks(mask: &BooleanBuffer, other: &BooleanBuffer) -> BooleanB
     BooleanBuffer::new(output.into(), 0, mask.len())
 }
 
-/// Deposits the least-significant bits of `values` into the set positions of
-/// `mask`, i.e. a software `pdep`. Bits of `values` above the
-/// `mask.count_ones()` meaningful ones are ignored.
-///
-/// Iterates over whichever side of `mask` has fewer bits: for a dense mask,
-/// insert a zero bit at each unset position, lowest first; otherwise scatter
-/// the low bits of `values` to each set position, lowest first.
+/// Software `pdep`: scatters the lowest `mask.count_ones()` bits of `values`
+/// into `mask`'s set positions. Visits whichever is fewer: unset or set bits.
 #[inline]
 fn deposit_u64(mut values: u64, mask: u64) -> u64 {
+    if values == 0 {
+        return 0;
+    }
+
     let mut zeros = !mask;
     if zeros.count_ones() <= 32 {
-        // Inserting a zero shifts the bits above it up by one, so the garbage
-        // bits above the meaningful ones fall off the top.
+        // Insert zeros from low to high; excess input bits shift out.
         while zeros != 0 {
             let lower = (1_u64 << zeros.trailing_zeros()) - 1;
             values = (values & lower) | ((values & !lower) << 1);
@@ -1230,6 +1210,44 @@ mod tests {
                 &expected_combined(&l_bits, &r_bits, |a, b| a || b),
                 "union",
             );
+        }
+    }
+
+    #[test]
+    fn dense_composition_with_zero_words_and_offsets() {
+        for mask_len in [8192, 8193, 65537] {
+            for (mask_offset, inner_offset) in [(0, 0), (3, 5), (63, 65), (65, 129)] {
+                for stride in [4, 100] {
+                    let mask =
+                        BooleanBuffer::from_iter((0..mask_offset + mask_len + 73).map(|i| {
+                            !(mask_offset..mask_offset + mask_len).contains(&i)
+                                || (i - mask_offset) % stride != 0
+                        }))
+                        .slice(mask_offset, mask_len);
+                    let len = mask.count_set_bits();
+                    for start in [0, 63, len / 2] {
+                        for select_last in [false, true] {
+                            let count = len / 10;
+                            let inner =
+                                BooleanBuffer::from_iter((0..inner_offset + len + 73).map(|i| {
+                                    if !(inner_offset..inner_offset + len).contains(&i) {
+                                        return true;
+                                    }
+                                    let j = i - inner_offset;
+                                    (start..start + count).contains(&j)
+                                        || select_last && j == len - 1
+                                }))
+                                .slice(inner_offset, len);
+                            let mut values = inner.iter();
+                            let expected = BooleanBuffer::from_iter(
+                                mask.iter().map(|v| v && values.next().unwrap()),
+                            );
+                            assert_eq!(and_then_masks(&mask, &inner), expected);
+                            assert_eq!(and_then_dense_masks(&mask, &inner), expected);
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10967.

# Rationale for this change

The mask-backed `RowSelection::and_then` implementation has high per-selected-row overhead for large, dense masks: it walks the outer set bits one at a time and appends each surviving row individually. Expanding the inner mask one 64-bit word at a time is substantially faster for these inputs.

# What changes are included in this PR?

- Add a word-at-a-time dense mask expansion path. Each output word deposits the next `popcount` bits of the inner mask into the set positions of the outer word (a software `pdep`), iterating over whichever side of the word has fewer bits.
- Keep the existing set-index path for short or sparse masks.
- Select the dense path for masks with at least 8,192 rows, at least ~75% outer selectivity, and at least ~5% inner selectivity.
- Add unit tests for the new path.

The dense path costs a fixed amount per output word regardless of how many inner rows survive. The set-index path only walks the outer set bits up to the last inner survivor, so it stays faster when the outer mask is sparse, or when only a few inner rows survive and they are clustered near the start of the selection. The thresholds keep the set-index path for those inputs.

The benchmark suite is submitted separately in #10969.

# Are these changes tested?

Yes. Tests cover bitmap offsets, threshold boundaries, and randomized 64-bit deposit inputs across the full mask density range, including every mask with at most one set or unset bit.

```console
cargo test -p parquet --lib arrow::arrow_reader::selection::algebra::tests

test result: ok. 23 passed; 0 failed
```

Using the benchmark suite in #10969, all 38 cases that select the dense path improved, with mean execution time reduced by 41.7% to 97.6% on an Apple M4 with Rust 1.97.1. The remaining 26 cases take the unchanged set-index path and show no measurable difference.

| Distribution | Rows | Outer | Inner | `main` | PR | Change |
|---|---:|---:|---:|---:|---:|---:|
| Pseudo-random | 8,192 | 75% | 5% | 3,691 ns | 1,456 ns | -60.7% |
| Clustered | 8,192 | 75% | 5% | 882 ns | 513 ns | -41.7% |
| Pseudo-random | 8,192 | 99% | 99% | 18,255 ns | 553 ns | -96.9% |
| Clustered | 65,536 | 99% | 99% | 142,840 ns | 3,389 ns | -97.6% |

# Are there any user-facing changes?

No. This is an internal performance optimization with no API or behavior changes.
