### PR TITLE
minor : batches_to_flight_data() should not require ownership of arguments  

### DIFF
--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -206,8 +206,8 @@ impl FlightSqlService for FlightSqlServiceImpl {
         self.check_token(&request)?;
         let batch = Self::fake_result().map_err(|e| status!("Could not fake a result", e))?;
         let schema = batch.schema_ref();
-        let batches = [batch.clone()];
-        let flight_data = batches_to_flight_data(schema, batches.iter())
+        let batches = vec![batch.clone()];
+        let flight_data = batches_to_flight_data(schema, batches)
             .map_err(|e| status!("Could not convert batches", e))?
             .into_iter()
             .map(Ok);

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -207,7 +207,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         let batch = Self::fake_result().map_err(|e| status!("Could not fake a result", e))?;
         let schema = batch.schema_ref();
         let batches = vec![batch.clone()];
-        let flight_data = batches_to_flight_data(schema, batches)
+        let flight_data = batches_to_flight_data(schema, &batches)
             .map_err(|e| status!("Could not convert batches", e))?
             .into_iter()
             .map(Ok);

--- a/arrow-flight/examples/flight_sql_server.rs
+++ b/arrow-flight/examples/flight_sql_server.rs
@@ -206,8 +206,8 @@ impl FlightSqlService for FlightSqlServiceImpl {
         self.check_token(&request)?;
         let batch = Self::fake_result().map_err(|e| status!("Could not fake a result", e))?;
         let schema = batch.schema_ref();
-        let batches = vec![batch.clone()];
-        let flight_data = batches_to_flight_data(schema, batches)
+        let batches = [batch.clone()];
+        let flight_data = batches_to_flight_data(schema, batches.iter())
             .map_err(|e| status!("Could not convert batches", e))?
             .into_iter()
             .map(Ok);

--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -83,7 +83,7 @@ pub fn flight_data_to_arrow_batch(
 /// Convert `RecordBatch`es to wire protocol `FlightData`s
 pub fn batches_to_flight_data(
     schema: &Schema,
-    batches: Vec<RecordBatch>,
+    batches: impl Iterator<Item = RecordBatch>,
 ) -> Result<Vec<FlightData>, ArrowError> {
     let options = IpcWriteOptions::default();
     let schema_flight_data: FlightData = SchemaAsIpc::new(schema, &options).into();
@@ -94,9 +94,9 @@ pub fn batches_to_flight_data(
     let mut dictionary_tracker = writer::DictionaryTracker::new(false);
     let mut ipc_write_context = IpcWriteContext::default();
 
-    for batch in &batches {
+    for batch in batches {
         let (encoded_dictionaries, encoded_batch) = data_gen.encode(
-            batch,
+            &batch,
             &mut dictionary_tracker,
             &options,
             &mut ipc_write_context,

--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -81,9 +81,9 @@ pub fn flight_data_to_arrow_batch(
 }
 
 /// Convert `RecordBatch`es to wire protocol `FlightData`s
-pub fn batches_to_flight_data(
+pub fn batches_to_flight_data<'a>(
     schema: &Schema,
-    batches: impl Iterator<Item = RecordBatch>,
+    batches: impl Iterator<Item = &'a RecordBatch>,
 ) -> Result<Vec<FlightData>, ArrowError> {
     let options = IpcWriteOptions::default();
     let schema_flight_data: FlightData = SchemaAsIpc::new(schema, &options).into();
@@ -96,7 +96,7 @@ pub fn batches_to_flight_data(
 
     for batch in batches {
         let (encoded_dictionaries, encoded_batch) = data_gen.encode(
-            &batch,
+            batch,
             &mut dictionary_tracker,
             &options,
             &mut ipc_write_context,

--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -83,7 +83,7 @@ pub fn flight_data_to_arrow_batch(
 /// Convert `RecordBatch`es to wire protocol `FlightData`s
 pub fn batches_to_flight_data<'a>(
     schema: &Schema,
-    batches: impl Iterator<Item = &'a RecordBatch>,
+    batches: impl IntoIterator<Item = &'a RecordBatch>,
 ) -> Result<Vec<FlightData>, ArrowError> {
     let options = IpcWriteOptions::default();
     let schema_flight_data: FlightData = SchemaAsIpc::new(schema, &options).into();

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -483,8 +483,8 @@ impl FlightSqlService for FlightSqlServiceImpl {
             ticket => panic!("Invalid ticket: {ticket:?}"),
         };
         let schema = batch.schema_ref();
-        let batches = vec![batch.clone()];
-        let flight_data = batches_to_flight_data(schema, batches)
+        let batches = [batch.clone()];
+        let flight_data = batches_to_flight_data(schema, batches.iter())
             .unwrap()
             .into_iter()
             .map(Ok);

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -484,7 +484,7 @@ impl FlightSqlService for FlightSqlServiceImpl {
         };
         let schema = batch.schema_ref();
         let batches = vec![batch.clone()];
-        let flight_data = batches_to_flight_data(schema, batches)
+        let flight_data = batches_to_flight_data(schema, &batches)
             .unwrap()
             .into_iter()
             .map(Ok);

--- a/arrow-flight/tests/flight_sql_client_cli.rs
+++ b/arrow-flight/tests/flight_sql_client_cli.rs
@@ -483,8 +483,8 @@ impl FlightSqlService for FlightSqlServiceImpl {
             ticket => panic!("Invalid ticket: {ticket:?}"),
         };
         let schema = batch.schema_ref();
-        let batches = [batch.clone()];
-        let flight_data = batches_to_flight_data(schema, batches.iter())
+        let batches = vec![batch.clone()];
+        let flight_data = batches_to_flight_data(schema, batches)
             .unwrap()
             .into_iter()
             .map(Ok);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #4014

# Rationale for this change
see  #4014

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
change arguments of `batches_to_flight_data()` to take in an iterator so that the underlying container (typically a vecotr) does not need to take ownership.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
n/a
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
yes, this is a breaking change. but it should be a no-op change for existing users that used `Vec<record_batch>`
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
