### PR TITLE
feat: thread flag throughout reader code

### DIFF
--- a/parquet/benches/arrow_reader.rs
+++ b/parquet/benches/arrow_reader.rs
@@ -1058,6 +1058,7 @@ fn create_decimal_by_bytes_reader(
             None,
             DEFAULT_BATCH_SIZE,
             None,
+            false,
         )
         .unwrap(),
         Type::FIXED_LEN_BYTE_ARRAY => make_fixed_len_byte_array_reader(
@@ -1096,6 +1097,7 @@ fn create_byte_array_reader(
         None,
         DEFAULT_BATCH_SIZE,
         None,
+        false,
     )
     .unwrap()
 }
@@ -1110,6 +1112,7 @@ fn create_byte_view_array_reader(
         None,
         DEFAULT_BATCH_SIZE,
         None,
+        false,
     )
     .unwrap()
 }
@@ -1124,6 +1127,7 @@ fn create_string_view_byte_array_reader(
         None,
         DEFAULT_BATCH_SIZE,
         None,
+        false,
     )
     .unwrap()
 }
@@ -1141,6 +1145,7 @@ fn create_string_byte_array_dictionary_reader(
         Some(arrow_type),
         DEFAULT_BATCH_SIZE,
         None,
+        false,
     )
     .unwrap()
 }
@@ -1155,6 +1160,7 @@ fn create_string_list_reader(
         None,
         DEFAULT_BATCH_SIZE,
         Some(2),
+        false,
     )
     .unwrap();
     let field = Field::new_list_field(DataType::Utf8, true);

--- a/parquet/benches/arrow_reader_peak_memory.rs
+++ b/parquet/benches/arrow_reader_peak_memory.rs
@@ -499,7 +499,8 @@ fn string_list_wrapper(
     column_desc: ColumnDescPtr,
 ) -> Box<dyn ArrayReader> {
     let child =
-        make_byte_array_reader(pages, column_desc, None, DEFAULT_BATCH_SIZE, Some(2)).unwrap();
+        make_byte_array_reader(pages, column_desc, None, DEFAULT_BATCH_SIZE, Some(2), false)
+            .unwrap();
     let field = Field::new_list_field(DataType::Utf8, true);
     let data_type = DataType::List(Arc::new(field));
     Box::new(ListArrayReader::<i32>::new(

--- a/parquet/src/arrow/array_reader/builder.rs
+++ b/parquet/src/arrow/array_reader/builder.rs
@@ -99,6 +99,8 @@ pub struct ArrayReaderBuilder<'a> {
     metrics: &'a ArrowReaderMetrics,
     /// Batch size hint for pre-allocating internal buffers (see [`Self::with_batch_size`])
     batch_size: usize,
+    /// Skip UTF-8 validation for string columns
+    skip_utf8_validation: bool,
 }
 
 /// Arguments threaded through the recursive `build_*_reader` calls.
@@ -148,6 +150,7 @@ impl<'a> ArrayReaderBuilder<'a> {
             parquet_metadata: None,
             metrics,
             batch_size: DEFAULT_BATCH_SIZE,
+            skip_utf8_validation: false,
         }
     }
 
@@ -173,6 +176,12 @@ impl<'a> ArrayReaderBuilder<'a> {
     /// Add parquet metadata to the builder for computing virtual column values
     pub fn with_parquet_metadata(mut self, parquet_metadata: &'a ParquetMetaData) -> Self {
         self.parquet_metadata = Some(parquet_metadata);
+        self
+    }
+
+    /// Skip UTF-8 validation for string columns.
+    pub fn with_skip_utf8_validation(mut self, skip: bool) -> Self {
+        self.skip_utf8_validation = skip;
         self
     }
 
@@ -543,6 +552,7 @@ impl<'a> ArrayReaderBuilder<'a> {
                     arrow_type,
                     self.batch_size,
                     padding_threshold,
+                    self.skip_utf8_validation,
                 )?,
                 Some(DataType::Utf8View | DataType::BinaryView) => make_byte_view_array_reader(
                     page_iterator,
@@ -550,6 +560,7 @@ impl<'a> ArrayReaderBuilder<'a> {
                     arrow_type,
                     self.batch_size,
                     padding_threshold,
+                    self.skip_utf8_validation,
                 )?,
                 _ => make_byte_array_reader(
                     page_iterator,
@@ -557,6 +568,7 @@ impl<'a> ArrayReaderBuilder<'a> {
                     arrow_type,
                     self.batch_size,
                     padding_threshold,
+                    self.skip_utf8_validation,
                 )?,
             },
             PhysicalType::FIXED_LEN_BYTE_ARRAY => match arrow_type {
@@ -566,6 +578,7 @@ impl<'a> ArrayReaderBuilder<'a> {
                     arrow_type,
                     self.batch_size,
                     padding_threshold,
+                    self.skip_utf8_validation,
                 )?,
                 _ => make_fixed_len_byte_array_reader(
                     page_iterator,

--- a/parquet/src/arrow/array_reader/byte_array.rs
+++ b/parquet/src/arrow/array_reader/byte_array.rs
@@ -44,6 +44,7 @@ pub fn make_byte_array_reader(
     arrow_type: Option<ArrowType>,
     batch_size: usize,
     padding_threshold: Option<i16>,
+    skip_utf8_validation: bool,
 ) -> Result<Box<dyn ArrayReader>> {
     // Check if Arrow type is specified, else create it from Parquet type
     let data_type = match arrow_type {
@@ -58,7 +59,9 @@ pub fn make_byte_array_reader(
         | ArrowType::Utf8
         | ArrowType::Decimal128(_, _)
         | ArrowType::Decimal256(_, _) => {
-            let mut reader = GenericRecordReader::new(column_desc, batch_size);
+            let is_string = matches!(data_type, ArrowType::Utf8 | ArrowType::Binary);
+            let mut reader = GenericRecordReader::new(column_desc, batch_size)
+                .with_skip_utf8_validation(skip_utf8_validation && is_string);
             if let Some(threshold) = padding_threshold {
                 reader.set_padding_threshold(threshold);
             }
@@ -67,7 +70,8 @@ pub fn make_byte_array_reader(
             )))
         }
         ArrowType::LargeUtf8 | ArrowType::LargeBinary => {
-            let mut reader = GenericRecordReader::new(column_desc, batch_size);
+            let mut reader = GenericRecordReader::new(column_desc, batch_size)
+                .with_skip_utf8_validation(skip_utf8_validation);
             if let Some(threshold) = padding_threshold {
                 reader.set_padding_threshold(threshold);
             }
@@ -259,6 +263,10 @@ impl<I: OffsetSizeTrait> ColumnValueDecoder for ByteArrayColumnValueDecoder<I> {
             .ok_or_else(|| general_err!("no decoder set"))?;
 
         decoder.skip(num_values, self.dict.as_ref())
+    }
+
+    fn set_validate_utf8(&mut self, validate: bool) {
+        self.validate_utf8 = validate;
     }
 }
 

--- a/parquet/src/arrow/array_reader/byte_array_dictionary.rs
+++ b/parquet/src/arrow/array_reader/byte_array_dictionary.rs
@@ -43,14 +43,15 @@ use crate::util::bit_util::FromBitpacked;
 /// A macro to reduce verbosity of [`make_byte_array_dictionary_reader`]
 macro_rules! make_reader {
     (
-        ($pages:expr, $column_desc:expr, $data_type:expr, $batch_size:expr, $padding_threshold:expr) => match ($k:expr, $v:expr) {
+        ($pages:expr, $column_desc:expr, $data_type:expr, $batch_size:expr, $padding_threshold:expr, $skip_utf8_validation:expr) => match ($k:expr, $v:expr) {
             $(($key_arrow:pat, $value_arrow:pat) => ($key_type:ty, $value_type:ty),)+
         }
     ) => {
         match ($k, $v) {
             $(
                 ($key_arrow, $value_arrow) => {
-                    let mut reader = GenericRecordReader::new($column_desc, $batch_size);
+                    let mut reader = GenericRecordReader::new($column_desc, $batch_size)
+                        .with_skip_utf8_validation($skip_utf8_validation);
                     if let Some(threshold) = $padding_threshold {
                         reader.set_padding_threshold(threshold);
                     }
@@ -84,6 +85,7 @@ pub fn make_byte_array_dictionary_reader(
     arrow_type: Option<ArrowType>,
     batch_size: usize,
     padding_threshold: Option<i16>,
+    skip_utf8_validation: bool,
 ) -> Result<Box<dyn ArrayReader>> {
     // Check if Arrow type is specified, else create it from Parquet type
     let data_type = match arrow_type {
@@ -96,7 +98,7 @@ pub fn make_byte_array_dictionary_reader(
     match &data_type {
         ArrowType::Dictionary(key_type, value_type) => {
             make_reader! {
-                (pages, column_desc, data_type, batch_size, padding_threshold) => match (key_type.as_ref(), value_type.as_ref()) {
+                (pages, column_desc, data_type, batch_size, padding_threshold, skip_utf8_validation) => match (key_type.as_ref(), value_type.as_ref()) {
                     (ArrowType::UInt8, ArrowType::Binary | ArrowType::Utf8 | ArrowType::Utf8View | ArrowType::BinaryView | ArrowType::FixedSizeBinary(_)) => (u8, i32),
                     (ArrowType::UInt8, ArrowType::LargeBinary | ArrowType::LargeUtf8) => (u8, i64),
                     (ArrowType::Int8, ArrowType::Binary | ArrowType::Utf8 | ArrowType::Utf8View | ArrowType::BinaryView | ArrowType::FixedSizeBinary(_)) => (i8, i32),
@@ -464,6 +466,10 @@ where
                 decoder.skip(num_values)
             }
         }
+    }
+
+    fn set_validate_utf8(&mut self, validate: bool) {
+        self.validate_utf8 = validate;
     }
 }
 

--- a/parquet/src/arrow/array_reader/byte_view_array.rs
+++ b/parquet/src/arrow/array_reader/byte_view_array.rs
@@ -47,6 +47,7 @@ pub fn make_byte_view_array_reader(
     arrow_type: Option<ArrowType>,
     batch_size: usize,
     padding_threshold: Option<i16>,
+    skip_utf8_validation: bool,
 ) -> Result<Box<dyn ArrayReader>> {
     // Check if Arrow type is specified, else create it from Parquet type
     let data_type = match arrow_type {
@@ -59,7 +60,9 @@ pub fn make_byte_view_array_reader(
 
     match data_type {
         ArrowType::BinaryView | ArrowType::Utf8View => {
-            let mut reader = GenericRecordReader::new(column_desc, batch_size);
+            let is_string = matches!(data_type, ArrowType::Utf8View);
+            let mut reader = GenericRecordReader::new(column_desc, batch_size)
+                .with_skip_utf8_validation(skip_utf8_validation && is_string);
             if let Some(threshold) = padding_threshold {
                 reader.set_padding_threshold(threshold);
             }
@@ -218,6 +221,10 @@ impl ColumnValueDecoder for ByteViewArrayColumnValueDecoder {
             .ok_or_else(|| general_err!("no decoder set"))?;
 
         decoder.skip(num_values, self.dict.as_ref())
+    }
+
+    fn set_validate_utf8(&mut self, validate: bool) {
+        self.validate_utf8 = validate;
     }
 }
 

--- a/parquet/src/arrow/arrow_reader/mod.rs
+++ b/parquet/src/arrow/arrow_reader/mod.rs
@@ -259,6 +259,8 @@ pub struct ArrowReaderBuilder<T> {
     pub(crate) metrics: ArrowReaderMetrics,
 
     pub(crate) max_predicate_cache_size: usize,
+
+    pub(crate) skip_utf8_validation: bool,
 }
 
 impl<T: Debug> Debug for ArrowReaderBuilder<T> {
@@ -299,7 +301,20 @@ impl<T> ArrowReaderBuilder<T> {
             offset: None,
             metrics: ArrowReaderMetrics::Disabled,
             max_predicate_cache_size: 100 * 1024 * 1024, // 100MB default cache size
+            skip_utf8_validation: true,
         }
+    }
+
+    /// Skip UTF-8 validation for string columns (defaults to `false`).
+    ///
+    /// See [`ArrowReaderOptions::with_skip_utf8_validation`] for details.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that all string columns contain valid UTF-8.
+    pub unsafe fn with_skip_utf8_validation(mut self, skip: bool) -> Self {
+        self.skip_utf8_validation = skip;
+        self
     }
 
     /// Returns a reference to the [`ParquetMetaData`] for this parquet file
@@ -587,6 +602,12 @@ impl<T> ArrowReaderBuilder<T> {
 pub struct ArrowReaderOptions {
     /// Should the reader strip any user defined metadata from the Arrow schema
     skip_arrow_metadata: bool,
+    /// Skip UTF-8 validation for string columns (default: false).
+    ///
+    /// When false (the default), columns annotated as UTF-8 in the Parquet schema are
+    /// validated on read. Set to true to skip validation for a performance gain when the
+    /// data is known to be valid.
+    pub(crate) skip_utf8_validation: bool,
     /// If provided, used as the schema hint when determining the Arrow schema,
     /// otherwise the schema hint is read from the [ARROW_SCHEMA_META_KEY]
     ///
@@ -620,6 +641,23 @@ impl ArrowReaderOptions {
     pub fn with_skip_arrow_metadata(self, skip_arrow_metadata: bool) -> Self {
         Self {
             skip_arrow_metadata,
+            ..self
+        }
+    }
+
+    /// Skip UTF-8 validation for string columns (defaults to `false`).
+    ///
+    /// When enabled, columns annotated as UTF-8 in the Parquet schema are read without
+    /// checking that the bytes are valid UTF-8. Useful when the data is known to be valid
+    /// and the validation overhead is measurable.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that all string columns in the file contain valid UTF-8.
+    /// Passing invalid UTF-8 to Arrow string arrays is undefined behavior.
+    pub unsafe fn with_skip_utf8_validation(self, skip_utf8_validation: bool) -> Self {
+        Self {
+            skip_utf8_validation,
             ..self
         }
     }
@@ -1208,8 +1246,12 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
     /// Use this method if you want to control the options for reading the
     /// [`ParquetMetaData`]
     pub fn try_new_with_options(reader: T, options: ArrowReaderOptions) -> Result<Self> {
-        let metadata = ArrowReaderMetadata::load(&reader, options)?;
-        Ok(Self::new_with_metadata(reader, metadata))
+        let skip = options.skip_utf8_validation;
+        ArrowReaderMetadata::load(&reader, options).map(|metadata| {
+            // Safety: the caller already upheld the contract when constructing
+            // ArrowReaderOptions::with_skip_utf8_validation (also unsafe).
+            unsafe { Self::new_with_metadata(reader, metadata).with_skip_utf8_validation(skip) }
+        })
     }
 
     /// Create a [`ParquetRecordBatchReaderBuilder`] from the provided [`ArrowReaderMetadata`]
@@ -1338,6 +1380,7 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
             metrics,
             // Not used for the sync reader, see https://github.com/apache/arrow-rs/issues/8000
             max_predicate_cache_size: _,
+            skip_utf8_validation,
         } = self;
 
         // Try to avoid allocate large buffer
@@ -1371,6 +1414,7 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
                 let array_reader = ArrayReaderBuilder::new(&reader, &metrics)
                     .with_batch_size(batch_size)
                     .with_parquet_metadata(&reader.metadata)
+                    .with_skip_utf8_validation(skip_utf8_validation)
                     .build_array_reader(fields.as_deref(), predicate.projection())?;
 
                 plan_builder = plan_builder.with_predicate(array_reader, predicate.as_mut())?;
@@ -1380,6 +1424,7 @@ impl<T: ChunkReader + 'static> ParquetRecordBatchReaderBuilder<T> {
         let array_reader = ArrayReaderBuilder::new(&reader, &metrics)
             .with_batch_size(batch_size)
             .with_parquet_metadata(&reader.metadata)
+            .with_skip_utf8_validation(skip_utf8_validation)
             .build_array_reader(fields.as_deref(), &projection)?;
 
         let read_plan = plan_builder

--- a/parquet/src/arrow/async_reader/mod.rs
+++ b/parquet/src/arrow/async_reader/mod.rs
@@ -693,6 +693,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
             offset,
             metrics,
             max_predicate_cache_size,
+            skip_utf8_validation,
         } = self;
 
         // Ensure schema of ParquetRecordBatchStream respects projection, and does
@@ -717,6 +718,7 @@ impl<T: AsyncFileReader + Send + 'static> ParquetRecordBatchStreamBuilder<T> {
             offset,
             metrics,
             max_predicate_cache_size,
+            skip_utf8_validation,
         }
         .build()?;
 

--- a/parquet/src/arrow/push_decoder/mod.rs
+++ b/parquet/src/arrow/push_decoder/mod.rs
@@ -318,6 +318,7 @@ impl ParquetPushDecoderBuilder {
             metrics,
             row_selection_policy,
             max_predicate_cache_size,
+            skip_utf8_validation,
         } = self;
 
         let has_predicates = filter
@@ -337,6 +338,7 @@ impl ParquetPushDecoderBuilder {
             max_predicate_cache_size,
             buffers,
             row_selection_policy,
+            skip_utf8_validation,
         );
 
         // Initialize the decoder with the configured options
@@ -379,6 +381,7 @@ fn builder_from_remaining(parts: RemainingRowGroupsParts) -> ParquetPushDecoderB
         metrics,
         row_selection_policy,
         buffers,
+        skip_utf8_validation,
     } = reader_builder;
 
     ArrowReaderBuilder {
@@ -395,6 +398,7 @@ fn builder_from_remaining(parts: RemainingRowGroupsParts) -> ParquetPushDecoderB
         offset,
         metrics,
         max_predicate_cache_size,
+        skip_utf8_validation,
     }
     // Carry the decoder's already-fetched bytes across the rebuild so the new
     // decoder does not re-request them.

--- a/parquet/src/arrow/push_decoder/reader_builder/mod.rs
+++ b/parquet/src/arrow/push_decoder/reader_builder/mod.rs
@@ -271,6 +271,9 @@ pub(crate) struct RowGroupReaderBuilder {
 
     /// The underlying data store
     buffers: PushBuffers,
+
+    /// Skip UTF-8 validation for string columns
+    skip_utf8_validation: bool,
 }
 
 /// The parts of a [`RowGroupReaderBuilder`] needed to rebuild it, recovered by
@@ -290,6 +293,7 @@ pub(crate) struct RowGroupReaderBuilderParts {
     /// Bytes already pushed into the decoder, carried across a rebuild so they
     /// are not re-requested.
     pub buffers: PushBuffers,
+    pub skip_utf8_validation: bool,
 }
 
 impl RowGroupReaderBuilder {
@@ -305,6 +309,7 @@ impl RowGroupReaderBuilder {
         max_predicate_cache_size: usize,
         buffers: PushBuffers,
         row_selection_policy: RowSelectionPolicy,
+        skip_utf8_validation: bool,
     ) -> Self {
         Self {
             batch_size,
@@ -317,6 +322,7 @@ impl RowGroupReaderBuilder {
             row_selection_policy,
             state: Some(RowGroupDecoderState::Finished),
             buffers,
+            skip_utf8_validation,
         }
     }
 
@@ -337,6 +343,7 @@ impl RowGroupReaderBuilder {
             row_selection_policy,
             state: _,
             buffers,
+            skip_utf8_validation,
         } = self;
         RowGroupReaderBuilderParts {
             batch_size,
@@ -347,6 +354,7 @@ impl RowGroupReaderBuilder {
             metrics,
             row_selection_policy,
             buffers,
+            skip_utf8_validation,
         }
     }
 
@@ -617,6 +625,7 @@ impl RowGroupReaderBuilder {
                     .with_batch_size(self.batch_size)
                     .with_cache_options(Some(&cache_options))
                     .with_parquet_metadata(&self.metadata)
+                    .with_skip_utf8_validation(self.skip_utf8_validation)
                     .build_array_reader(self.fields.as_deref(), predicate.projection())?;
 
                 // Auto resolution and loaded ranges are projection-specific, so restore the
@@ -791,7 +800,8 @@ impl RowGroupReaderBuilder {
                 // if we have any cached results, connect them up
                 let array_reader_builder = ArrayReaderBuilder::new(&row_group, &self.metrics)
                     .with_batch_size(self.batch_size)
-                    .with_parquet_metadata(&self.metadata);
+                    .with_parquet_metadata(&self.metadata)
+                    .with_skip_utf8_validation(self.skip_utf8_validation);
                 let array_reader = if let Some(cache_info) = cache_info.as_ref() {
                     let cache_options: CacheOptions = cache_info.builder().consumer();
                     array_reader_builder

--- a/parquet/src/arrow/record_reader/mod.rs
+++ b/parquet/src/arrow/record_reader/mod.rs
@@ -85,6 +85,8 @@ pub struct GenericRecordReader<V, CV> {
     /// as the valid_mask for `pad_nulls` (via `as_slice()`) and as the null
     /// bitmap consumed by the leaf reader (via `consume_compact_bitmap`).
     compact_bitmap: Option<BooleanBufferBuilder>,
+    /// When true, overrides the decoder's default UTF-8 validation to disabled.
+    skip_utf8_validation: bool,
 }
 
 impl<V, CV> GenericRecordReader<V, CV>
@@ -114,13 +116,25 @@ where
             values_written: 0,
             padding_threshold: None,
             compact_bitmap: None,
+            skip_utf8_validation: false,
         }
+    }
+
+    /// Disable UTF-8 validation for string columns.
+    ///
+    /// When set, overrides the decoder's schema-derived `validate_utf8` flag to `false`.
+    pub fn with_skip_utf8_validation(mut self, skip: bool) -> Self {
+        self.skip_utf8_validation = skip;
+        self
     }
 
     /// Set the current page reader.
     pub fn set_page_reader(&mut self, page_reader: Box<dyn PageReader>) -> Result<()> {
         let descr = &self.column_desc;
-        let values_decoder = CV::new(descr);
+        let mut values_decoder = CV::new(descr);
+        if self.skip_utf8_validation {
+            values_decoder.set_validate_utf8(false);
+        }
 
         let def_level_decoder = (descr.max_def_level() != 0).then(|| {
             DefinitionLevelBufferDecoder::new(descr.max_def_level(), packed_null_mask(descr))

--- a/parquet/src/column/reader/decoder.rs
+++ b/parquet/src/column/reader/decoder.rs
@@ -132,6 +132,11 @@ pub trait ColumnValueDecoder {
     ///
     /// Returns the number of values skipped
     fn skip_values(&mut self, num_values: usize) -> Result<usize>;
+
+    /// Override whether UTF-8 validation is performed.
+    ///
+    /// Only meaningful for byte-array decoders; the default implementation is a no-op.
+    fn set_validate_utf8(&mut self, _validate: bool) {}
 }
 
 /// Bucket-based storage for decoder instances keyed by `Encoding`.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #6701.

# Rationale for this change

see #6701. TLDR; users should not pay the performance cost of validating utf8 strings if they know their data is already valid.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Adds a `skip_utf8_validation` option to `ArrowReaderOptions` that allows callers to bypass the per-read UTF-8 validity check on string columns.


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?
n/a

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?

Yes. `ArrowReaderOptions::with_skip_utf8_validation` is a new public API. It is marked `unsafe fn` so callers must explicitly acknowledge the invariant — that all string columns contain valid UTF-8 — at the call site.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
