### PR TITLE
Document platform endianness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ arrow-rs and parquet are built and tested with stable Rust, and will keep a roll
 
 Note: If a Rust hotfix is released for the current MSRV, the MSRV will be updated to the specific minor version that includes all applicable hotfixes preceding other policies.
 
+### Platform Support
+
+Only little-endian platforms are officially supported and tested in CI.
+Big-endian platforms are not tested in CI and may not work correctly.
+Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+but compatibility is not guaranteed.
+
 ### Guidelines for `panic` vs `Result`
 
 In general, use panics for bad states that are unreachable, unrecoverable or harmful.

--- a/arrow-arith/src/lib.rs
+++ b/arrow-arith/src/lib.rs
@@ -16,6 +16,13 @@
 // under the License.
 
 //! Arrow arithmetic and aggregation kernels
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-array/src/lib.rs
+++ b/arrow-array/src/lib.rs
@@ -220,6 +220,13 @@
 //! [`csv`]: https://docs.rs/arrow/latest/arrow/csv/index.html
 //! [DataFusion]: https://github.com/apache/arrow-datafusion
 //! [RecordBatchStream]: https://docs.rs/datafusion/latest/datafusion/execution/trait.RecordBatchStream.html
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-avro/src/lib.rs
+++ b/arrow-avro/src/lib.rs
@@ -251,6 +251,13 @@
 //!
 //! [Apache Arrow]: https://arrow.apache.org/
 //! [Apache Avro]: https://avro.apache.org/
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-buffer/src/lib.rs
+++ b/arrow-buffer/src/lib.rs
@@ -31,6 +31,13 @@
 //! - [`ScalarBuffer<T>`][]: Typed buffer for primitive types (e.g., `i32`, `f64`)
 //! - [`OffsetBuffer<O>`][]: Offsets used in variable-length types (e.g., strings, lists)
 //! - [`RunEndBuffer<E>`][]: Run-ends used in run-encoded encoded data
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-cast/src/lib.rs
+++ b/arrow-cast/src/lib.rs
@@ -16,6 +16,13 @@
 // under the License.
 
 //! Functions for converting from one data type to another in [Apache Arrow](https://docs.rs/arrow)
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-cmp/src/lib.rs
+++ b/arrow-cmp/src/lib.rs
@@ -28,6 +28,13 @@
 //! dependency (`arrow-ord` already depends on `arrow-select`) or force every
 //! downstream user of `arrow-array` to compile the comparator machinery whether
 //! they need it or not.
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![deny(rustdoc::broken_intra_doc_links)]
 #![warn(missing_docs)]

--- a/arrow-csv/src/lib.rs
+++ b/arrow-csv/src/lib.rs
@@ -18,6 +18,13 @@
 //! Transfer data between the [Apache Arrow] memory format and CSV (comma-separated values).
 //!
 //! [Apache Arrow]: https://arrow.apache.org/
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-data/src/lib.rs
+++ b/arrow-data/src/lib.rs
@@ -18,6 +18,13 @@
 //! Low-level array data abstractions for [Apache Arrow Rust](https://docs.rs/arrow)
 //!
 //! For a higher-level, strongly-typed interface see [arrow_array](https://docs.rs/arrow_array)
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-flight/src/lib.rs
+++ b/arrow-flight/src/lib.rs
@@ -36,6 +36,13 @@
 //!    `flight-sql` feature of this crate to be activated.
 //!
 //! [Flight SQL]: https://arrow.apache.org/docs/format/FlightSql.html
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-integration-test/src/lib.rs
+++ b/arrow-integration-test/src/lib.rs
@@ -28,6 +28,13 @@
 //! this context](https://github.com/apache/arrow-rs/issues/8684#issuecomment-3433193158).
 //!
 //! </div>
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-ipc/src/lib.rs
+++ b/arrow-ipc/src/lib.rs
@@ -37,6 +37,13 @@
 //! [IPC File Format]: https://arrow.apache.org/docs/format/Columnar.html#ipc-file-format
 //! [FileReader]: reader::FileReader
 //! [FileWriter]: writer::FileWriter
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-json/src/lib.rs
+++ b/arrow-json/src/lib.rs
@@ -79,6 +79,13 @@
 //! [hexadecimal]: https://en.wikipedia.org/wiki/Hexadecimal
 //! [`Base16` encoding]: https://en.wikipedia.org/wiki/Base16#Base16
 //! [`Base64`]: https://en.wikipedia.org/wiki/Base64
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-ord/src/lib.rs
+++ b/arrow-ord/src/lib.rs
@@ -42,6 +42,13 @@
 //! assert_eq!(col1.values(), &[2, 1, 4, 3]);
 //! ```
 //!
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-pyarrow/src/lib.rs
+++ b/arrow-pyarrow/src/lib.rs
@@ -68,6 +68,13 @@
 //!
 //! Input hints name the pyarrow classes only, and are therefore narrower than what is accepted: the
 //! PyCapsule interface is duck-typed and has no canonical Python type to name.
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 use std::convert::{From, TryFrom};
 use std::ffi::CStr;

--- a/arrow-row/src/lib.rs
+++ b/arrow-row/src/lib.rs
@@ -152,6 +152,13 @@
 //! [compared]: PartialOrd
 //! [compare]: PartialOrd
 //! [the issue]: https://github.com/apache/arrow-rs/issues/4811
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-schema/src/lib.rs
+++ b/arrow-schema/src/lib.rs
@@ -16,6 +16,13 @@
 // under the License.
 
 //! Arrow logical types
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-select/src/lib.rs
+++ b/arrow-select/src/lib.rs
@@ -16,6 +16,13 @@
 // under the License.
 
 //! Arrow selection kernels
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow-string/src/lib.rs
+++ b/arrow-string/src/lib.rs
@@ -16,6 +16,13 @@
 // under the License.
 
 //! Arrow string kernels
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://arrow.apache.org/img/arrow-logo_chevrons_black-txt_white-bg.svg",

--- a/arrow/src/lib.rs
+++ b/arrow/src/lib.rs
@@ -21,6 +21,13 @@
 //! Please see the [arrow crates.io](https://crates.io/crates/arrow)
 //! page for feature flags and tips to improve performance.
 //!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
+//!
 //! # Columnar Format
 //!
 //! The [`array`] module provides statically typed implementations of all the array types as defined

--- a/parquet-geospatial/src/lib.rs
+++ b/parquet-geospatial/src/lib.rs
@@ -19,6 +19,13 @@
 //!
 //! [Geometry and Geography Encoding]: https://github.com/apache/parquet-format/blob/master/Geospatial.md
 //! [Apache Parquet]: https://parquet.apache.org/
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 pub mod bounding;
 pub mod interval;

--- a/parquet-variant-compute/src/lib.rs
+++ b/parquet-variant-compute/src/lib.rs
@@ -38,6 +38,13 @@
 //! [Apache Parquet]: https://parquet.apache.org/
 //! [`VariantPath`]: parquet_variant::VariantPath
 //! [Variant issue]: https://github.com/apache/arrow-rs/issues/6736
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 mod arrow_to_variant;
 mod cast_to_variant;

--- a/parquet-variant-json/src/lib.rs
+++ b/parquet-variant-json/src/lib.rs
@@ -30,6 +30,13 @@
 //! If you are interested in helping, you can find more information on the GitHub [Variant issue]
 //!
 //! [Variant issue]: https://github.com/apache/arrow-rs/issues/6736
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 mod from_json;
 mod to_json;

--- a/parquet-variant/src/lib.rs
+++ b/parquet-variant/src/lib.rs
@@ -30,6 +30,13 @@
 //! If you are interested in helping, you can find more information on the GitHub [Variant issue]
 //!
 //! [Variant issue]: https://github.com/apache/arrow-rs/issues/6736
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 mod builder;
 mod decoder;

--- a/parquet/src/lib.rs
+++ b/parquet/src/lib.rs
@@ -137,6 +137,13 @@
 //! [Dremel]: https://research.google/pubs/pub36632/
 //! [Logical Types]: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
 //! [object_store]: https://docs.rs/object_store/latest/object_store/
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg",

--- a/parquet_derive/src/lib.rs
+++ b/parquet_derive/src/lib.rs
@@ -17,6 +17,13 @@
 
 //! This crate provides a procedural macro to derive
 //! implementations of a RecordWriter and RecordReader
+//!
+//! # Platform Support
+//!
+//! Only little-endian platforms are officially supported and tested in CI.
+//! Big-endian platforms are not tested in CI and may not work correctly.
+//! Fixes for big-endian platforms are welcome and handled on a best-effort basis,
+//! but compatibility is not guaranteed.
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/apache/parquet-format/25f05e73d8cd7f5c83532ce51cb4f4de8ba5f2a2/logo/parquet-logos_1.svg",


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6917.

# Rationale for this change

The endianness support and testing expectations discussed in #6917 are not currently stated in the repository's user documentation. Users should be able to find these limitations when choosing a crate.

# What changes are included in this PR?

Add a Platform Support section to the root README and the API landing page of every published library crate. It states that only little-endian platforms are officially supported and tested in CI, while big-endian platforms are untested and may not work correctly. Big-endian fixes are welcome on a best-effort basis, with no compatibility guarantee.

Each crate includes the full paragraph because it can be consumed independently.

# Are these changes tested?

Documentation only. `cargo fmt --all -- --check` and `git diff --check` pass. Verified that the root README and all 25 published library crates contain identical policy wording.

# Are there any user-facing changes?

Documents the platform support and testing expectations. No API or runtime behavior changes.
