### PR TITLE
Avoid overflow in decimal precision and scale arithmetic

### DIFF
--- a/arrow-arith/src/numeric.rs
+++ b/arrow-arith/src/numeric.rs
@@ -1047,12 +1047,13 @@ fn decimal_op<T: DecimalType>(
 
             // max(s1, s2) + max(p1-s1, p2-s2) + 1
             let result_precision =
-                (result_scale.saturating_add((*p1 as i8 - s1).max(*p2 as i8 - s2)) as u8)
-                    .saturating_add(1)
-                    .min(T::MAX_PRECISION);
+                (result_scale as i16 + (*p1 as i16 - *s1 as i16).max(*p2 as i16 - *s2 as i16) + 1)
+                    .min(T::MAX_PRECISION as i16) as u8;
 
-            let l_mul = T::Native::usize_as(10).pow_checked((result_scale - s1) as _)?;
-            let r_mul = T::Native::usize_as(10).pow_checked((result_scale - s2) as _)?;
+            let l_mul =
+                T::Native::usize_as(10).pow_checked((result_scale as i16 - *s1 as i16) as _)?;
+            let r_mul =
+                T::Native::usize_as(10).pow_checked((result_scale as i16 - *s2 as i16) as _)?;
 
             match op {
                 // Equal scales make both decimal multipliers one.
@@ -1086,8 +1087,8 @@ fn decimal_op<T: DecimalType>(
         }
         Op::Mul | Op::MulWrapping => {
             let result_precision = p1.saturating_add(p2 + 1).min(T::MAX_PRECISION);
-            let result_scale = s1.saturating_add(*s2);
-            if result_scale > T::MAX_SCALE {
+            let result_scale = *s1 as i16 + *s2 as i16;
+            if result_scale > T::MAX_SCALE as i16 {
                 // SQL standard says that if the resulting scale of a multiply operation goes
                 // beyond the maximum, rounding is not acceptable and thus an error occurs
                 return Err(ArrowError::InvalidArgumentError(format!(
@@ -1097,6 +1098,14 @@ fn decimal_op<T: DecimalType>(
                     T::MAX_SCALE
                 )));
             }
+            let result_scale = i8::try_from(result_scale).map_err(|_| {
+                ArrowError::InvalidArgumentError(format!(
+                    "Output scale of {} {op} {} would be less than min scale of {}",
+                    l.data_type(),
+                    r.data_type(),
+                    i8::MIN
+                ))
+            })?;
 
             try_op!(l, l_s, r, r_s, l.mul_checked(r))
                 .with_precision_and_scale(result_precision, result_scale)?
@@ -1140,12 +1149,14 @@ fn decimal_op<T: DecimalType>(
             // max(s1, s2)
             let result_scale = *s1.max(s2);
             // min(p1-s1, p2 -s2) + max( s1,s2 )
-            let result_precision =
-                (result_scale.saturating_add((*p1 as i8 - s1).min(*p2 as i8 - s2)) as u8)
-                    .min(T::MAX_PRECISION);
+            let result_precision = (result_scale as i16
+                + (*p1 as i16 - *s1 as i16).min(*p2 as i16 - *s2 as i16))
+            .min(T::MAX_PRECISION as i16) as u8;
 
-            let l_mul = T::Native::usize_as(10).pow_wrapping((result_scale - s1) as _);
-            let r_mul = T::Native::usize_as(10).pow_wrapping((result_scale - s2) as _);
+            let l_mul =
+                T::Native::usize_as(10).pow_checked((result_scale as i16 - *s1 as i16) as _)?;
+            let r_mul =
+                T::Native::usize_as(10).pow_checked((result_scale as i16 - *s2 as i16) as _)?;
 
             try_op!(
                 l,
@@ -1532,6 +1543,82 @@ mod tests {
         assert_eq!(err, "Divide by zero error");
         let err = rem(&a, &b).unwrap_err().to_string();
         assert_eq!(err, "Divide by zero error");
+    }
+
+    #[test]
+    fn test_decimal256_negative_scale_metadata() {
+        for (precision, scale, expected_precision) in
+            [(76, -51, 76), (76, -52, 76), (76, -76, 76), (20, -128, 21)]
+        {
+            let a = Decimal256Array::from(vec![Some(i256::ONE), Some(i256::MINUS_ONE), None])
+                .with_precision_and_scale(precision, scale)
+                .unwrap();
+            let b = Decimal256Array::from(vec![i256::from_i128(2), i256::ONE, i256::ONE])
+                .with_precision_and_scale(precision, scale)
+                .unwrap();
+            for (operation, values, precision) in [
+                (
+                    add as fn(_, _) -> _,
+                    [Some(3), Some(0), None],
+                    expected_precision,
+                ),
+                (add_wrapping, [Some(3), Some(0), None], expected_precision),
+                (sub, [Some(-1), Some(-2), None], expected_precision),
+                (sub_wrapping, [Some(-1), Some(-2), None], expected_precision),
+                (rem, [Some(1), Some(0), None], precision),
+            ] {
+                let expected =
+                    Decimal256Array::from(values.map(|x| x.map(i256::from_i128)).to_vec())
+                        .with_precision_and_scale(precision, scale)
+                        .unwrap();
+                let result = operation(&a, &b).unwrap();
+                assert_eq!(result.as_primitive::<Decimal256Type>(), &expected);
+            }
+        }
+    }
+
+    #[test]
+    fn test_decimal256_extreme_scale_difference() {
+        let a = Decimal256Array::from(vec![i256::ONE])
+            .with_precision_and_scale(20, i8::MIN)
+            .unwrap();
+        let b = Decimal256Array::from(vec![i256::from_i128(2)])
+            .with_precision_and_scale(20, i8::MIN + 1)
+            .unwrap();
+        for (operation, value, precision) in
+            [(add as fn(_, _) -> _, 12, 22), (sub, 8, 22), (rem, 0, 20)]
+        {
+            let result = operation(&a, &b).unwrap();
+            assert_eq!(result.data_type(), &DataType::Decimal256(precision, -127));
+            assert_eq!(
+                result.as_primitive::<Decimal256Type>().value(0),
+                i256::from_i128(value)
+            );
+        }
+        let b = b.with_precision_and_scale(76, 76).unwrap();
+        for operation in [add, sub, rem] {
+            assert!(matches!(
+                operation(&a, &b),
+                Err(ArrowError::ArithmeticOverflow(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn test_decimal256_multiply_minimum_scale() {
+        let a = Decimal256Array::from(vec![i256::ONE])
+            .with_precision_and_scale(76, -64)
+            .unwrap();
+        for operation in [mul, mul_wrapping] {
+            let result = operation(&a, &a).unwrap();
+            assert_eq!(result.data_type(), &DataType::Decimal256(76, i8::MIN));
+            assert_eq!(result.as_primitive::<Decimal256Type>().value(0), i256::ONE);
+            let b = a.clone().with_precision_and_scale(76, -65).unwrap();
+            assert!(matches!(
+                operation(&a, &b),
+                Err(ArrowError::InvalidArgumentError(_))
+            ));
+        }
     }
 
     #[test]

--- a/arrow-cast/src/cast/decimal.rs
+++ b/arrow-cast/src/cast/decimal.rs
@@ -172,7 +172,7 @@ where
     I::Native: DecimalCast + ArrowNativeTypeOp,
     O::Native: DecimalCast + ArrowNativeTypeOp,
 {
-    let delta_scale = output_scale - input_scale;
+    let delta_scale = output_scale as i16 - input_scale as i16;
 
     // O::MAX_FOR_EACH_PRECISION[k] stores 10^k - 1 (e.g., 9, 99, 999, ...).
     // Adding 1 yields exactly 10^k without computing a power at runtime.
@@ -188,7 +188,7 @@ where
     // then an increase of scale by 3 will have the following effect on the representation:
     // [xxxxx] -> [xxxxx000], so for the cast to be infallible, the output type
     // needs to provide at least 8 digits precision
-    let is_infallible_cast = (input_precision as i8) + delta_scale <= (output_precision as i8);
+    let is_infallible_cast = (input_precision as i16) + delta_scale <= (output_precision as i16);
     let f_infallible = is_infallible_cast
         .then_some(move |x| O::Native::from_decimal(x).unwrap().mul_wrapping(mul));
     Some((f_fallible, f_infallible))
@@ -221,7 +221,7 @@ where
     I::Native: DecimalCast + ArrowNativeTypeOp,
     O::Native: DecimalCast + ArrowNativeTypeOp,
 {
-    let delta_scale = input_scale - output_scale;
+    let delta_scale = input_scale as i16 - output_scale as i16;
 
     // delta_scale is guaranteed to be > 0, but may also be larger than I::MAX_PRECISION. If so, the
     // scale change divides out more digits than the input has precision and the result of the cast
@@ -259,7 +259,7 @@ where
     // the output type needs to have at least 3 digits of precision.
     // e.g. Decimal(5, 3) 99.999 to Decimal(3, 0) will result in 100:
     // [99999] -> [99] + 1 = [100], a cast to Decimal(2, 0) would not be possible
-    let is_infallible_cast = (input_precision as i8) - delta_scale < (output_precision as i8);
+    let is_infallible_cast = (input_precision as i16) - delta_scale < (output_precision as i16);
     let f_infallible = is_infallible_cast.then_some(move |x| f_fallible(x).unwrap());
     Some((f_fallible, f_infallible))
 }
@@ -908,6 +908,26 @@ mod tests {
     fn test_rescale_decimal_upscale_overflow_returns_none() {
         let result = rescale_decimal::<Decimal32Type, Decimal32Type>(9_999_i32, 4, 0, 5, 2);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_rescale_decimal256_extreme_scales() {
+        assert_eq!(
+            rescale_decimal::<Decimal256Type, Decimal256Type>(i256::ONE, 76, -76, 76, 0),
+            None
+        );
+        assert_eq!(
+            rescale_decimal::<Decimal256Type, Decimal256Type>(i256::ZERO, 76, -76, 76, 0),
+            Some(i256::ZERO)
+        );
+        assert_eq!(
+            rescale_decimal::<Decimal256Type, Decimal256Type>(i256::ONE, 76, i8::MIN, 76, 76),
+            None
+        );
+        assert_eq!(
+            rescale_decimal::<Decimal256Type, Decimal256Type>(i256::ONE, 76, 76, 76, i8::MIN),
+            Some(i256::ZERO)
+        );
     }
 
     #[test]

--- a/arrow-cast/src/cast/mod.rs
+++ b/arrow-cast/src/cast/mod.rs
@@ -11024,6 +11024,82 @@ mod tests {
     }
 
     #[test]
+    fn test_cast_decimal256_negative_scale_metadata() {
+        for scale in [-51, -52, -75, -76] {
+            let input = Decimal256Array::from(vec![
+                Some(i256::ZERO),
+                Some(i256::ONE),
+                Some(i256::MINUS_ONE),
+                Some(i256::from_i128(6)),
+                None,
+            ])
+            .with_precision_and_scale(76, scale)
+            .unwrap();
+            let value = i256::from_i128(10).pow_wrapping((-scale) as u32);
+            let values = if scale == -76 {
+                vec![Some(i256::ZERO), None, None, None, None]
+            } else {
+                vec![
+                    Some(i256::ZERO),
+                    Some(value),
+                    Some(-value),
+                    Some(value * i256::from_i128(6)),
+                    None,
+                ]
+            };
+            let expected = Decimal256Array::from(values)
+                .with_precision_and_scale(76, 0)
+                .unwrap();
+            let result = cast(&input, &DataType::Decimal256(76, 0)).unwrap();
+            assert_eq!(result.as_primitive::<Decimal256Type>(), &expected);
+            let result = cast_with_options(
+                &input,
+                &DataType::Decimal256(76, 0),
+                &CastOptions {
+                    safe: false,
+                    ..Default::default()
+                },
+            );
+            if scale == -76 {
+                assert!(result.is_err());
+            } else {
+                assert_eq!(result.unwrap().as_primitive::<Decimal256Type>(), &expected);
+            }
+        }
+    }
+
+    #[test]
+    fn test_cast_decimal256_extreme_scale_difference() {
+        for (low_scale, high_scale) in [(-76, 76), (i8::MIN, 76)] {
+            let input = Decimal256Array::from(vec![Some(i256::ONE), Some(i256::MINUS_ONE), None])
+                .with_precision_and_scale(76, low_scale)
+                .unwrap();
+            for safe in [true, false] {
+                let options = CastOptions {
+                    safe,
+                    ..Default::default()
+                };
+                assert!(
+                    cast_with_options(&input, &DataType::Decimal256(76, high_scale), &options)
+                        .is_err()
+                );
+                let input = input
+                    .clone()
+                    .with_precision_and_scale(76, high_scale)
+                    .unwrap();
+                let expected =
+                    Decimal256Array::from(vec![Some(i256::ZERO), Some(i256::ZERO), None])
+                        .with_precision_and_scale(76, low_scale)
+                        .unwrap();
+                let result =
+                    cast_with_options(&input, &DataType::Decimal256(76, low_scale), &options)
+                        .unwrap();
+                assert_eq!(result.as_primitive::<Decimal256Type>(), &expected);
+            }
+        }
+    }
+
+    #[test]
     fn test_cast_decimal128_to_decimal128_negative_scale() {
         let input_type = DataType::Decimal128(20, 0);
         let output_type = DataType::Decimal128(20, -1);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #10978.

# Rationale for this change

Valid negative decimal scales can overflow `i8` precision/scale calculations, causing debug panics or incorrect metadata and cast fast-path selection when overflow checks are disabled.

# What changes are included in this PR?

- Compute add/subtract/remainder precision and scale differences in `i16`, clamping precision before narrowing.
- Reject unrepresentable multiplication scales and overflowing remainder alignment factors.
- Widen decimal cast scale differences and precision checks while preserving existing rounding, nulls, and safe/unsafe cast behavior.

# Are these changes tested?

The six new regression tests fail on current `main` before the fix.

- `cargo +stable test -p arrow-arith -p arrow-cast --lib`: 623 passed.
- `cargo +stable --config 'profile.test.package.arrow-arith.overflow-checks=false' --config 'profile.test.package.arrow-cast.overflow-checks=false' test -p arrow-arith -p arrow-cast --lib decimal256 --verbose`: 31 passed. This is an unchecked test profile, not an optimized release build.
- `cargo +stable fmt --all -- --check` and `git diff --check`: passed.
- `cargo +stable clippy -p arrow-arith -p arrow-cast --lib --tests --no-deps -- -D warnings -A clippy::chunks_exact_to_as_chunks`: passed.

Local checks used Rust 1.98.0 on Windows because the installed repository-pinned 1.97.1 toolchain was incomplete. Strict Clippy first reported the new `chunks_exact_to_as_chunks` lint in unchanged `arrow-buffer` and `arrow-arith/src/aggregate.rs` code. The scoped run allows only that lint; the repository's existing removed-lint configuration also emits a compatibility warning. No source or lint configuration was changed for these diagnostics.

# Are there any user-facing changes?

Affected addition, subtraction, multiplication, remainder, and decimal casts now return correctly calculated results or checked errors for extreme negative scales instead of panicking or wrapping metadata. Public API signatures are unchanged.

AI assistance: OpenAI Codex (GPT-6) generated the implementation, regression tests, and this description. Codex agents reviewed the diff and ran the checks listed above. I have personally reviewed the code in this PR.
