### PR TITLE
fix(parquet): do not cache an ALP preset built from an empty first page

### DIFF
--- a/parquet/src/encodings/encoding/alp_encoder.rs
+++ b/parquet/src/encodings/encoding/alp_encoder.rs
@@ -703,8 +703,14 @@ where
             None => {
                 let built = build_preset(values);
                 let page = encode_page(values, &built, scratch)?;
+                let had_values = !values.is_empty();
                 values.clear();
-                *preset = Some(built);
+                // An empty page yields the fallback preset (exponent 0, factor 0),
+                // which would pin the whole chunk to an integer scale. Leave the
+                // preset unset so the first page with values builds it.
+                if had_values {
+                    *preset = Some(built);
+                }
                 page
             }
             Some(preset) => streaming.finish(preset.as_slice(), scratch)?,
@@ -1078,4 +1084,47 @@ mod tests {
         // round-trip proves the page survives both paths losslessly.
         assert_bits_eq(&roundtrip::<DoubleType>(&values), &values);
     }
+
+    /// An empty first data page must not pin the chunk's preset to exponent 0 /
+    /// factor 0: `flush_buffer` caches the first page's preset for the whole
+    /// chunk, so a degenerate one makes every later fractional value an exception.
+    #[test]
+    fn test_empty_first_page_does_not_poison_preset() {
+        let values: Vec<f64> = (0..3000).map(|i| (i as f64) * 0.01).collect();
+
+        // Baseline: the same values encoded as the first page of a chunk.
+        let mut baseline_encoder = AlpEncoder::<DoubleType>::new();
+        baseline_encoder.put(&values).unwrap();
+        let baseline = baseline_encoder.flush_buffer().unwrap();
+
+        // The same values, but preceded by an empty first page.
+        let mut encoder = AlpEncoder::<DoubleType>::new();
+        let empty = encoder.flush_buffer().unwrap();
+        assert_eq!(
+            empty.len(),
+            ALP_HEADER_SIZE,
+            "an empty page should be header-only"
+        );
+
+        encoder.put(&values).unwrap();
+        let after_empty = encoder.flush_buffer().unwrap();
+
+        assert!(
+            after_empty.len() < values.len() * std::mem::size_of::<f64>(),
+            "page after an empty first page ({} bytes) is no smaller than raw f64 ({} bytes); \
+             the same values encoded as the first page take {} bytes",
+            after_empty.len(),
+            values.len() * std::mem::size_of::<f64>(),
+            baseline.len()
+        );
+
+        assert!(
+            after_empty.len() <= baseline.len() + baseline.len() / 10,
+            "empty first page poisoned the preset: {} bytes vs {} bytes when encoded first ({:.1}x larger)",
+            after_empty.len(),
+            baseline.len(),
+            after_empty.len() as f64 / baseline.len() as f64
+        );
+    }
+
 }

--- a/parquet/src/encodings/encoding/alp_encoder.rs
+++ b/parquet/src/encodings/encoding/alp_encoder.rs
@@ -697,20 +697,18 @@ where
             streaming,
         } = self;
 
-        // The first flush builds the preset from the whole buffered page and
-        // encodes it in one pass; that also arms streaming for later pages.
+        // The first nonempty flush builds the preset from the whole buffered
+        // page and encodes it in one pass; that also arms streaming for later pages.
         let page = match preset {
+            // Nothing to sample, so no preset to build. Leaving it unset keeps the
+            // chunk off the fallback parameters, which would make every later
+            // fractional value an exception.
+            None if values.is_empty() => encode_page(values, &[], scratch)?,
             None => {
                 let built = build_preset(values);
                 let page = encode_page(values, &built, scratch)?;
-                let had_values = !values.is_empty();
                 values.clear();
-                // An empty page yields the fallback preset (exponent 0, factor 0),
-                // which would pin the whole chunk to an integer scale. Leave the
-                // preset unset so the first page with values builds it.
-                if had_values {
-                    *preset = Some(built);
-                }
+                *preset = Some(built);
                 page
             }
             Some(preset) => streaming.finish(preset.as_slice(), scratch)?,
@@ -1109,22 +1107,9 @@ mod tests {
         encoder.put(&values).unwrap();
         let after_empty = encoder.flush_buffer().unwrap();
 
-        assert!(
-            after_empty.len() < values.len() * std::mem::size_of::<f64>(),
-            "page after an empty first page ({} bytes) is no smaller than raw f64 ({} bytes); \
-             the same values encoded as the first page take {} bytes",
-            after_empty.len(),
-            values.len() * std::mem::size_of::<f64>(),
-            baseline.len()
-        );
-
-        assert!(
-            after_empty.len() <= baseline.len() + baseline.len() / 10,
-            "empty first page poisoned the preset: {} bytes vs {} bytes when encoded first ({:.1}x larger)",
-            after_empty.len(),
-            baseline.len(),
-            after_empty.len() as f64 / baseline.len() as f64
+        assert_eq!(
+            after_empty, baseline,
+            "a leading empty page must not affect encoding of the first nonempty page"
         );
     }
-
 }


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10644.

# Rationale for this change

When a column chunk's first data page has no values, `build_preset` returns the fallback pair (exponent 0, factor 0). `flush_buffer` cached that for the whole chunk, and `select_params` short-circuits on a single-candidate preset, so every later page was stuck on an integer scale and every fractional value became an exception.

It's reachable from the normal write path, not just the encoder API: the column writer counts levels rather than values, so a first page of all nulls flushes an empty buffer.

Encoding 3000 values of `i * 0.01` (raw f64 would be 24,000 bytes):

| | before | after |
| --- | --- | --- |
| values as the first page | 3,808 | 3,808 |
| values after an empty first page | 31,258 | 3,808 |

Before the fix the chunk ends up bigger than leaving it unencoded. After, a leading empty page costs only its 7-byte header.

# What changes are included in this PR?

`flush_buffer` only caches the preset when the page had values. `put` already branches on whether the preset is set, so the next page with values builds it.

The issue asks only for regression coverage and @alamb suggested the fix as a follow-up — this has both. Happy to split them if you'd rather.

# Are these changes tested?

`test_empty_first_page_does_not_poison_preset`, which fails on main. Full `cargo test -p parquet` passes (1558 tests); fmt and clippy clean.

One thing I'd like a second opinion on: with the preset left unset, an all-null first page no longer arms the streaming path, so the second page takes the buffered path. The tests agree that's correct, but it's the part of this I'm least certain about.

---

Per the AI policy in CONTRIBUTING.md: I used Claude Code to trace the encoder and draft the fix and test. I've reviewed all of it and verified the behaviour myself — the numbers above are measured locally on this branch and on main.