### PR TITLE
feat(variant): allow creating VariantArray from Option items convertible to Variant

### DIFF
--- a/parquet-variant-compute/src/variant_array.rs
+++ b/parquet-variant-compute/src/variant_array.rs
@@ -614,9 +614,9 @@ impl From<VariantArray> for ArrayRef {
     }
 }
 
-impl<'m, 'v> FromIterator<Option<Variant<'m, 'v>>> for VariantArray {
-    fn from_iter<T: IntoIterator<Item = Option<Variant<'m, 'v>>>>(iter: T) -> Self {
-        let iter = iter.into_iter();
+impl<'m, 'v, V: Into<Variant<'m, 'v>>> FromIterator<Option<V>> for VariantArray {
+    fn from_iter<T: IntoIterator<Item = Option<V>>>(iter: T) -> Self {
+        let iter = iter.into_iter().map(|value| value.map(Into::into));
 
         let mut b = VariantArrayBuilder::new(iter.size_hint().0);
         b.extend(iter);
@@ -1837,6 +1837,56 @@ mod test {
         assert_eq!(variant_array.value(2), Variant::BooleanFalse);
 
         assert!(variant_array.is_null(3));
+    }
+
+    #[test]
+    fn test_from_option_into_variants_into_variant_array() {
+        // Items that convert cleanly to `Variant` can be collected directly,
+        // without wrapping them in `Some(Variant::from(..))` first
+        let v = vec![Some(42_i64), None, Some(-1_i64)];
+
+        let variant_array = VariantArray::from_iter(v);
+
+        assert_eq!(variant_array.len(), 3);
+
+        assert!(!variant_array.is_null(0));
+        assert_eq!(variant_array.value(0), Variant::Int64(42));
+
+        assert!(variant_array.is_null(1));
+
+        assert!(!variant_array.is_null(2));
+        assert_eq!(variant_array.value(2), Variant::Int64(-1));
+    }
+
+    #[test]
+    fn test_from_option_str_into_variant_array() {
+        let v = vec![
+            Some("hello"),
+            None,
+            Some(
+                "hello world this is much longer than the maximum short string length of sixty three bytes",
+            ),
+        ];
+
+        let variant_array: VariantArray = v.into_iter().collect();
+
+        assert_eq!(variant_array.len(), 3);
+
+        assert!(!variant_array.is_null(0));
+        assert_eq!(
+            variant_array.value(0),
+            Variant::ShortString(ShortString::try_new("hello").unwrap())
+        );
+
+        assert!(variant_array.is_null(1));
+
+        assert!(!variant_array.is_null(2));
+        assert_eq!(
+            variant_array.value(2),
+            Variant::String(
+                "hello world this is much longer than the maximum short string length of sixty three bytes"
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Rationale

Closes #8628.

Previously `VariantArray` could be collected only from `Option<Variant>` items:

```rust
let arr: VariantArray = values.iter().map(|v| Some(Variant::from(*v))).collect();
```

With this change, any type that converts cleanly into `Variant` can be collected directly:

```rust
let arr: VariantArray = vec![Some(1_i64), None, Some(42_i64)].into_iter().collect();

let arr: VariantArray = vec![Some("hello"), Some("a very long string exceeding the short string limit")].into_iter().collect();
```

This follows the suggestion made in https://github.com/apache/arrow-rs/pull/8625#discussion_r2432827098.

## Changes

- `parquet-variant-compute/src/variant_array.rs`: generalize `FromIterator<Option<Variant<'m, 'v>>>` to `impl<'m, 'v, V: Into<Variant<'m, 'v>>> FromIterator<Option<V>>`, converting each item through `Into::into`. Existing code that collects `Option<Variant>` items keeps working (identity `Into`).
- Added regression tests: `i64` items with nulls, `&str` items covering both short-string (ShortString) and long-string (String) storage.

## Verification

- `cargo test -p parquet-variant-compute --lib` — 366 tests passed (364 existing + 2 new), including the new `test_from_option_into_variants_into_variant_array` and `test_from_option_str_into_variant_array`.
- `cargo clippy -p parquet-variant-compute --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

Note: local verification used the `x86_64-pc-windows-gnu` target; upstream CI covers the full matrix.

## AI disclosure

Per the Arrow project's AI-generated submissions guidance: this change was implemented with the assistance of an AI coding agent. The author reviewed the final diff, verified it compiles and passes tests/clippy/fmt locally, and takes full ownership of the change.

The ASF ICLA may need to be on file before merge (asf-clabot will report the status).