### PR TITLE
feat(cast): treat bare interval units as zero (#6390)

### DIFF
--- a/arrow-cast/src/parse.rs
+++ b/arrow-cast/src/parse.rs
@@ -1653,7 +1653,20 @@ fn parse_interval_components(
     // parse amounts and units
     let Ok(pairs): Result<Vec<(IntervalAmount, IntervalUnit)>, ArrowError> = raw_pairs
         .iter()
-        .map(|(a, u)| Ok((a.parse()?, IntervalUnit::from_str_or_config(*u, config)?)))
+        .map(|(a, u)| {
+            // A unit with no preceding amount (e.g. the "hour" in "5 day hour")
+            // is treated as an amount of zero, matching PostgreSQL. An empty
+            // input that contains no unit at all is not affected.
+            let amount = if a.is_empty() && u.is_some() {
+                IntervalAmount {
+                    integer: 0,
+                    frac: 0,
+                }
+            } else {
+                a.parse()?
+            };
+            Ok((amount, IntervalUnit::from_str_or_config(*u, config)?))
+        })
         .collect()
     else {
         return Err(ArrowError::ParseError(format!(
@@ -2580,14 +2593,50 @@ mod tests {
             .unwrap(),
         );
 
+        // a bare unit contributes zero rather than erroring (#6390)
         assert_eq!(
-            Interval::parse("1h s", &config).unwrap_err().to_string(),
-            r#"Parser error: Invalid input syntax for type interval: "1h s""#
+            Interval::new(0, 0, NANOS_PER_HOUR),
+            Interval::parse("1h s", &config).unwrap(),
         );
 
         assert_eq!(
             Interval::parse("1XX", &config).unwrap_err().to_string(),
             r#"Parser error: Invalid input syntax for type interval: "1XX""#
+        );
+    }
+
+    #[test]
+    fn test_interval_bare_units() {
+        let config = IntervalParseConfig::new(IntervalUnit::Month);
+
+        // "5 day hour" should parse like "5 day 0 hour"
+        assert_eq!(
+            Interval::new(0, 5, 0),
+            Interval::parse("5 day hour", &config).unwrap(),
+        );
+
+        // unit matching is case insensitive
+        assert_eq!(
+            Interval::new(0, 5, 0),
+            Interval::parse("5 day HOUR", &config).unwrap(),
+        );
+
+        // bare unit in the middle of the interval
+        assert_eq!(
+            Interval::new(1, 2, 0),
+            Interval::parse("1 month hour 2 days", &config).unwrap(),
+        );
+
+        // a bare unit alone is zero
+        assert_eq!(
+            Interval::new(0, 0, 0),
+            Interval::parse("hour", &config).unwrap(),
+        );
+
+        // an empty string contains no unit and stays invalid
+        assert_eq!(
+            Interval::parse("", &config).unwrap_err().to_string(),
+            r#"Parser error: Invalid input syntax for type interval: """#
         );
     }
 
@@ -3576,6 +3625,16 @@ mod tests {
         assert_eq!(interval.months, 0);
         assert_eq!(interval.days, 0);
         assert_eq!(interval.nanoseconds, NANOS_PER_SECOND);
+
+        // a bare unit is treated as zero (#6390)
+        let interval = parse_interval_month_day_nano_config(
+            "5 day hour",
+            IntervalParseConfig::new(IntervalUnit::Second),
+        )
+        .unwrap();
+        assert_eq!(interval.months, 0);
+        assert_eq!(interval.days, 5);
+        assert_eq!(interval.nanoseconds, 0);
     }
     #[test]
     fn test_parse_prefix_white_space() {


### PR DESCRIPTION
## What does this PR do?

PostgreSQL interprets an interval unit with no preceding amount as an amount of zero — `'5 day hour'` is the same as `'5 day 0 hour'`. `parse_interval_month_day_nano_config` (and friends) instead rejected such strings, because the empty amount failed to parse.

This is the gap behind the DataFusion case `SELECT interval '5 day' hour` (which becomes the interval string `"5 day HOUR"`), see https://github.com/apache/datafusion/issues/12448. The arrow-rs interval parser is documented to match PostgreSQL's interval parser (arrow-cast/src/parse.rs, `split_interval_components` doc comment).

## Changes

In `parse_interval_components` (arrow-cast/src/parse.rs), an empty amount string is now treated as a zero `IntervalAmount` **only when a unit is actually present**:

- `"5 day hour"` → `5 days` (like `"5 day 0 hour"`)
- Case-insensitive units already work, so `"5 day HOUR"` also parses
- A bare unit alone, e.g. `"hour"`, is zero
- An empty string `""` contains no unit and remains invalid
- Unknown units and repeated units still error

One existing test changed: `"1h s"` previously errored and now parses as `1 hour` (the bare `s` contributes zero). This is the intended permissiveness change from #6390.

## Checklist

- [x] `cargo test -p arrow-cast` (392 passed)
- [x] Verified the new tests fail without the fix (stash the implementation change → 3 tests fail)
- [x] Verified the `""` regression test fails if the `u.is_some()` guard is removed
- [x] `cargo clippy -p arrow-cast --all-targets`
- [x] `cargo fmt -p arrow-cast -- --check`
- [x] `typos`
