### PR TITLE
perf(nullbuf::expand) non aligned counts

### DIFF
--- a/arrow-buffer/src/buffer/null.rs
+++ b/arrow-buffer/src/buffer/null.rs
@@ -147,6 +147,10 @@ impl NullBuffer {
             // boundary (bit i starts at bit i*count, which is divisible by 8),
             // so we can fill count/8 bytes of 0xFF at a time instead of setting
             // bits individually.
+            //
+            // By iterating over contiguous runs of valid bits rather than
+            // individual bits, a dense validity buffer (long runs of non-null
+            // values) collapses into a single fill call per run.
             let bytes_per_bit = count / 8;
             let buf = buffer.as_mut();
             for (start, end) in BitSliceIterator::new(
@@ -178,12 +182,42 @@ impl NullBuffer {
                 }
             }
         } else {
-            for i in 0..self.buffer.len() {
-                if self.is_null(i) {
-                    continue;
-                }
-                for j in 0..count {
-                    crate::bit_util::set_bit(buffer.as_mut(), i * count + j)
+            // For each contiguous run of valid bits [start, end), the corresponding
+            // output bits [start*count, end*count) are set. Boundary bytes that are
+            // only partially covered are ORed with a mask; fully covered interior
+            // bytes are filled with 0xFF.
+            let buf = buffer.as_mut();
+            for (start, end) in BitSliceIterator::new(
+                self.buffer.values(),
+                self.buffer.offset(),
+                self.buffer.len(),
+            ) {
+                let start_bit = start * count;
+                let end_bit = end * count;
+                let start_byte = start_bit / 8;
+                let start_offset = (start_bit % 8) as u32; // first bit to set within start_byte
+                let end_byte = end_bit / 8;
+                let end_offset = (end_bit % 8) as u32; // one-past-last bit within end_byte
+
+                if start_byte == end_byte {
+                    // All bits land in one byte: mask from start_offset up to end_offset.
+                    // 0xFF << start_offset  → bits [start_offset, 7] set
+                    // (1 << end_offset) - 1 → bits [0, end_offset) set
+                    // AND of both           → bits [start_offset, end_offset) set
+                    buf[start_byte] |= (0xFFu8 << start_offset) & ((1u8 << end_offset) - 1);
+                } else {
+                    if start_offset != 0 {
+                        // Partial leading byte: set bits from start_offset to bit 7.
+                        buf[start_byte] |= 0xFFu8 << start_offset;
+                    }
+                    // Full interior bytes (skip start_byte if it was only partially covered).
+                    let full_start = start_byte + (start_offset != 0) as usize;
+                    buf[full_start..end_byte].fill(0xFF);
+                    if end_offset != 0 {
+                        // Partial trailing byte: set bits 0 up to end_offset.
+                        // (1 << end_offset) - 1 → bits [0, end_offset) set
+                        buf[end_byte] |= (1u8 << end_offset) - 1;
+                    }
                 }
             }
         }

--- a/arrow-buffer/src/buffer/null.rs
+++ b/arrow-buffer/src/buffer/null.rs
@@ -147,10 +147,6 @@ impl NullBuffer {
             // boundary (bit i starts at bit i*count, which is divisible by 8),
             // so we can fill count/8 bytes of 0xFF at a time instead of setting
             // bits individually.
-            //
-            // By iterating over contiguous runs of valid bits rather than
-            // individual bits, a dense validity buffer (long runs of non-null
-            // values) collapses into a single fill call per run.
             let bytes_per_bit = count / 8;
             let buf = buffer.as_mut();
             for (start, end) in BitSliceIterator::new(

--- a/arrow/benches/boolean_kernels.rs
+++ b/arrow/benches/boolean_kernels.rs
@@ -91,16 +91,12 @@ fn bench_null_buffer_expand(c: &mut Criterion) {
     let mut group = c.benchmark_group("null_buffer_expand");
 
     let cases: &[(&str, usize, usize)] = &[
-        ("len=512/count=16", 512, 16),
-        ("len=512/count=12", 512, 12),
+        ("len=512/count=16", 512, 16), // pow2
+        ("len=512/count=12", 512, 12), // non-pow2
         ("len=1024/count=128", 1024, 128),
         ("len=1024/count=96", 1024, 96),
         ("len=2048/count=256", 2048, 256),
         ("len=2048/count=192", 2048, 192),
-        // general (non-multiple-of-4) path
-        ("len=1024/count=7", 1024, 7),
-        ("len=1024/count=17", 1024, 17),
-        ("len=1024/count=29", 1024, 29),
     ];
 
     for &(label, len, count) in cases {

--- a/arrow/benches/boolean_kernels.rs
+++ b/arrow/benches/boolean_kernels.rs
@@ -91,12 +91,16 @@ fn bench_null_buffer_expand(c: &mut Criterion) {
     let mut group = c.benchmark_group("null_buffer_expand");
 
     let cases: &[(&str, usize, usize)] = &[
-        ("len=512/count=16", 512, 16), // pow2
-        ("len=512/count=12", 512, 12), // non-pow2
+        ("len=512/count=16", 512, 16),
+        ("len=512/count=12", 512, 12),
         ("len=1024/count=128", 1024, 128),
         ("len=1024/count=96", 1024, 96),
         ("len=2048/count=256", 2048, 256),
         ("len=2048/count=192", 2048, 192),
+        // general (non-multiple-of-4) path
+        ("len=1024/count=7", 1024, 7),
+        ("len=1024/count=17", 1024, 17),
+        ("len=1024/count=29", 1024, 29),
     ];
 
     for &(label, len, count) in cases {


### PR DESCRIPTION
## note I did use ai to help me with the bit maniluplation logic!

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- follow up to #10976

# Rationale for this change

`NullBuffer::expand` now has a fast path for count % 8 == 0 (byte-aligned) and count % 4 == 0 (nibble-aligned) counts. For all other values of count the fallback iterated every bit individually, calling set_bit per valid index. This is O(n × count) bit-level writes even when the validity buffer is mostly non-null.


<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Replaces the bit-by-bit fallback in `NullBuffer::try_expand` with a BitSliceIterator based approach that works over contiguous runs of valid bits rather than individual bits. For each run [start, end) it computes the output byte range [start*count/8, end*count/8] and sets it with byte-level OR masks:
- A partial leading byte is ORed with 0xFF << start_offset.
- Full interior bytes are filled with 0xFF.
- A partial trailing byte is ORed with (1 << end_offset) - 1.
- When the entire run fits in a single byte, both masks are ANDed together.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
yes, test was introduced in #10976
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
