### PR TITLE
fix(arrow-ipc): write 8-byte i64 length prefix for compressed IPC buffers on wasm32

### DIFF
--- a/arrow-ipc/src/compression.rs
+++ b/arrow-ipc/src/compression.rs
@@ -201,7 +201,7 @@ impl CompressionCodec {
             // empty input, nothing to do
         } else {
             // write compressed data directly into the output buffer
-            output.extend_from_slice(&uncompressed_data_len.to_le_bytes());
+            output.extend_from_slice(&(uncompressed_data_len as i64).to_le_bytes());
             self.compress(input, output, context)?;
 
             let compression_len = output.len() - original_output_len;
@@ -442,5 +442,21 @@ mod tests {
                 .contains("Compressed IPC buffer is too short"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    #[cfg(feature = "lz4")]
+    fn test_compress_to_vec_writes_8_byte_length_prefix() {
+        // The length prefix must always be 8 bytes (i64),
+        // even on platforms where `usize` is narrower (e.g. wasm32).
+        let input_bytes = vec![42u8; 132];
+        let codec = super::CompressionCodec::Lz4Frame;
+        let mut output_bytes: Vec<u8> = Vec::new();
+        codec
+            .compress_to_vec(&input_bytes, &mut output_bytes, &mut Default::default())
+            .unwrap();
+
+        let prefix: [u8; 8] = output_bytes[..8].try_into().unwrap();
+        assert_eq!(i64::from_le_bytes(prefix), input_bytes.len() as i64);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

* Closes https://github.com/apache/arrow-rs/issues/10986.

# Rationale for this change

On `wasm32`, `usize` is 32-bit, causing the compressed IPC buffer length prefix to be written as 4 bytes instead of the required 8-byte `i64` value.

# What changes are included in this PR?

Serialize the uncompressed buffer length explicitly as `i64` to ensure the IPC compression prefix is always 8 bytes across platforms.

# Are these changes tested?

Yes. Verified the generated compressed IPC buffer and confirmed the 8-byte length prefix is correctly written on `wasm32`.

# Are there any user-facing changes?

No. This is a bug fix for IPC compression compatibility on `wasm32`; there are no API or breaking changes.
