### PR TITLE
Fix interleave on zero-width FixedSizeListArray

### DIFF
--- a/arrow-select/src/interleave.rs
+++ b/arrow-select/src/interleave.rs
@@ -543,7 +543,13 @@ fn interleave_fixed_size_list(
         }
     };
 
-    let array = FixedSizeListArray::new(field.clone(), size, interleaved_values, interleaved.nulls);
+    let array = FixedSizeListArray::try_new_with_length(
+        field.clone(),
+        size,
+        interleaved_values,
+        interleaved.nulls,
+        indices.len(),
+    )?;
     Ok(Arc::new(array))
 }
 
@@ -2186,6 +2192,23 @@ mod tests {
         let values = result.values().as_primitive::<Int32Type>();
         // [[5,6], [7,8], [1,2], [9,10], [3,4]]
         assert_eq!(values.values(), &[5, 6, 7, 8, 1, 2, 9, 10, 3, 4]);
+    }
+
+    #[test]
+    fn test_interleave_zero_sized_fixed_size_list() {
+        let input = FixedSizeListArray::try_new_with_length(
+            Field::new_list_field(DataType::Int32, true).into(),
+            0,
+            Arc::new(Int32Array::new_null(0)),
+            None,
+            3,
+        )
+        .unwrap();
+
+        let indices = [(0, 2), (0, 0)];
+        let result = interleave(&[&input], &indices).unwrap();
+
+        assert_eq!(result.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Broke in #10046. Same fix as #10915
# Which issue does this PR close?
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax.
-->

- Closes #11025.

# Rationale for this change
(see issue).
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are these changes tested?

Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

If this PR claims a performance improvement, please include evidence such as benchmark results.
-->

# Are there any user-facing changes?
Yes, this fixes interleave semantics to the semantics in v58.3,  which I had before upgrading today.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.

If there are any breaking changes to public APIs, please call them out.
-->
