### PR TITLE
Adapt predicate cache batch granularity to make zero-rewrite reassembly the common case

### DIFF
--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -501,10 +501,16 @@ impl RowGroupReaderBuilder {
                 let cache_projection =
                     self.compute_cache_projection(row_group_info.row_group_idx, &filter);
 
+                let cache_batch_size = self.cache_batch_size(
+                    row_group_info.row_group_idx,
+                    row_group_info.row_count,
+                    &filter,
+                    &cache_projection,
+                );
                 let cache_info = CacheInfo::new(
                     cache_projection,
                     Arc::new(RwLock::new(RowGroupCache::new(
-                        self.batch_size,
+                        cache_batch_size,
                         self.max_predicate_cache_size,
                     ))),
                 );
@@ -824,6 +830,62 @@ impl RowGroupReaderBuilder {
     ///
     /// Returns the columns that are used by the filters *and* then used in the
     /// final projection, excluding any nested columns.
+    /// Chooses the predicate cache's batch granularity for one row group.
+    ///
+    /// The consumer-side reassembly in `CachedArrayReader::consume_batch`
+    /// concatenates one slice per cached batch its span touches. For byte-view
+    /// columns that concat rewrites every non-inline view's `buffer_index`,
+    /// which profiling shows dominates the cache's cost (arrow-rs#10774),
+    /// while a span served from a single cached batch is a plain `filter`
+    /// that shares the source buffers and rewrites nothing.
+    ///
+    /// Use one batch for the whole row group -- making the zero-rewrite path
+    /// the only path -- when all of the following hold:
+    ///
+    /// 1. The filter has a single predicate. With several predicates the
+    ///    later producers read under the selection refined by earlier ones;
+    ///    coarse batches then expand each fetch to the whole row group,
+    ///    decoding rows the selection skipped (measured 2x regressions on
+    ///    multi-predicate ClickBench queries).
+    /// 2. At least one cached column is BYTE_ARRAY. Fixed-width concat is a
+    ///    plain memcpy with nothing to save, and the larger one-shot decode
+    ///    allocations measurably hurt (ClickBench Q1).
+    /// 3. The cached columns' uncompressed size fits in half the cache
+    ///    budget, so coarser entries cannot start failing inserts, which
+    ///    would push consumers onto the re-decode fallback at whole-row-group
+    ///    granularity.
+    ///
+    /// Otherwise fall back to `self.batch_size` (the previous behavior).
+    fn cache_batch_size(
+        &self,
+        row_group_idx: usize,
+        row_count: usize,
+        filter: &RowFilter,
+        cache_projection: &ProjectionMask,
+    ) -> usize {
+        use crate::basic::Type as PhysicalType;
+
+        if filter.predicates.len() != 1 {
+            return self.batch_size;
+        }
+        let rg = self.metadata.row_group(row_group_idx);
+        let mut cached_bytes: i64 = 0;
+        let mut has_byte_array = false;
+        for (idx, col) in rg.columns().iter().enumerate() {
+            if !cache_projection.leaf_included(idx) {
+                continue;
+            }
+            cached_bytes += col.uncompressed_size();
+            has_byte_array |= col.column_descr().physical_type() == PhysicalType::BYTE_ARRAY;
+        }
+        if !has_byte_array
+            || (cached_bytes as usize).saturating_mul(2) > self.max_predicate_cache_size
+        {
+            return self.batch_size;
+        }
+        row_count.max(self.batch_size)
+    }
+
     fn compute_cache_projection(&self, row_group_idx: usize, filter: &RowFilter) -> ProjectionMask {
         let meta = self.metadata.row_group(row_group_idx);
         match self.compute_cache_projection_inner(filter) {

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -878,9 +878,17 @@ impl RowGroupReaderBuilder {
             cached_bytes += col.uncompressed_size();
             has_byte_array |= col.column_descr().physical_type() == PhysicalType::BYTE_ARRAY;
         }
-        if !has_byte_array
-            || (cached_bytes as usize).saturating_mul(2) > self.max_predicate_cache_size
-        {
+        // Cap the coarse entry's size rather than merely fitting the budget.
+        // Two reasons, both measured: (1) multi-megabyte one-shot decode
+        // allocations cost more than the rewrite they save when the query's
+        // output is sparse (URL at ~40MB/row-group regressed ~2% while
+        // SearchPhrase at ~9MB won 6-15%); output selectivity is unknowable
+        // here, so entry size is the proxy. (2) Entries near the cache budget
+        // start failing inserts, pushing consumers onto the re-decode
+        // fallback at whole-row-group granularity.
+        const COARSE_ENTRY_MAX_BYTES: usize = 16 * 1024 * 1024;
+        let cap = COARSE_ENTRY_MAX_BYTES.min(self.max_predicate_cache_size / 2);
+        if !has_byte_array || cached_bytes as usize > cap {
             return self.batch_size;
         }
         row_count.max(self.batch_size)


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #10774.

## Rationale for this change

`CachedArrayReader::consume_batch` reassembles each consumed span from the cached batches it touches:

- span within **one** cached batch → `filter` alone, which shares the source data buffers — for byte-view columns, zero `buffer_index` rewriting (measured 0.058 ns/row)
- span across **N** batches → filter each slice + `concat`, which rewrites every non-inline view's `buffer_index` (0.498 ns/row, 8.6x)

On ClickBench Q12/Q25 shapes the multi-batch spans are 12.8% of calls but cover **50% of all rows**, and `concat_byte_view` dominates the cache's profile (the 5% flagged in #10774). Per the discussion there, single-pass kernel replacements (`interleave`, index-based and run-based gathers, and the `coalesce` machinery) all measured slower — at ~80% selectivity nothing beats filter's run-based bulk copy — so this PR makes the multi-slice path *rare* instead of faster.

## What changes are included in this PR?

Cache the whole row group as a single batch when all of the following hold, otherwise keep `batch_size` (today's behavior):

1. **The filter has one predicate.** With several, later producers read under the selection refined by earlier predicates; coarse batches then expand each fetch to whole-row-group granularity, decoding rows the selection skipped (measured ~2x regressions on multi-predicate queries Q22/Q36 with a naive global multiplier).
2. **At least one cached column is BYTE_ARRAY.** Fixed-width concat is a plain memcpy with nothing to save, and the larger one-shot decode allocations measurably hurt (Q1 +20% with the naive multiplier).
3. **Cached columns total at most 16MB uncompressed per row group** (and at most half the cache budget). Entry size is a proxy for two measured effects: multi-megabyte one-shot decode allocations cost more than the rewrite they save when the query's output is sparse (URL at ~40MB/RG regressed ~2% in a controlled local A/B while SearchPhrase at ~9MB won 6-15%; output selectivity is unknowable when the cache is built), and entries near the cache budget start failing inserts, pushing consumers onto the re-decode fallback at whole-row-group granularity (this compounds on Q22, which already sees ~11k rejected inserts per session today).

Each gate corresponds to a regression observed when testing an unconditional granularity increase; with the gates, slice counters show exactly the intended targeting (Q12: multi-slice calls 12.8% → 0; Q1/Q22/Q36: unchanged).

## Are these changes tested?

Existing parquet `--lib` suite: 1401 passed (the one failure, `test_int96_interop`, is a missing `parquet-testing` file, unaffected by this change).

Local timing is too noisy on my machine to quote; requesting the benchmark bot below. Back-to-back runs with exact slice counters showed async/Q12 −14% at whole-row-group granularity with multi-slice reassembly eliminated.

## Are there any user-facing changes?

No API changes. The predicate cache may hold the same data in fewer, larger entries for single-predicate scans over string/binary columns; peak cached bytes are unchanged (gated to half the budget), but eviction/accounting granularity is coarser for those scans.

