### PR TITLE
[WIP][Parquet] Add FastLanes packing and UTL delta to PFOR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrow"
 version = "59.2.0"
 dependencies = [
@@ -1023,6 +1029,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_for"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "988d3bd6bf67b6d7ae2b519c55296fa57411c27c312575e47b2975f8d1d8590b"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1271,19 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastlanes"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cb755aee48ff7b0907995d2949c68c8c17900970076dff6a808e18e592d71"
+dependencies = [
+ "arrayref",
+ "const_for",
+ "num-traits",
+ "paste",
+ "seq-macro",
 ]
 
 [[package]]
@@ -2425,6 +2450,7 @@ dependencies = [
  "clap",
  "crc32fast",
  "criterion",
+ "fastlanes",
  "flate2",
  "futures",
  "half",
@@ -2528,6 +2554,12 @@ dependencies = [
  "parquet_derive",
  "uuid",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -280,6 +280,11 @@ required-features = ["experimental", "default"]
 harness = false
 
 [[bench]]
+name = "pfor"
+required-features = ["experimental", "default"]
+harness = false
+
+[[bench]]
 name = "bit_packing"
 required-features = ["experimental", "default"]
 harness = false

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -76,6 +76,8 @@ simdutf8 = { workspace = true , optional = true }
 ring = { version = "0.17", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
+# Wire-format oracle for the byte-oriented kernels, not used by the codec.
+fastlanes = "=0.5.0"
 base64 = { version = "0.23", default-features = false, features = ["std"] }
 criterion = { workspace = true, default-features = false, features = ["async_futures"]  }
 snap = { version = "1.0", default-features = false }

--- a/parquet/benches/pfor.rs
+++ b/parquet/benches/pfor.rs
@@ -1,0 +1,499 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! PFOR against DELTA_BINARY_PACKED on encode speed, decode speed and size.
+//!
+//! The columns are the ones the C++ implementation is benchmarked on: integer
+//! columns from ClickBench, TPC-H, TPC-DS and the NYC taxi trip data, plus four
+//! sorted or near-sorted shapes that separate the delta schemes from each other.
+//! The distributions are the same, and each column keeps the seed it has there,
+//! but the generators draw from a different engine, so the values are not
+//! identical to the C++ ones -- only the shape of each column is.
+//!
+//! Run with `cargo bench -p parquet --bench pfor`. The byte counts and ratios
+//! are printed once, before the timings.
+
+use criterion::*;
+use parquet::basic::{Encoding, Type as ParquetType};
+use parquet::data_type::{DataType, Int32Type, Int64Type};
+use parquet::decoding::{Decoder, get_decoder};
+use parquet::encoding::get_encoder;
+use parquet::schema::types::{ColumnDescPtr, ColumnDescriptor, ColumnPath, Type};
+use rand::prelude::*;
+use std::sync::Arc;
+
+/// The element count the C++ comparison benchmark uses, so the two sets of
+/// numbers describe the same amount of work per iteration.
+const NUM_VALUES: usize = 102_400;
+
+/// The encodings under comparison. PFOR first, so it is the baseline column in
+/// the printed table.
+const ENCODINGS: [Encoding; 2] = [Encoding::PFOR, Encoding::DELTA_BINARY_PACKED];
+
+// ============================================================================
+// Draws
+//
+// Only three shapes of draw are needed, and writing them out keeps the bench
+// free of a distribution dependency the crate does not otherwise have.
+// ============================================================================
+
+struct Draw(StdRng);
+
+impl Draw {
+    fn new(seed: u64) -> Self {
+        Self(StdRng::seed_from_u64(seed))
+    }
+
+    /// Uniform over the inclusive range, in i64 so a full-width i32 range and a
+    /// negative low bound both work.
+    fn uniform(&mut self, low: i64, high: i64) -> i64 {
+        low + (self.0.random::<u64>() % ((high - low + 1) as u64)) as i64
+    }
+
+    fn unit(&mut self) -> f64 {
+        // 53 bits, the mantissa, so the value is uniform in [0, 1).
+        (self.0.random::<u64>() >> 11) as f64 / (1u64 << 53) as f64
+    }
+
+    /// Exponential with the given mean, by inverting the CDF.
+    fn exponential(&mut self, mean: f64) -> f64 {
+        -mean * (1.0 - self.unit()).ln()
+    }
+
+    /// A power of a uniform draw, which is how the C++ benchmark approximates a
+    /// Zipf-like distribution over a fixed number of values.
+    fn skewed(&mut self, exponent: f64, cardinality: i64) -> i64 {
+        (self.unit().powf(exponent) * cardinality as f64) as i64 + 1
+    }
+}
+
+fn fill(n: usize, seed: u64, mut f: impl FnMut(&mut Draw) -> i64) -> Vec<i32> {
+    let mut draw = Draw::new(seed);
+    (0..n).map(|_| f(&mut draw) as i32).collect()
+}
+
+// ============================================================================
+// ClickBench columns
+// ============================================================================
+
+fn client_ip(n: usize) -> Vec<i32> {
+    fill(n, 101, |d| d.uniform(0x0A00_0000, 0xDFFF_FFFF))
+}
+
+fn url_region_id(n: usize) -> Vec<i32> {
+    fill(n, 102, |d| d.skewed(2.0, 1000))
+}
+
+/// A counter that advances by one to four. Sorted, with small steps.
+fn counter_id(n: usize) -> Vec<i32> {
+    let mut draw = Draw::new(103);
+    let mut counter = 100_000i64;
+    (0..n)
+        .map(|_| {
+            counter += 1 + draw.uniform(0, 3);
+            counter as i32
+        })
+        .collect()
+}
+
+fn event_date(n: usize) -> Vec<i32> {
+    const DATES: [i64; 5] = [19691, 19692, 19693, 19694, 19695];
+    fill(n, 104, |d| DATES[d.uniform(0, 4) as usize])
+}
+
+fn event_time(n: usize) -> Vec<i32> {
+    fill(n, 105, |d| 1_704_067_200 + d.uniform(0, 86_399))
+}
+
+fn good_event(n: usize) -> Vec<i32> {
+    fill(n, 106, |d| i64::from(d.uniform(0, 99) < 95))
+}
+
+fn hid(n: usize) -> Vec<i32> {
+    fill(n, 107, |d| d.uniform(i32::MIN as i64, i32::MAX as i64))
+}
+
+fn hit_color(n: usize) -> Vec<i32> {
+    fill(n, 108, |d| d.uniform(1, 5))
+}
+
+fn ip_network_id(n: usize) -> Vec<i32> {
+    fill(n, 109, |d| d.uniform(1, 10_000))
+}
+
+fn java_enable(n: usize) -> Vec<i32> {
+    fill(n, 110, |d| i64::from(d.uniform(0, 99) < 85))
+}
+
+fn os(n: usize) -> Vec<i32> {
+    fill(n, 111, |d| d.uniform(1, 20))
+}
+
+fn resolution(n: usize) -> Vec<i32> {
+    const RESOLUTIONS: [i64; 14] = [
+        360, 480, 600, 720, 768, 800, 900, 1024, 1050, 1080, 1200, 1440, 1600, 2160,
+    ];
+    fill(n, 112, |d| RESOLUTIONS[d.uniform(0, 13) as usize])
+}
+
+fn traffic_source_id(n: usize) -> Vec<i32> {
+    fill(n, 113, |d| d.uniform(0, 10))
+}
+
+fn user_agent(n: usize) -> Vec<i32> {
+    fill(n, 114, |d| d.skewed(1.5, 100))
+}
+
+// ============================================================================
+// TPC-DS store_sales and date_dim columns
+// ============================================================================
+
+fn tpcds_sold_date_sk(n: usize) -> Vec<i32> {
+    fill(n, 201, |d| 2_450_815 + d.uniform(0, 1820))
+}
+
+fn tpcds_store_sk(n: usize) -> Vec<i32> {
+    fill(n, 202, |d| d.uniform(1, 1000))
+}
+
+/// A skewed surrogate key: most rows land on a low key, a few reach the cap.
+fn tpcds_item_sk(n: usize) -> Vec<i32> {
+    fill(n, 203, |d| {
+        (d.exponential(1.0 / 0.00005) as i64 + 1).min(100_000)
+    })
+}
+
+fn tpcds_quantity(n: usize) -> Vec<i32> {
+    fill(n, 204, |d| {
+        if d.uniform(0, 99) < 90 {
+            d.uniform(1, 10)
+        } else {
+            d.uniform(11, 100)
+        }
+    })
+}
+
+fn tpcds_customer_sk(n: usize) -> Vec<i32> {
+    fill(n, 311, |d| d.uniform(1, 2_000_000))
+}
+
+/// Price in cents, floored at a dollar and with a long tail, so the top of the
+/// distribution is what a fixed bit width has to treat as an exception.
+fn tpcds_ext_sales_price(n: usize) -> Vec<i32> {
+    fill(n, 312, |d| {
+        (100 + d.exponential(5000.0) as i64).min(2_000_000)
+    })
+}
+
+/// Usually a small profit, sometimes a loss, so the frame of reference is
+/// negative rather than zero.
+fn tpcds_net_profit(n: usize) -> Vec<i32> {
+    fill(n, 313, |d| d.uniform(-10_000, 300_000))
+}
+
+fn tpcds_d_year(n: usize) -> Vec<i32> {
+    fill(n, 314, |d| d.uniform(1998, 2003))
+}
+
+// ============================================================================
+// TPC-H lineitem columns
+// ============================================================================
+
+fn tpch_l_quantity(n: usize) -> Vec<i32> {
+    fill(n, 301, |d| d.uniform(1, 50))
+}
+
+fn tpch_l_extended_price(n: usize) -> Vec<i32> {
+    fill(n, 302, |d| d.uniform(1, 50) * d.uniform(90_000, 209_900))
+}
+
+/// Includes zero, because no discount is a real value.
+fn tpch_l_discount(n: usize) -> Vec<i32> {
+    fill(n, 303, |d| d.uniform(0, 10))
+}
+
+fn tpch_l_ship_date(n: usize) -> Vec<i32> {
+    fill(n, 304, |d| 8036 + d.uniform(0, 2557))
+}
+
+// ============================================================================
+// NYC taxi trip columns
+// ============================================================================
+
+fn taxi_pickup_unix_time(n: usize) -> Vec<i32> {
+    fill(n, 321, |d| 1_420_070_400 + d.uniform(0, 2_678_400))
+}
+
+fn taxi_trip_distance_x100(n: usize) -> Vec<i32> {
+    fill(n, 322, |d| (10 + d.exponential(180.0) as i64).min(10_000))
+}
+
+fn taxi_fare_cents(n: usize) -> Vec<i32> {
+    fill(n, 323, |d| (250 + d.exponential(1000.0) as i64).min(15_000))
+}
+
+// ============================================================================
+// Sorted and near-sorted columns
+//
+// Every generator above draws independently around a base, which is the case
+// delta encoding is not for: the difference of two independent draws spans the
+// whole range whichever two are picked. Separating the delta schemes needs
+// columns whose value depends on the one before it.
+// ============================================================================
+
+/// Event timestamps arriving a few seconds apart, as in a table clustered on
+/// time.
+fn sorted_unix_time(n: usize) -> Vec<i32> {
+    let mut draw = Draw::new(401);
+    let mut t = 1_700_000_000i64;
+    (0..n)
+        .map(|_| {
+            t += draw.uniform(0, 7);
+            t as i32
+        })
+        .collect()
+}
+
+/// A sorted key with runs of duplicates, as a join key or a dictionary-sorted
+/// column produces: most steps are zero, some are one.
+fn sorted_key_dups(n: usize) -> Vec<i32> {
+    let mut draw = Draw::new(402);
+    let mut k = 5_000_000i64;
+    (0..n)
+        .map(|_| {
+            k += draw.uniform(0, 1);
+            k as i32
+        })
+        .collect()
+}
+
+/// An exact +1 row id, the best case for any delta scheme.
+fn monotone_row_id(n: usize) -> Vec<i32> {
+    (1..=n as i32).collect()
+}
+
+/// Sorted except that one row in fifty arrives late, so a few differences are
+/// large and negative. Tests whether one bit width per vector survives an
+/// outlier.
+fn near_sorted_unix_time(n: usize) -> Vec<i32> {
+    let mut values = sorted_unix_time(n);
+    let mut draw = Draw::new(403);
+    for value in &mut values {
+        if draw.uniform(0, 49) == 0 {
+            *value -= draw.uniform(1, 3600) as i32;
+        }
+    }
+    values
+}
+
+/// A column of the corpus: its name, and the generator that produces it.
+type Column = (&'static str, fn(usize) -> Vec<i32>);
+
+const COLUMNS: &[Column] = &[
+    // ClickBench
+    ("ClientIP", client_ip),
+    ("UrlRegionID", url_region_id),
+    ("CounterID", counter_id),
+    ("EventDate", event_date),
+    ("EventTime", event_time),
+    ("GoodEvent", good_event),
+    ("HID", hid),
+    ("HitColor", hit_color),
+    ("IPNetworkID", ip_network_id),
+    ("JavaEnable", java_enable),
+    ("OS", os),
+    ("Resolution", resolution),
+    ("TrafficSourceID", traffic_source_id),
+    ("UserAgent", user_agent),
+    // TPC-DS
+    ("TpcdsSoldDateSk", tpcds_sold_date_sk),
+    ("TpcdsStoreSk", tpcds_store_sk),
+    ("TpcdsItemSk", tpcds_item_sk),
+    ("TpcdsQuantity", tpcds_quantity),
+    ("TpcdsCustomerSk", tpcds_customer_sk),
+    ("TpcdsExtSalesPrice", tpcds_ext_sales_price),
+    ("TpcdsNetProfit", tpcds_net_profit),
+    ("TpcdsDYear", tpcds_d_year),
+    // TPC-H
+    ("TpchLQuantity", tpch_l_quantity),
+    ("TpchLExtendedPrice", tpch_l_extended_price),
+    ("TpchLDiscount", tpch_l_discount),
+    ("TpchLShipDate", tpch_l_ship_date),
+    // NYC taxi
+    ("TaxiPickupUnixTime", taxi_pickup_unix_time),
+    ("TaxiTripDistanceX100", taxi_trip_distance_x100),
+    ("TaxiFareCents", taxi_fare_cents),
+    // Sorted and near-sorted
+    ("SortedUnixTime", sorted_unix_time),
+    ("SortedKeyDups", sorted_key_dups),
+    ("MonotoneRowId", monotone_row_id),
+    ("NearSortedUnixTime", near_sorted_unix_time),
+];
+
+/// The i64 leg. The residuals of a widened i32 column still fit in 32 bits, so
+/// each of these scales the column up until it needs the wide paths: the widths
+/// the cost model chooses, the wide frame of reference, and the eight-byte
+/// exception values.
+const WIDE_COLUMNS: &[Column] = &[
+    ("HID", hid),
+    ("TpcdsCustomerSk", tpcds_customer_sk),
+    ("TaxiPickupUnixTime", taxi_pickup_unix_time),
+    ("SortedUnixTime", sorted_unix_time),
+];
+
+fn widen(values: &[i32]) -> Vec<i64> {
+    // A nanosecond-scale multiplier and a base above 2^32: the differences stay
+    // proportional to the original column's, but neither the values nor the
+    // frame fit in 32 bits.
+    values
+        .iter()
+        .map(|&v| (1i64 << 40) | (i64::from(v) * 1_000_003))
+        .collect()
+}
+
+// ============================================================================
+// Harness
+// ============================================================================
+
+fn descriptor(physical_type: ParquetType) -> ColumnDescPtr {
+    ColumnDescPtr::new(ColumnDescriptor::new(
+        Arc::new(
+            Type::primitive_type_builder("col", physical_type)
+                .build()
+                .unwrap(),
+        ),
+        0,
+        0,
+        ColumnPath::new(vec![]),
+    ))
+}
+
+fn encode<T: DataType>(values: &[T::T], encoding: Encoding, descr: &ColumnDescPtr) -> bytes::Bytes {
+    let mut encoder = get_encoder::<T>(encoding, descr).unwrap();
+    encoder.put(values).unwrap();
+    encoder.flush_buffer().unwrap()
+}
+
+fn decode<T: DataType>(
+    encoded: bytes::Bytes,
+    out: &mut [T::T],
+    encoding: Encoding,
+    descr: &ColumnDescPtr,
+) {
+    let mut decoder: Box<dyn Decoder<T>> = get_decoder(descr.clone(), encoding).unwrap();
+    decoder.set_data(encoded, out.len()).unwrap();
+    let mut done = 0;
+    while done < out.len() {
+        let read = decoder.get(&mut out[done..]).unwrap();
+        assert_ne!(read, 0, "decoder stalled");
+        done += read;
+    }
+}
+
+/// Print the size of every column under both encodings, once, before any timing
+/// runs. Ratios are against the plain 4- or 8-byte-per-value form.
+fn report_sizes<T: DataType>(label: &str, columns: &[(&str, Vec<T::T>)], descr: &ColumnDescPtr) {
+    println!("\n{label}: bytes and ratio over {NUM_VALUES} values");
+    println!(
+        "{:<22} {:>12} {:>7} {:>12} {:>7}  smaller",
+        "column", "PFOR", "ratio", "DBP", "ratio"
+    );
+    for (name, values) in columns {
+        let plain = (values.len() * std::mem::size_of::<T::T>()) as f64;
+        let sizes: Vec<usize> = ENCODINGS
+            .iter()
+            .map(|&encoding| encode::<T>(values, encoding, descr).len())
+            .collect();
+        let smaller = if sizes[0] < sizes[1] { "PFOR" } else { "DBP" };
+        println!(
+            "{:<22} {:>12} {:>7.2} {:>12} {:>7.2}  {}",
+            name,
+            sizes[0],
+            plain / sizes[0] as f64,
+            sizes[1],
+            plain / sizes[1] as f64,
+            smaller
+        );
+    }
+}
+
+fn bench_type<T: DataType>(
+    c: &mut Criterion,
+    label: &str,
+    columns: &[(&str, Vec<T::T>)],
+    descr: &ColumnDescPtr,
+) {
+    report_sizes::<T>(label, columns, descr);
+
+    let mut encoding_group = c.benchmark_group(format!("{label}/encode"));
+    for (name, values) in columns {
+        encoding_group.throughput(Throughput::Bytes(
+            (values.len() * std::mem::size_of::<T::T>()) as u64,
+        ));
+        for encoding in ENCODINGS {
+            encoding_group.bench_function(BenchmarkId::new(format!("{encoding:?}"), name), |b| {
+                b.iter(|| encode::<T>(values, encoding, descr))
+            });
+        }
+    }
+    encoding_group.finish();
+
+    let mut decoding_group = c.benchmark_group(format!("{label}/decode"));
+    for (name, values) in columns {
+        decoding_group.throughput(Throughput::Bytes(
+            (values.len() * std::mem::size_of::<T::T>()) as u64,
+        ));
+        let mut out = vec![T::T::default(); values.len()];
+        for encoding in ENCODINGS {
+            let encoded = encode::<T>(values, encoding, descr);
+            // A wrong decode makes the timings meaningless, so check the round
+            // trip once per column before measuring it.
+            decode::<T>(encoded.clone(), &mut out, encoding, descr);
+            assert!(out == *values, "{encoding:?} did not round trip {name}");
+            decoding_group.bench_function(BenchmarkId::new(format!("{encoding:?}"), name), |b| {
+                b.iter(|| decode::<T>(encoded.clone(), &mut out, encoding, descr))
+            });
+        }
+    }
+    decoding_group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let narrow: Vec<(&str, Vec<i32>)> = COLUMNS
+        .iter()
+        .map(|(name, generate)| (*name, generate(NUM_VALUES)))
+        .collect();
+    bench_type::<Int32Type>(c, "int32", &narrow, &descriptor(ParquetType::INT32));
+
+    let wide: Vec<(&str, Vec<i64>)> = WIDE_COLUMNS
+        .iter()
+        .map(|(name, generate)| (*name, widen(&generate(NUM_VALUES))))
+        .collect();
+    bench_type::<Int64Type>(c, "int64", &wide, &descriptor(ParquetType::INT64));
+}
+
+criterion_group! {
+    name = benches;
+    // 33 columns times two encodings times two directions is a lot of
+    // benchmarks, so each one is measured for less than criterion's default.
+    config = Criterion::default()
+        .sample_size(50)
+        .warm_up_time(std::time::Duration::from_millis(500))
+        .measurement_time(std::time::Duration::from_secs(2));
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/parquet/benches/pfor.rs
+++ b/parquet/benches/pfor.rs
@@ -15,34 +15,51 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! PFOR against DELTA_BINARY_PACKED on encode speed, decode speed and size.
+//! PFOR against the other ways Parquet can carry an integer column.
 //!
-//! The columns are the ones the C++ implementation is benchmarked on: integer
-//! columns from ClickBench, TPC-H, TPC-DS and the NYC taxi trip data, plus four
-//! sorted or near-sorted shapes that separate the delta schemes from each other.
-//! The distributions are the same, and each column keeps the seed it has there,
-//! but the generators draw from a different engine, so the values are not
-//! identical to the C++ ones -- only the shape of each column is.
+//! Six arms, on the columns the C++ implementation is benchmarked on:
 //!
-//! Run with `cargo bench -p parquet --bench pfor`. The byte counts and ratios
-//! are printed once, before the timings.
+//! | arm | what it is |
+//! |---|---|
+//! | `RLE_BITPACK` | the RLE/bit-packed hybrid at the column's own bit width |
+//! | `DELTA_BINARY_PACKED` | Parquet's delta bit packing |
+//! | `PFOR` | PFOR with the differencing mode turned off |
+//! | `PFOR+DELTA` | PFOR free to choose differencing per vector, which is the default |
+//! | `PLAIN+ZSTD` | the raw little-endian values through zstd |
+//! | `PLAIN+LZ4` | the raw little-endian values through lz4 |
+//!
+//! The columns are integer columns from ClickBench, TPC-H, TPC-DS and the NYC taxi
+//! data, plus four sorted or near-sorted shapes that separate the delta schemes from
+//! each other. The distributions are the same as the C++ benchmark's and each column
+//! keeps the seed it has there, but the generators draw from a different engine, so
+//! the values are not identical -- only the shape of each column is.
+//!
+//! The two compressor arms time the compressor alone, over a buffer of values that is
+//! already in memory, which is what the C++ benchmark times. So their decode figure is
+//! bytes-to-bytes and does not include producing typed values; the other four arms all
+//! decode to values.
+//!
+//! Run with `cargo bench -p parquet --bench pfor`, or a subset with e.g.
+//! `cargo bench -p parquet --bench pfor -- "int32/decode/PFOR"`. The sizes are printed
+//! once, before the timings.
 
+use bytes::Bytes;
 use criterion::*;
-use parquet::basic::{Encoding, Type as ParquetType};
+use parquet::basic::{Compression, Encoding, Type as ParquetType, ZstdLevel};
+use parquet::compression::{Codec, CodecOptionsBuilder, create_codec};
 use parquet::data_type::{DataType, Int32Type, Int64Type};
 use parquet::decoding::{Decoder, get_decoder};
-use parquet::encoding::get_encoder;
+use parquet::encoding::{Encoder, PforEncoder, get_encoder};
+use parquet::encodings::pfor::PforInt;
+use parquet::encodings::rle::{RleDecoder, RleEncoder};
 use parquet::schema::types::{ColumnDescPtr, ColumnDescriptor, ColumnPath, Type};
+use parquet::util::bit_util::FromBitpacked;
 use rand::prelude::*;
 use std::sync::Arc;
 
 /// The element count the C++ comparison benchmark uses, so the two sets of
 /// numbers describe the same amount of work per iteration.
 const NUM_VALUES: usize = 102_400;
-
-/// The encodings under comparison. PFOR first, so it is the baseline column in
-/// the printed table.
-const ENCODINGS: [Encoding; 2] = [Encoding::PFOR, Encoding::DELTA_BINARY_PACKED];
 
 // ============================================================================
 // Draws
@@ -369,6 +386,74 @@ fn widen(values: &[i32]) -> Vec<i64> {
 // Harness
 // ============================================================================
 
+/// The arms of the comparison. Two of them are not simply an `Encoding`: PFOR's
+/// differencing mode is a knob on the encoder rather than a second encoding, and the
+/// compressor arms are a codec applied to a plain buffer.
+#[derive(Clone, Copy)]
+enum Arm {
+    /// The RLE/bit-packed hybrid, at the column's own bit width. That width is not
+    /// carried in the stream, so the reader is told it out of band -- which is also how
+    /// the C++ benchmark's RLE arm is set up.
+    RleBitPack,
+    /// An encoding the crate hands out through `get_encoder`/`get_decoder`.
+    Direct(Encoding),
+    /// PFOR, with the per-vector differencing mode allowed or forbidden.
+    Pfor { delta: bool },
+    /// The raw little-endian values through a page compressor.
+    PlainCompressed(Compression),
+}
+
+/// `(benchmark id, table heading, arm)`. Built at run time rather than declared as a
+/// constant because a zstd level is fallible to construct.
+fn arms() -> Vec<(&'static str, &'static str, Arm)> {
+    vec![
+        ("RLE_BITPACK", "RLE", Arm::RleBitPack),
+        (
+            "DELTA_BINARY_PACKED",
+            "DBP",
+            Arm::Direct(Encoding::DELTA_BINARY_PACKED),
+        ),
+        ("PFOR", "PFOR", Arm::Pfor { delta: false }),
+        ("PFOR+DELTA", "PFOR+D", Arm::Pfor { delta: true }),
+        (
+            "PLAIN+LZ4",
+            "LZ4",
+            Arm::PlainCompressed(Compression::LZ4_RAW),
+        ),
+        (
+            "PLAIN+ZSTD",
+            "ZSTD",
+            Arm::PlainCompressed(Compression::ZSTD(ZstdLevel::default())),
+        ),
+    ]
+}
+
+/// One column under one arm: the bytes, plus the bit width the RLE hybrid has to be
+/// handed back at decode time.
+struct Encoded {
+    bytes: Bytes,
+    bit_width: u8,
+}
+
+/// The value-type-dependent pieces the RLE arm needs, which `DataType` does not carry.
+/// The unsigned reinterpretation is what makes a negative value cost the full width,
+/// matching the C++ RLE arm.
+trait BenchValue: Copy + Default + PartialEq + FromBitpacked {
+    fn unsigned(self) -> u64;
+}
+
+impl BenchValue for i32 {
+    fn unsigned(self) -> u64 {
+        u64::from(self as u32)
+    }
+}
+
+impl BenchValue for i64 {
+    fn unsigned(self) -> u64 {
+        self as u64
+    }
+}
+
 fn descriptor(physical_type: ParquetType) -> ColumnDescPtr {
     ColumnDescPtr::new(ColumnDescriptor::new(
         Arc::new(
@@ -382,52 +467,150 @@ fn descriptor(physical_type: ParquetType) -> ColumnDescPtr {
     ))
 }
 
-fn encode<T: DataType>(values: &[T::T], encoding: Encoding, descr: &ColumnDescPtr) -> bytes::Bytes {
-    let mut encoder = get_encoder::<T>(encoding, descr).unwrap();
+fn codec_for(compression: Compression) -> Box<dyn Codec> {
+    create_codec(compression, &CodecOptionsBuilder::default().build())
+        .unwrap()
+        .expect("codec feature not enabled")
+}
+
+/// The bit width the RLE hybrid needs: enough bits for the widest value, read unsigned.
+fn bit_width_of<V: BenchValue>(values: &[V]) -> u8 {
+    let widest = values.iter().map(|v| v.unsigned()).max().unwrap_or(0);
+    (u64::BITS - widest.leading_zeros()).max(1) as u8
+}
+
+fn plain_bytes<T: DataType>(values: &[T::T], descr: &ColumnDescPtr) -> Bytes {
+    let mut encoder = get_encoder::<T>(Encoding::PLAIN, descr).unwrap();
     encoder.put(values).unwrap();
     encoder.flush_buffer().unwrap()
 }
 
-fn decode<T: DataType>(
-    encoded: bytes::Bytes,
-    out: &mut [T::T],
-    encoding: Encoding,
-    descr: &ColumnDescPtr,
-) {
-    let mut decoder: Box<dyn Decoder<T>> = get_decoder(descr.clone(), encoding).unwrap();
-    decoder.set_data(encoded, out.len()).unwrap();
-    let mut done = 0;
-    while done < out.len() {
-        let read = decoder.get(&mut out[done..]).unwrap();
-        assert_ne!(read, 0, "decoder stalled");
-        done += read;
+fn encode<T: DataType>(arm: Arm, values: &[T::T], descr: &ColumnDescPtr) -> Encoded
+where
+    T::T: BenchValue + PforInt,
+{
+    let bit_width = bit_width_of(values);
+    let bytes = match arm {
+        Arm::Direct(encoding) => {
+            let mut encoder = get_encoder::<T>(encoding, descr).unwrap();
+            encoder.put(values).unwrap();
+            encoder.flush_buffer().unwrap()
+        }
+        Arm::Pfor { delta } => {
+            let mut encoder = PforEncoder::<T>::new().with_delta_enabled(delta);
+            encoder.put(values).unwrap();
+            encoder.flush_buffer().unwrap()
+        }
+        Arm::RleBitPack => {
+            let mut encoder = RleEncoder::new(
+                bit_width,
+                RleEncoder::max_buffer_size(bit_width, values.len()),
+            );
+            for value in values {
+                encoder.put(value.unsigned());
+            }
+            Bytes::from(encoder.consume())
+        }
+        Arm::PlainCompressed(compression) => {
+            let plain = plain_bytes::<T>(values, descr);
+            let mut out = Vec::new();
+            codec_for(compression).compress(&plain, &mut out).unwrap();
+            Bytes::from(out)
+        }
+    };
+    Encoded { bytes, bit_width }
+}
+
+/// Decode one column back to values. Not used for the compressor arms, which stop at
+/// bytes.
+fn decode<T: DataType>(arm: Arm, encoded: &Encoded, out: &mut [T::T], descr: &ColumnDescPtr)
+where
+    T::T: BenchValue,
+{
+    match arm {
+        Arm::RleBitPack => {
+            let mut decoder = RleDecoder::new(encoded.bit_width);
+            decoder.set_data(encoded.bytes.clone()).unwrap();
+            let mut done = 0;
+            while done < out.len() {
+                let read = decoder.get_batch(&mut out[done..]).unwrap();
+                assert_ne!(read, 0, "decoder stalled");
+                done += read;
+            }
+        }
+        arm => {
+            let encoding = match arm {
+                Arm::Direct(encoding) => encoding,
+                Arm::Pfor { .. } => Encoding::PFOR,
+                _ => unreachable!("compressor arms do not decode to values"),
+            };
+            let mut decoder: Box<dyn Decoder<T>> = get_decoder(descr.clone(), encoding).unwrap();
+            decoder.set_data(encoded.bytes.clone(), out.len()).unwrap();
+            let mut done = 0;
+            while done < out.len() {
+                let read = decoder.get(&mut out[done..]).unwrap();
+                assert_ne!(read, 0, "decoder stalled");
+                done += read;
+            }
+        }
     }
 }
 
-/// Print the size of every column under both encodings, once, before any timing
-/// runs. Ratios are against the plain 4- or 8-byte-per-value form.
-fn report_sizes<T: DataType>(label: &str, columns: &[(&str, Vec<T::T>)], descr: &ColumnDescPtr) {
-    println!("\n{label}: bytes and ratio over {NUM_VALUES} values");
-    println!(
-        "{:<22} {:>12} {:>7} {:>12} {:>7}  smaller",
-        "column", "PFOR", "ratio", "DBP", "ratio"
-    );
+/// A wrong decode makes a timing meaningless, so every arm round trips once per column
+/// before it is measured.
+fn verify<T: DataType>(
+    arm: Arm,
+    name: &str,
+    encoded: &Encoded,
+    values: &[T::T],
+    descr: &ColumnDescPtr,
+) where
+    T::T: BenchValue + PforInt,
+{
+    if let Arm::PlainCompressed(compression) = arm {
+        let plain = plain_bytes::<T>(values, descr);
+        let mut got = Vec::new();
+        codec_for(compression)
+            .decompress(&encoded.bytes, &mut got, Some(plain.len()))
+            .unwrap();
+        assert!(got == plain.as_ref(), "did not round trip {name}");
+    } else {
+        let mut out = vec![T::T::default(); values.len()];
+        decode::<T>(arm, encoded, &mut out, descr);
+        assert!(out == *values, "did not round trip {name}");
+    }
+}
+
+/// Print the compression ratio of every column under every arm, once, before any timing
+/// runs. The ratio is against the plain 4- or 8-byte-per-value form.
+fn report_sizes<T: DataType>(label: &str, columns: &[(&str, Vec<T::T>)], descr: &ColumnDescPtr)
+where
+    T::T: BenchValue + PforInt,
+{
+    let arms = arms();
+    println!("\n{label}: ratio over plain, {NUM_VALUES} values per column");
+    print!("{:<22} {:>10}", "column", "plain B");
+    for (_, heading, _) in &arms {
+        print!("{heading:>9}");
+    }
+    println!("{:>10}", "smallest");
     for (name, values) in columns {
         let plain = (values.len() * std::mem::size_of::<T::T>()) as f64;
-        let sizes: Vec<usize> = ENCODINGS
+        let sizes: Vec<usize> = arms
             .iter()
-            .map(|&encoding| encode::<T>(values, encoding, descr).len())
+            .map(|&(_, _, arm)| encode::<T>(arm, values, descr).bytes.len())
             .collect();
-        let smaller = if sizes[0] < sizes[1] { "PFOR" } else { "DBP" };
-        println!(
-            "{:<22} {:>12} {:>7.2} {:>12} {:>7.2}  {}",
-            name,
-            sizes[0],
-            plain / sizes[0] as f64,
-            sizes[1],
-            plain / sizes[1] as f64,
-            smaller
-        );
+        let best = sizes
+            .iter()
+            .enumerate()
+            .min_by_key(|&(_, size)| size)
+            .map(|(index, _)| arms[index].1)
+            .unwrap();
+        print!("{:<22} {:>10}", name, plain as u64);
+        for size in &sizes {
+            print!("{:>9.2}", plain / *size as f64);
+        }
+        println!("{best:>10}");
     }
 }
 
@@ -436,40 +619,65 @@ fn bench_type<T: DataType>(
     label: &str,
     columns: &[(&str, Vec<T::T>)],
     descr: &ColumnDescPtr,
-) {
+) where
+    T::T: BenchValue + PforInt,
+{
     report_sizes::<T>(label, columns, descr);
+    let arms = arms();
+    let value_bytes = std::mem::size_of::<T::T>();
 
-    let mut encoding_group = c.benchmark_group(format!("{label}/encode"));
+    let mut encode_group = c.benchmark_group(format!("{label}/encode"));
     for (name, values) in columns {
-        encoding_group.throughput(Throughput::Bytes(
-            (values.len() * std::mem::size_of::<T::T>()) as u64,
-        ));
-        for encoding in ENCODINGS {
-            encoding_group.bench_function(BenchmarkId::new(format!("{encoding:?}"), name), |b| {
-                b.iter(|| encode::<T>(values, encoding, descr))
-            });
+        encode_group.throughput(Throughput::Bytes((values.len() * value_bytes) as u64));
+        for &(id, _, arm) in &arms {
+            let id = BenchmarkId::new(id, name);
+            if let Arm::PlainCompressed(compression) = arm {
+                // The compressor arms time the codec alone, over a buffer that is
+                // already in memory, which is what the C++ benchmark times.
+                let plain = plain_bytes::<T>(values, descr);
+                let mut codec = codec_for(compression);
+                let mut out = Vec::new();
+                encode_group.bench_function(id, |b| {
+                    b.iter(|| {
+                        out.clear();
+                        codec.compress(&plain, &mut out).unwrap();
+                    })
+                });
+            } else {
+                encode_group.bench_function(id, |b| b.iter(|| encode::<T>(arm, values, descr)));
+            }
         }
     }
-    encoding_group.finish();
+    encode_group.finish();
 
-    let mut decoding_group = c.benchmark_group(format!("{label}/decode"));
+    let mut decode_group = c.benchmark_group(format!("{label}/decode"));
     for (name, values) in columns {
-        decoding_group.throughput(Throughput::Bytes(
-            (values.len() * std::mem::size_of::<T::T>()) as u64,
-        ));
+        decode_group.throughput(Throughput::Bytes((values.len() * value_bytes) as u64));
         let mut out = vec![T::T::default(); values.len()];
-        for encoding in ENCODINGS {
-            let encoded = encode::<T>(values, encoding, descr);
-            // A wrong decode makes the timings meaningless, so check the round
-            // trip once per column before measuring it.
-            decode::<T>(encoded.clone(), &mut out, encoding, descr);
-            assert!(out == *values, "{encoding:?} did not round trip {name}");
-            decoding_group.bench_function(BenchmarkId::new(format!("{encoding:?}"), name), |b| {
-                b.iter(|| decode::<T>(encoded.clone(), &mut out, encoding, descr))
-            });
+        for &(id, _, arm) in &arms {
+            let encoded = encode::<T>(arm, values, descr);
+            verify::<T>(arm, name, &encoded, values, descr);
+            let id = BenchmarkId::new(id, name);
+            if let Arm::PlainCompressed(compression) = arm {
+                let plain_len = values.len() * value_bytes;
+                let mut codec = codec_for(compression);
+                let mut bytes = Vec::with_capacity(plain_len);
+                decode_group.bench_function(id, |b| {
+                    b.iter(|| {
+                        bytes.clear();
+                        codec
+                            .decompress(&encoded.bytes, &mut bytes, Some(plain_len))
+                            .unwrap();
+                    })
+                });
+            } else {
+                decode_group.bench_function(id, |b| {
+                    b.iter(|| decode::<T>(arm, &encoded, &mut out, descr))
+                });
+            }
         }
     }
-    decoding_group.finish();
+    decode_group.finish();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -488,8 +696,8 @@ fn criterion_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    // 33 columns times two encodings times two directions is a lot of
-    // benchmarks, so each one is measured for less than criterion's default.
+    // 33 columns times six arms times two directions is a lot of benchmarks, so each
+    // one is measured for less than criterion's default.
     config = Criterion::default()
         .sample_size(50)
         .warm_up_time(std::time::Duration::from_millis(500))

--- a/parquet/benches/pfor.rs
+++ b/parquet/benches/pfor.rs
@@ -17,7 +17,7 @@
 
 //! PFOR against the other ways Parquet can carry an integer column.
 //!
-//! Six arms, on the columns the C++ implementation is benchmarked on:
+//! Eight arms, on the columns the C++ implementation is benchmarked on:
 //!
 //! | arm | what it is |
 //! |---|---|
@@ -25,6 +25,8 @@
 //! | `DELTA_BINARY_PACKED` | Parquet's delta bit packing |
 //! | `PFOR` | PFOR with the differencing mode turned off |
 //! | `PFOR+DELTA` | PFOR free to choose differencing per vector, which is the default |
+//! | `PFOR_FASTLANES` | PFOR with byte-oriented FastLanes packing and fused frame addition |
+//! | `PFOR_FASTLANES+DELTA` | the same FastLanes layout with optional differencing |
 //! | `PLAIN+ZSTD` | the raw little-endian values through zstd |
 //! | `PLAIN+LZ4` | the raw little-endian values through lz4 |
 //!
@@ -55,6 +57,7 @@ use parquet::encodings::rle::{RleDecoder, RleEncoder};
 use parquet::schema::types::{ColumnDescPtr, ColumnDescriptor, ColumnPath, Type};
 use parquet::util::bit_util::FromBitpacked;
 use rand::prelude::*;
+use std::hint::black_box;
 use std::sync::Arc;
 
 /// The element count the C++ comparison benchmark uses, so the two sets of
@@ -398,7 +401,7 @@ enum Arm {
     /// An encoding the crate hands out through `get_encoder`/`get_decoder`.
     Direct(Encoding),
     /// PFOR, with the per-vector differencing mode allowed or forbidden.
-    Pfor { delta: bool },
+    Pfor { delta: bool, fastlanes: bool },
     /// The raw little-endian values through a page compressor.
     PlainCompressed(Compression),
 }
@@ -413,8 +416,38 @@ fn arms() -> Vec<(&'static str, &'static str, Arm)> {
             "DBP",
             Arm::Direct(Encoding::DELTA_BINARY_PACKED),
         ),
-        ("PFOR", "PFOR", Arm::Pfor { delta: false }),
-        ("PFOR+DELTA", "PFOR+D", Arm::Pfor { delta: true }),
+        (
+            "PFOR",
+            "PFOR",
+            Arm::Pfor {
+                delta: false,
+                fastlanes: false,
+            },
+        ),
+        (
+            "PFOR+DELTA",
+            "PFOR+D",
+            Arm::Pfor {
+                delta: true,
+                fastlanes: false,
+            },
+        ),
+        (
+            "PFOR_FASTLANES",
+            "PFOR+FL",
+            Arm::Pfor {
+                delta: false,
+                fastlanes: true,
+            },
+        ),
+        (
+            "PFOR_FASTLANES+DELTA",
+            "PFOR+FL+D",
+            Arm::Pfor {
+                delta: true,
+                fastlanes: true,
+            },
+        ),
         (
             "PLAIN+LZ4",
             "LZ4",
@@ -496,8 +529,10 @@ where
             encoder.put(values).unwrap();
             encoder.flush_buffer().unwrap()
         }
-        Arm::Pfor { delta } => {
-            let mut encoder = PforEncoder::<T>::new().with_delta_enabled(delta);
+        Arm::Pfor { delta, fastlanes } => {
+            let mut encoder = PforEncoder::<T>::new()
+                .with_delta_enabled(delta)
+                .with_fastlanes_enabled(fastlanes);
             encoder.put(values).unwrap();
             encoder.flush_buffer().unwrap()
         }
@@ -600,6 +635,14 @@ where
             .iter()
             .map(|&(_, _, arm)| encode::<T>(arm, values, descr).bytes.len())
             .collect();
+        assert_eq!(
+            sizes[2], sizes[4],
+            "FastLanes changed plain PFOR size for {name}"
+        );
+        assert_eq!(
+            sizes[3], sizes[5],
+            "FastLanes changed delta PFOR size for {name}"
+        );
         let best = sizes
             .iter()
             .enumerate()
@@ -644,7 +687,15 @@ fn bench_type<T: DataType>(
                     })
                 });
             } else {
-                encode_group.bench_function(id, |b| b.iter(|| encode::<T>(arm, values, descr)));
+                encode_group.bench_function(id, |b| {
+                    b.iter(|| {
+                        black_box(encode::<T>(
+                            black_box(arm),
+                            black_box(values),
+                            black_box(descr),
+                        ))
+                    })
+                });
             }
         }
     }
@@ -672,7 +723,15 @@ fn bench_type<T: DataType>(
                 });
             } else {
                 decode_group.bench_function(id, |b| {
-                    b.iter(|| decode::<T>(arm, &encoded, &mut out, descr))
+                    b.iter(|| {
+                        decode::<T>(
+                            black_box(arm),
+                            black_box(&encoded),
+                            black_box(&mut out),
+                            black_box(descr),
+                        );
+                        black_box(&out);
+                    })
                 });
             }
         }
@@ -696,7 +755,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    // 33 columns times six arms times two directions is a lot of benchmarks, so each
+    // 37 columns times eight arms times two directions is a lot of benchmarks, so each
     // one is measured for less than criterion's default.
     config = Criterion::default()
         .sample_size(50)

--- a/parquet/benches/pfor.rs
+++ b/parquet/benches/pfor.rs
@@ -17,7 +17,7 @@
 
 //! PFOR against the other ways Parquet can carry an integer column.
 //!
-//! Eight arms, on the columns the C++ implementation is benchmarked on:
+//! Nine arms, on the columns the C++ implementation is benchmarked on:
 //!
 //! | arm | what it is |
 //! |---|---|
@@ -27,6 +27,7 @@
 //! | `PFOR+DELTA` | PFOR free to choose differencing per vector, which is the default |
 //! | `PFOR_FASTLANES` | PFOR with byte-oriented FastLanes packing and fused frame addition |
 //! | `PFOR_FASTLANES+DELTA` | the same FastLanes layout with optional differencing |
+//! | `PFOR_FASTLANES+UTL_DELTA` | FastLanes with independent UTL delta lanes and per-lane starts |
 //! | `PLAIN+ZSTD` | the raw little-endian values through zstd |
 //! | `PLAIN+LZ4` | the raw little-endian values through lz4 |
 //!
@@ -38,7 +39,7 @@
 //!
 //! The two compressor arms time the compressor alone, over a buffer of values that is
 //! already in memory, which is what the C++ benchmark times. So their decode figure is
-//! bytes-to-bytes and does not include producing typed values; the other four arms all
+//! bytes-to-bytes and does not include producing typed values; the other arms all
 //! decode to values.
 //!
 //! Run with `cargo bench -p parquet --bench pfor`, or a subset with e.g.
@@ -401,7 +402,11 @@ enum Arm {
     /// An encoding the crate hands out through `get_encoder`/`get_decoder`.
     Direct(Encoding),
     /// PFOR, with the per-vector differencing mode allowed or forbidden.
-    Pfor { delta: bool, fastlanes: bool },
+    Pfor {
+        delta: bool,
+        fastlanes: bool,
+        utl_delta: bool,
+    },
     /// The raw little-endian values through a page compressor.
     PlainCompressed(Compression),
 }
@@ -422,6 +427,7 @@ fn arms() -> Vec<(&'static str, &'static str, Arm)> {
             Arm::Pfor {
                 delta: false,
                 fastlanes: false,
+                utl_delta: false,
             },
         ),
         (
@@ -430,6 +436,7 @@ fn arms() -> Vec<(&'static str, &'static str, Arm)> {
             Arm::Pfor {
                 delta: true,
                 fastlanes: false,
+                utl_delta: false,
             },
         ),
         (
@@ -438,6 +445,7 @@ fn arms() -> Vec<(&'static str, &'static str, Arm)> {
             Arm::Pfor {
                 delta: false,
                 fastlanes: true,
+                utl_delta: false,
             },
         ),
         (
@@ -446,6 +454,16 @@ fn arms() -> Vec<(&'static str, &'static str, Arm)> {
             Arm::Pfor {
                 delta: true,
                 fastlanes: true,
+                utl_delta: false,
+            },
+        ),
+        (
+            "PFOR_FASTLANES+UTL_DELTA",
+            "PFOR+UTL",
+            Arm::Pfor {
+                delta: true,
+                fastlanes: true,
+                utl_delta: true,
             },
         ),
         (
@@ -529,10 +547,15 @@ where
             encoder.put(values).unwrap();
             encoder.flush_buffer().unwrap()
         }
-        Arm::Pfor { delta, fastlanes } => {
+        Arm::Pfor {
+            delta,
+            fastlanes,
+            utl_delta,
+        } => {
             let mut encoder = PforEncoder::<T>::new()
                 .with_delta_enabled(delta)
-                .with_fastlanes_enabled(fastlanes);
+                .with_fastlanes_enabled(fastlanes)
+                .with_fastlanes_delta_enabled(utl_delta);
             encoder.put(values).unwrap();
             encoder.flush_buffer().unwrap()
         }
@@ -613,6 +636,40 @@ fn verify<T: DataType>(
         let mut out = vec![T::T::default(); values.len()];
         decode::<T>(arm, encoded, &mut out, descr);
         assert!(out == *values, "did not round trip {name}");
+    }
+    if let Arm::Pfor {
+        delta,
+        fastlanes,
+        utl_delta,
+    } = arm
+    {
+        let bytes = &encoded.bytes;
+        let vector_size = 1usize << bytes[1];
+        let num_vectors = values.len().div_ceil(vector_size);
+        let mut delta_vectors = 0;
+        let mut utl_blocks = 0;
+        let mut patches = 0;
+        for vector in 0..num_vectors {
+            let offset_at = 7 + vector * 4;
+            let at = 7 + u32::from_le_bytes(bytes[offset_at..offset_at + 4].try_into().unwrap())
+                as usize;
+            let width_at = at + T::T::BYTE_WIDTH;
+            if bytes[width_at] & 0x80 != 0 {
+                delta_vectors += 1;
+                if utl_delta {
+                    utl_blocks += (values.len() - vector * vector_size).min(vector_size) / 1024;
+                }
+            }
+            patches +=
+                u16::from_le_bytes(bytes[width_at + 1..width_at + 3].try_into().unwrap()) as usize;
+        }
+        // Outside the timer: retain exact sizes and actual mode selections so
+        // delta-allowed workloads cannot be mistaken for forced-delta timings.
+        println!(
+            "PFOR_STATS,int{},{name},delta={delta},fastlanes={fastlanes},utl={utl_delta},bytes={},vectors={num_vectors},delta_vectors={delta_vectors},utl_blocks={utl_blocks},patches={patches}",
+            T::T::BYTE_WIDTH * 8,
+            bytes.len()
+        );
     }
 }
 

--- a/parquet/src/arrow/arrow_writer/mod.rs
+++ b/parquet/src/arrow/arrow_writer/mod.rs
@@ -3133,6 +3133,89 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(s)]).unwrap();
         roundtrip(batch, None);
     }
+
+    #[test]
+    fn arrow_writer_pfor() {
+        // The round-trip matrix above covers PFOR across page versions, nullability and row group
+        // sizes. What it does not check is that PFOR is what actually ended up in the file, so this
+        // reads the encoding back out of the column chunk metadata.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("i32", DataType::Int32, false),
+            Field::new("i64", DataType::Int64, true),
+        ]));
+
+        let i32_values: Vec<i32> = (0..5000).map(|i| 1_000_000 + (i % 17)).collect();
+        let i64_values: Vec<Option<i64>> = (0..5000)
+            .map(|i| {
+                if i % 7 == 0 {
+                    None
+                } else {
+                    Some(i * 1_000_003)
+                }
+            })
+            .collect();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(i32_values)),
+                Arc::new(Int64Array::from(i64_values)),
+            ],
+        )
+        .unwrap();
+
+        let props = WriterProperties::builder()
+            .set_dictionary_enabled(false)
+            .set_encoding(Encoding::PFOR)
+            .build();
+
+        let mut buffer = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buffer, schema.clone(), Some(props)).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let reader = ParquetRecordBatchReaderBuilder::try_new(Bytes::from(buffer)).unwrap();
+        let row_group = reader.metadata().row_group(0);
+        for column in 0..row_group.num_columns() {
+            let column = row_group.column(column);
+            let encodings: Vec<_> = column.encodings().collect();
+            assert!(
+                encodings.contains(&Encoding::PFOR),
+                "{} was written as {encodings:?}",
+                column.column_path()
+            );
+        }
+
+        let read = reader
+            .build()
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        let read = arrow::compute::concat_batches(&schema, &read).unwrap();
+        assert_eq!(read, batch);
+    }
+
+    #[test]
+    #[should_panic(expected = "PFOR is not supported for type")]
+    fn arrow_writer_pfor_is_refused_for_other_types() {
+        // PFOR is defined for INT32 and INT64 only, so a column of any other physical type has to
+        // be refused. The lookup returns an error, and the column writer unwraps it -- which is how
+        // this crate already treats an encoding a column cannot use.
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "col",
+            DataType::Float64,
+            false,
+        )]));
+        let props = WriterProperties::builder()
+            .set_dictionary_enabled(false)
+            .set_encoding(Encoding::PFOR)
+            .build();
+        let mut writer = ArrowWriter::try_new(Vec::new(), schema.clone(), Some(props)).unwrap();
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Float64Array::from(vec![1.0, 2.0]))])
+                .unwrap();
+        let _ = writer.write(&batch);
+    }
+
     #[test]
     fn arrow_writer_page_size() {
         let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, false)]));
@@ -3404,6 +3487,7 @@ mod tests {
                     Encoding::PLAIN,
                     Encoding::DELTA_BINARY_PACKED,
                     Encoding::BYTE_STREAM_SPLIT,
+                    Encoding::PFOR,
                 ],
                 DataType::Float32 | DataType::Float64 => {
                     vec![Encoding::PLAIN, Encoding::BYTE_STREAM_SPLIT]

--- a/parquet/src/basic.rs
+++ b/parquet/src/basic.rs
@@ -451,6 +451,15 @@ enum Encoding {
   /// afterwards. Note that the use of this encoding with FIXED_LEN_BYTE_ARRAY(N) data may
   /// perform poorly for large values of N.
   BYTE_STREAM_SPLIT = 9;
+  /// Patched Frame of Reference encoding for integers, either INT32 or INT64.
+  ///
+  /// Values are encoded in fixed-size vectors. Each vector subtracts a frame of
+  /// reference, bit-packs the residuals at a width chosen by a cost model, and
+  /// stores the values that do not fit at that width separately, as exceptions.
+  ///
+  /// Value 10 is reserved for the separately proposed ALP encoding, so this
+  /// enum has a hole at 10. See `EncodingMask::ALLOWED_MASK`.
+  PFOR = 11;
 }
 );
 
@@ -471,6 +480,7 @@ impl FromStr for Encoding {
             "DELTA_BYTE_ARRAY" | "delta_byte_array" => Ok(Encoding::DELTA_BYTE_ARRAY),
             "RLE_DICTIONARY" | "rle_dictionary" => Ok(Encoding::RLE_DICTIONARY),
             "BYTE_STREAM_SPLIT" | "byte_stream_split" => Ok(Encoding::BYTE_STREAM_SPLIT),
+            "PFOR" | "pfor" => Ok(Encoding::PFOR),
             _ => Err(general_err!("unknown encoding: {}", s)),
         }
     }
@@ -516,9 +526,15 @@ impl EncodingMask {
     /// Highest valued discriminant in the [`Encoding`] enum
     const MAX_ENCODING: i32 = Encoding::MAX_DISCRIMINANT;
     /// A mask consisting of unused bit positions, used for validation. This includes the never
-    /// used GROUP_VAR_INT encoding value of `1`.
+    /// used GROUP_VAR_INT encoding value of `1`, and the value `10` held in reserve for the
+    /// separately proposed ALP encoding.
+    ///
+    /// Bit 10 has to be listed here rather than left to the range check: it sits below
+    /// [`Self::MAX_ENCODING`], so without it a column chunk claiming encoding 10 would pass
+    /// [`Self::try_new`] and then panic in `i32_to_encoding` when the mask was iterated --
+    /// a panic reachable from a file.
     const ALLOWED_MASK: u32 =
-        !(1u32 << (EncodingMask::MAX_ENCODING as u32 + 1)).wrapping_sub(1) | (1 << 1);
+        !(1u32 << (EncodingMask::MAX_ENCODING as u32 + 1)).wrapping_sub(1) | (1 << 1) | (1 << 10);
 
     /// Attempt to create a new `EncodingMask` from an integer.
     ///
@@ -610,6 +626,7 @@ fn i32_to_encoding(val: i32) -> Encoding {
         7 => Encoding::DELTA_BYTE_ARRAY,
         8 => Encoding::RLE_DICTIONARY,
         9 => Encoding::BYTE_STREAM_SPLIT,
+        11 => Encoding::PFOR,
         _ => panic!("Impossible encoding {val}"),
     }
 }
@@ -1970,6 +1987,7 @@ mod tests {
         );
         assert_eq!(Encoding::DELTA_BYTE_ARRAY.to_string(), "DELTA_BYTE_ARRAY");
         assert_eq!(Encoding::RLE_DICTIONARY.to_string(), "RLE_DICTIONARY");
+        assert_eq!(Encoding::PFOR.to_string(), "PFOR");
     }
 
     #[test]
@@ -2316,9 +2334,14 @@ mod tests {
         encoding = "BYTE_STREAM_SPLIT".parse().unwrap();
         assert_eq!(encoding, Encoding::BYTE_STREAM_SPLIT);
 
+        encoding = "PFOR".parse().unwrap();
+        assert_eq!(encoding, Encoding::PFOR);
+
         // test lowercase
         encoding = "byte_stream_split".parse().unwrap();
         assert_eq!(encoding, Encoding::BYTE_STREAM_SPLIT);
+        encoding = "pfor".parse().unwrap();
+        assert_eq!(encoding, Encoding::PFOR);
 
         // test unknown string
         match "plain_xxx".parse::<Encoding>() {
@@ -2452,6 +2475,7 @@ mod tests {
             Encoding::PLAIN_DICTIONARY,
             Encoding::RLE_DICTIONARY,
             Encoding::BYTE_STREAM_SPLIT,
+            Encoding::PFOR,
         ];
         encodings_roundtrip(encodings.into());
     }
@@ -2475,6 +2499,22 @@ mod tests {
             err.to_string(),
             "Parquet error: Attempt to create invalid mask: 0x2"
         );
+
+        // Value 10 is reserved for ALP and has no `Encoding` variant, so a mask claiming it
+        // has to be rejected here. Were it accepted, iterating the mask would reach
+        // `i32_to_encoding(10)` and panic.
+        let res = EncodingMask::try_new(1 << 10);
+        assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Parquet error: Attempt to create invalid mask: 0x400"
+        );
+
+        // The bit above the hole is a real encoding and must still be accepted.
+        let mask = EncodingMask::try_new(1 << 11).unwrap();
+        assert!(mask.is_only(Encoding::PFOR));
+        assert_eq!(mask.encodings().collect::<Vec<_>>(), vec![Encoding::PFOR]);
     }
 
     #[test]

--- a/parquet/src/bin/parquet-rewrite.rs
+++ b/parquet/src/bin/parquet-rewrite.rs
@@ -130,6 +130,9 @@ enum EncodingArgs {
 
     /// Encoding for fixed-width data.
     ByteStreamSplit,
+
+    /// Patched frame of reference encoding for integers, either INT32 or INT64.
+    Pfor,
 }
 
 #[expect(deprecated)]
@@ -145,6 +148,7 @@ impl From<EncodingArgs> for Encoding {
             EncodingArgs::DeltaByteArray => Self::DELTA_BYTE_ARRAY,
             EncodingArgs::RleDictionary => Self::RLE_DICTIONARY,
             EncodingArgs::ByteStreamSplit => Self::BYTE_STREAM_SPLIT,
+            EncodingArgs::Pfor => Self::PFOR,
         }
     }
 }

--- a/parquet/src/data_type.rs
+++ b/parquet/src/data_type.rs
@@ -718,6 +718,7 @@ pub(crate) mod private {
         + Send
         + HeapSize
         + crate::encodings::decoding::private::GetDecoder
+        + crate::encodings::encoding::private::GetEncoder
         + crate::file::statistics::private::MakeStatistics
     {
         const PHYSICAL_TYPE: Type;

--- a/parquet/src/encodings/decoding.rs
+++ b/parquet/src/encodings/decoding.rs
@@ -34,6 +34,9 @@ use crate::schema::types::ColumnDescPtr;
 use crate::util::bit_util::{self, BitReader, FromBitpacked};
 
 mod byte_stream_split_decoder;
+mod pfor_decoder;
+
+pub use pfor_decoder::PforDecoder;
 
 pub(crate) mod private {
     use super::*;
@@ -63,7 +66,8 @@ pub(crate) mod private {
             Encoding::RLE
             | Encoding::DELTA_BINARY_PACKED
             | Encoding::DELTA_BYTE_ARRAY
-            | Encoding::DELTA_LENGTH_BYTE_ARRAY => Err(general_err!(
+            | Encoding::DELTA_LENGTH_BYTE_ARRAY
+            | Encoding::PFOR => Err(general_err!(
                 "Encoding {} is not supported for type",
                 encoding
             )),
@@ -91,6 +95,7 @@ pub(crate) mod private {
             match encoding {
                 Encoding::BYTE_STREAM_SPLIT => Ok(Box::new(ByteStreamSplitDecoder::new())),
                 Encoding::DELTA_BINARY_PACKED => Ok(Box::new(DeltaBitPackDecoder::new())),
+                Encoding::PFOR => Ok(Box::new(PforDecoder::new())),
                 _ => get_decoder_default(descr, encoding),
             }
         }
@@ -104,6 +109,7 @@ pub(crate) mod private {
             match encoding {
                 Encoding::BYTE_STREAM_SPLIT => Ok(Box::new(ByteStreamSplitDecoder::new())),
                 Encoding::DELTA_BINARY_PACKED => Ok(Box::new(DeltaBitPackDecoder::new())),
+                Encoding::PFOR => Ok(Box::new(PforDecoder::new())),
                 _ => get_decoder_default(descr, encoding),
             }
         }

--- a/parquet/src/encodings/decoding/pfor_decoder.rs
+++ b/parquet/src/encodings/decoding/pfor_decoder.rs
@@ -1,0 +1,712 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! PFOR decoder. See [`crate::encodings::pfor`] for the wire format.
+
+use std::marker::PhantomData;
+
+use bytes::Bytes;
+
+use super::Decoder;
+use crate::basic::Encoding;
+use crate::data_type::DataType;
+use crate::encodings::pfor::*;
+use crate::errors::{ParquetError, Result};
+use crate::util::bit_util::BitReader;
+
+/// Decoder for [`Encoding::PFOR`].
+///
+/// A page is decoded one vector at a time into [`Self::vector`], and callers are served out of
+/// that buffer. Decoding a whole vector at once is what the format asks for -- the residuals are
+/// bit-packed as one run and the exceptions patched over the result -- and buffering it is what
+/// lets [`Decoder::get`] stop mid-vector and resume where it left off.
+pub struct PforDecoder<T: DataType> {
+    /// The page, from its header on. `None` until [`Decoder::set_data`].
+    data: Option<Bytes>,
+    /// Header of the page being decoded.
+    header: PforHeader,
+    /// The vector currently being served, decoded in full.
+    vector: Vec<T::T>,
+    /// Position in [`Self::vector`] of the next value to hand out.
+    vector_pos: usize,
+    /// Index of the next vector to decode.
+    next_vector: usize,
+    /// Values of the page not yet handed out.
+    values_left: usize,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: DataType> Default for PforDecoder<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: DataType> PforDecoder<T> {
+    /// Creates a decoder with no page set.
+    pub fn new() -> Self {
+        Self {
+            data: None,
+            header: PforHeader {
+                packing_mode: PACKING_MODE_FOR_BIT_PACK,
+                log_vector_size: DEFAULT_LOG_VECTOR_SIZE,
+                value_byte_width: 0,
+                num_elements: 0,
+            },
+            vector: Vec::new(),
+            vector_pos: 0,
+            next_vector: 0,
+            values_left: 0,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: DataType> PforDecoder<T>
+where
+    T::T: PforInt,
+{
+    /// Number of elements vector `index` of the current page holds.
+    ///
+    /// Every vector but the last is full; the last holds whatever remains.
+    fn elements_in_vector(&self, index: usize) -> usize {
+        let vector_size = self.header.vector_size();
+        let start = index * vector_size;
+        std::cmp::min(vector_size, self.header.num_elements as usize - start)
+    }
+
+    /// Decode vector `index` into [`Self::vector`], replacing whatever it held.
+    fn decode_vector(&mut self, index: usize) -> Result<()> {
+        let data = self
+            .data
+            .as_ref()
+            .ok_or_else(|| general_err!("PFOR decoder has no data"))?;
+        let num_elements = self.elements_in_vector(index);
+
+        // Offsets count from the start of the offset array, which follows the header.
+        let payload = &data[HEADER_SIZE..];
+        let offset = read_offset(payload, index);
+        let src = &payload[offset..];
+
+        let info = PforVectorInfo::<T::T>::read(src)?;
+        let info_bytes = info.stored_bytes();
+        if info_bytes > src.len() {
+            return Err(general_err!(
+                "PFOR delta vector needs {} bytes of metadata but only {} remain",
+                info_bytes,
+                src.len()
+            ));
+        }
+
+        // A differenced vector stores its own first value, which is what lets it decode without
+        // the vector before it -- the property the mode exists for.
+        let start_value = if info.is_delta {
+            T::T::read_le(&src[T::T::INFO_SIZE..])
+        } else {
+            T::T::default()
+        };
+
+        // Everything below is sized by fields that came off the wire, so check them against the
+        // vector's element count and against the bytes that remain before reading any of them.
+        if info.num_exceptions as usize > num_elements {
+            return Err(general_err!(
+                "PFOR vector has {} exceptions but only {} elements",
+                info.num_exceptions,
+                num_elements
+            ));
+        }
+        let packed_bytes = bytes_for_bits(num_elements * info.bit_width as usize);
+        let exception_bytes = info.num_exceptions as usize * (POSITION_SIZE + T::T::BYTE_WIDTH);
+        if info_bytes + packed_bytes + exception_bytes > src.len() {
+            return Err(general_err!(
+                "PFOR vector needs {} bytes but only {} remain",
+                info_bytes + packed_bytes + exception_bytes,
+                src.len()
+            ));
+        }
+
+        self.vector.clear();
+        self.vector.resize(num_elements, T::T::default());
+        let frame_bits = info.frame_of_reference.to_bits();
+
+        // A constant vector, which is the whole of what it stores.
+        if info.bit_width == 0 && info.num_exceptions == 0 {
+            if info.is_delta {
+                // Every difference is the frame, so the values step by it from the start value.
+                // Slot 0 always holds a difference of zero, so a frame other than zero cannot
+                // occur here, but the running sum reconstructs the sequence either way rather
+                // than assuming it.
+                let mut acc = start_value.to_bits();
+                for (i, slot) in self.vector.iter_mut().enumerate() {
+                    if i > 0 {
+                        acc = acc.wrapping_add(frame_bits);
+                    }
+                    *slot = T::T::from_bits(acc);
+                }
+            } else {
+                self.vector.fill(info.frame_of_reference);
+            }
+            return Ok(());
+        }
+
+        // Unpack the residuals, then add the frame back. The add is modular in the unsigned
+        // domain, so the bits the unpacker wrote are the signed values once the frame is on them,
+        // exactly as the encoder produced them.
+        if info.bit_width > 0 {
+            let packed_start = HEADER_SIZE + offset + info_bytes;
+            let mut reader = BitReader::new(data.slice(packed_start..packed_start + packed_bytes));
+            let unpacked = reader.get_batch(&mut self.vector, info.bit_width as usize);
+            if unpacked != num_elements {
+                return Err(general_err!(
+                    "PFOR vector unpacked {} of {} values",
+                    unpacked,
+                    num_elements
+                ));
+            }
+            if frame_bits != 0 {
+                for slot in &mut self.vector {
+                    *slot = T::T::from_bits(slot.to_bits().wrapping_add(frame_bits));
+                }
+            }
+        } else {
+            // Width zero with exceptions: every unpatched slot is the frame itself.
+            self.vector.fill(info.frame_of_reference);
+        }
+
+        // Patch the exceptions in. They are stored as two arrays, positions then values, both at
+        // the end of the vector.
+        if info.num_exceptions > 0 {
+            let num_exceptions = info.num_exceptions as usize;
+            let positions_at = info_bytes + packed_bytes;
+            let values_at = positions_at + num_exceptions * POSITION_SIZE;
+            let positions = &src[positions_at..values_at];
+            let values = &src[values_at..values_at + num_exceptions * T::T::BYTE_WIDTH];
+
+            // Every position indexes the vector, so one past its end would be an out-of-bounds
+            // write. Take the maximum first: a reduction still vectorizes, where a bounds check
+            // inside the patch loop would not.
+            let mut max_position = 0u16;
+            for i in 0..num_exceptions {
+                let at = i * POSITION_SIZE;
+                let position = u16::from_le_bytes([positions[at], positions[at + 1]]);
+                max_position = max_position.max(position);
+            }
+            if max_position as usize >= num_elements {
+                return Err(general_err!(
+                    "PFOR exception position {} is outside a vector of {} elements",
+                    max_position,
+                    num_elements
+                ));
+            }
+
+            for i in 0..num_exceptions {
+                let at = i * POSITION_SIZE;
+                let position =
+                    u16::from_le_bytes([positions[at], positions[at + 1]]) as usize;
+                // The exception carries whatever the packed stream carries: a value in a plain
+                // vector, a difference in a differenced one.
+                self.vector[position] = T::T::read_le(&values[i * T::T::BYTE_WIDTH..]);
+            }
+        }
+
+        // In a differenced vector, everything above produced differences. Sum them.
+        //
+        // This has to come after the patch: an exception in a differenced vector is a difference
+        // too, and summing before patching would carry the placeholder zero into every value that
+        // follows. The sum runs in the unsigned domain for the same reason the frame add does.
+        if info.is_delta {
+            let mut acc = start_value.to_bits();
+            for slot in &mut self.vector {
+                acc = acc.wrapping_add(slot.to_bits());
+                *slot = T::T::from_bits(acc);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Make sure [`Self::vector`] has a value to hand out, decoding the next vector if not.
+    ///
+    /// Returns false once the page is exhausted.
+    fn ensure_vector(&mut self) -> Result<bool> {
+        while self.vector_pos >= self.vector.len() {
+            if self.next_vector >= self.header.num_vectors() {
+                return Ok(false);
+            }
+            let index = self.next_vector;
+            self.next_vector += 1;
+            self.decode_vector(index)?;
+            self.vector_pos = 0;
+        }
+        Ok(true)
+    }
+}
+
+impl<T: DataType> Decoder<T> for PforDecoder<T>
+where
+    T::T: PforInt,
+{
+    fn set_data(&mut self, data: Bytes, num_values: usize) -> Result<()> {
+        let header = PforHeader::read::<T::T>(&data)?;
+
+        // The page carries its own count, and that is the count the vectors were laid out from, so
+        // it is what the decoder reads. `num_values` is the level count when a V1 page does not
+        // give a value count of its own, and that includes nulls, which PFOR does not store -- so
+        // the two are equal only for a required column. What cannot happen either way is a page
+        // claiming more values than there are levels to put them in.
+        if header.num_elements as usize > num_values {
+            return Err(general_err!(
+                "PFOR header element count {} exceeds the {} values the page has room for",
+                header.num_elements,
+                num_values
+            ));
+        }
+
+        let num_vectors = header.num_vectors();
+        let offset_array_size = num_vectors * OFFSET_SIZE;
+        if HEADER_SIZE + offset_array_size > data.len() {
+            return Err(general_err!(
+                "PFOR offset array for {} vectors does not fit in {} bytes",
+                num_vectors,
+                data.len()
+            ));
+        }
+        let payload_size = data.len() - HEADER_SIZE;
+        validate_offsets(&data[HEADER_SIZE..], num_vectors, payload_size)?;
+
+        self.values_left = header.num_elements as usize;
+        self.header = header;
+        self.data = Some(data);
+        self.vector.clear();
+        self.vector_pos = 0;
+        self.next_vector = 0;
+        Ok(())
+    }
+
+    fn get(&mut self, buffer: &mut [T::T]) -> Result<usize> {
+        let mut written = 0;
+        while written < buffer.len() {
+            if !self.ensure_vector()? {
+                break;
+            }
+            let available = self.vector.len() - self.vector_pos;
+            let take = std::cmp::min(available, buffer.len() - written);
+            buffer[written..written + take]
+                .clone_from_slice(&self.vector[self.vector_pos..self.vector_pos + take]);
+            self.vector_pos += take;
+            written += take;
+        }
+        self.values_left -= written;
+        Ok(written)
+    }
+
+    fn values_left(&self) -> usize {
+        self.values_left
+    }
+
+    fn encoding(&self) -> Encoding {
+        Encoding::PFOR
+    }
+
+    fn skip(&mut self, num_values: usize) -> Result<usize> {
+        let mut skipped = 0;
+        while skipped < num_values {
+            // A vector nobody has read into can be skipped without decoding it at all, which is
+            // the whole reason the offset array is in the page.
+            if self.vector_pos >= self.vector.len() {
+                if self.next_vector >= self.header.num_vectors() {
+                    break;
+                }
+                let whole = self.elements_in_vector(self.next_vector);
+                if skipped + whole <= num_values {
+                    self.next_vector += 1;
+                    self.vector.clear();
+                    self.vector_pos = 0;
+                    skipped += whole;
+                    continue;
+                }
+            }
+            if !self.ensure_vector()? {
+                break;
+            }
+            let available = self.vector.len() - self.vector_pos;
+            let take = std::cmp::min(available, num_values - skipped);
+            self.vector_pos += take;
+            skipped += take;
+        }
+        self.values_left -= skipped;
+        Ok(skipped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_type::{Int32Type, Int64Type};
+
+    /// Decode a whole page, checking the value count as well as the values.
+    fn decode<T: DataType>(page: &[u8], num_values: usize) -> Result<Vec<T::T>>
+    where
+        T::T: PforInt,
+    {
+        let mut decoder = PforDecoder::<T>::new();
+        decoder.set_data(Bytes::copy_from_slice(page), num_values)?;
+        let mut out = vec![T::T::default(); num_values];
+        let read = decoder.get(&mut out)?;
+        out.truncate(read);
+        assert_eq!(decoder.values_left(), 0);
+        Ok(out)
+    }
+
+    /// Assemble a page out of literal vector bodies, filling in the offset array.
+    ///
+    /// The offsets are the one part of a page that cannot be written by hand without recomputing
+    /// them on every edit; the vector bodies below are literal bytes, so what is being tested is
+    /// still the format and not our encoder.
+    fn page(log_vector_size: u8, value_byte_width: u8, num_elements: i32, vectors: &[Vec<u8>]) -> Vec<u8> {
+        let mut out = vec![PACKING_MODE_FOR_BIT_PACK, log_vector_size, value_byte_width];
+        out.extend_from_slice(&num_elements.to_le_bytes());
+        let offset_array_at = out.len();
+        out.resize(offset_array_at + vectors.len() * OFFSET_SIZE, 0);
+        for (v, body) in vectors.iter().enumerate() {
+            let offset = (out.len() - offset_array_at) as u32;
+            let at = offset_array_at + v * OFFSET_SIZE;
+            out[at..at + OFFSET_SIZE].copy_from_slice(&offset.to_le_bytes());
+            out.extend_from_slice(body);
+        }
+        out
+    }
+
+    #[test]
+    fn test_decode_golden_page_byte_for_byte() {
+        // One page written out in full, so that a change to the layout has to change this test.
+        // Two vectors of eight: the first packs 100..=107 at three bits over a frame of 100, the
+        // second is a pair of sevens and so packs at width zero.
+        #[rustfmt::skip]
+        let golden = vec![
+            // header: bit-packed mode, 2^3 values per vector, 4-byte values, 10 elements
+            0x00, 0x03, 0x04, 0x0A, 0x00, 0x00, 0x00,
+            // offsets: the first vector starts just past the 8-byte array, the second 10 bytes on
+            0x08, 0x00, 0x00, 0x00,
+            0x12, 0x00, 0x00, 0x00,
+            // vector 0 info: frame 100, width 3, no exceptions
+            0x64, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00,
+            // vector 0 residuals 0..=7 at 3 bits, least significant bit first
+            0x88, 0xC6, 0xFA,
+            // vector 1 info: frame 7, width 0, no exceptions -- and so no residuals at all
+            0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        assert_eq!(
+            decode::<Int32Type>(&golden, 10).unwrap(),
+            vec![100, 101, 102, 103, 104, 105, 106, 107, 7, 7]
+        );
+    }
+
+    #[test]
+    fn test_decode_exceptions_are_patched() {
+        // 10..=16 pack at three bits over a frame of 10; 1000 does not, so it travels as an
+        // exception and its packed slot holds a zero.
+        #[rustfmt::skip]
+        let vector = vec![
+            0x0A, 0x00, 0x00, 0x00, 0x03, 0x01, 0x00, // frame 10, width 3, one exception
+            0x88, 0xC6, 0x1A,                         // residuals 0..=6 then the placeholder
+            0x07, 0x00,                               // the exception is at position 7
+            0xE8, 0x03, 0x00, 0x00,                   // and its value is 1000
+        ];
+        assert_eq!(
+            decode::<Int32Type>(&page(3, 4, 8, &[vector]), 8).unwrap(),
+            vec![10, 11, 12, 13, 14, 15, 16, 1000]
+        );
+    }
+
+    #[test]
+    fn test_decode_below_frame_values_are_patched() {
+        // The frame does not have to be the minimum. Here it is 100 and one value sits below it,
+        // where the residual wraps and fails the width test from the other side -- which is what
+        // lets one window cover a cluster with outliers on both sides of it.
+        #[rustfmt::skip]
+        let vector = vec![
+            0x64, 0x00, 0x00, 0x00, 0x02, 0x02, 0x00, // frame 100, width 2, two exceptions
+            0x24,                                     // residuals 0, 1, 2, and one placeholder
+            0x00, 0x00,                               // position 0
+            0x03, 0x00,                               // position 3
+            0xC6, 0xFF, 0xFF, 0xFF,                   // -58
+            0xE8, 0x03, 0x00, 0x00,                   // 1000
+        ];
+        assert_eq!(
+            decode::<Int32Type>(&page(3, 4, 4, &[vector]), 4).unwrap(),
+            vec![-58, 101, 102, 1000]
+        );
+    }
+
+    #[test]
+    fn test_decode_delta_vector() {
+        // The differencing flag in bit 7 of the width byte, a start value between the info and the
+        // residuals, and d[0] == 0.
+        #[rustfmt::skip]
+        let vector = vec![
+            0x00, 0x00, 0x00, 0x00, 0x82, 0x00, 0x00, // frame 0, width 2 with the delta flag
+            0xE8, 0x03, 0x00, 0x00,                   // start value 1000
+            0xA8, 0xAA,                               // 0 then seven twos, at 2 bits each
+        ];
+        assert_eq!(
+            decode::<Int32Type>(&page(3, 4, 8, &[vector]), 8).unwrap(),
+            vec![1000, 1002, 1004, 1006, 1008, 1010, 1012, 1014]
+        );
+    }
+
+    #[test]
+    fn test_decode_delta_vector_patches_before_summing() {
+        // An exception in a differenced vector holds a difference, and the sum has to run after the
+        // patch: summing first would carry the placeholder zero into every value after it.
+        #[rustfmt::skip]
+        let vector = vec![
+            0x00, 0x00, 0x00, 0x00, 0x81, 0x01, 0x00, // frame 0, width 1 with the delta flag
+            0x0A, 0x00, 0x00, 0x00,                   // start value 10
+            0x0A,                                     // differences 0, 1, 0 (a placeholder), 1
+            0x02, 0x00,                               // the placeholder is at position 2
+            0xF4, 0x01, 0x00, 0x00,                   // and the difference there is really 500
+        ];
+        assert_eq!(
+            decode::<Int32Type>(&page(3, 4, 4, &[vector]), 4).unwrap(),
+            vec![10, 11, 511, 512]
+        );
+    }
+
+    #[test]
+    fn test_decode_delta_vector_at_width_zero() {
+        // A constant difference needs no residuals at all: the values are the start value plus the
+        // frame, stepped. This is the fast path in the decoder, so it gets a page of its own.
+        #[rustfmt::skip]
+        let vector = vec![
+            0x03, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, // frame 3, width 0 with the delta flag
+            0x05, 0x00, 0x00, 0x00,                   // start value 5
+        ];
+        assert_eq!(
+            decode::<Int32Type>(&page(3, 4, 4, &[vector]), 4).unwrap(),
+            vec![5, 8, 11, 14]
+        );
+    }
+
+    #[test]
+    fn test_decode_int64_at_full_width() {
+        // Width 64 needs all seven bits of the width field, and a six-bit field would read it as a
+        // constant vector. At that width the residuals are just little-endian words, which is what
+        // makes the page writable by hand.
+        let frame = i64::MIN;
+        let values = vec![i64::MIN, i64::MAX, -1, 0, 1, 2, 3, 4];
+        let mut vector = frame.to_le_bytes().to_vec();
+        vector.push(64);
+        vector.extend_from_slice(&0u16.to_le_bytes());
+        for value in &values {
+            vector.extend_from_slice(&(value.wrapping_sub(frame) as u64).to_le_bytes());
+        }
+        assert_eq!(decode::<Int64Type>(&page(3, 8, 8, &[vector]), 8).unwrap(), values);
+    }
+
+    #[test]
+    fn test_decode_empty_page() {
+        // No values still has to be a readable page: a reader loads the header before it knows how
+        // many values the page holds.
+        let empty = page(3, 4, 0, &[]);
+        assert_eq!(empty.len(), HEADER_SIZE);
+        assert!(decode::<Int32Type>(&empty, 0).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_get_stops_and_resumes_mid_vector() {
+        // Vectors of eight, read three at a time, so every read but the first starts part-way into
+        // a buffered vector and one of them spans a vector boundary.
+        let expected: Vec<i32> = (0..20).collect();
+        let page = encoded_page::<Int32Type>(&expected, 8);
+
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        decoder.set_data(page, expected.len()).unwrap();
+
+        let mut got = Vec::new();
+        let mut buffer = [0i32; 3];
+        loop {
+            let read = decoder.get(&mut buffer).unwrap();
+            if read == 0 {
+                break;
+            }
+            got.extend_from_slice(&buffer[..read]);
+            assert_eq!(decoder.values_left(), expected.len() - got.len());
+        }
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn test_skip_whole_and_partial_vectors() {
+        let expected: Vec<i32> = (0..40).collect();
+
+        // A skip landing exactly on a vector boundary, which decodes nothing at all.
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        decoder.set_data(encoded_page::<Int32Type>(&expected, 8), 40).unwrap();
+        assert_eq!(decoder.skip(16).unwrap(), 16);
+        assert_eq!(decoder.values_left(), 24);
+        let mut out = vec![0i32; 24];
+        assert_eq!(decoder.get(&mut out).unwrap(), 24);
+        assert_eq!(out, expected[16..]);
+
+        // A skip stopping part-way into a vector, then a read that continues from there.
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        decoder.set_data(encoded_page::<Int32Type>(&expected, 8), 40).unwrap();
+        assert_eq!(decoder.skip(19).unwrap(), 19);
+        let mut out = vec![0i32; 5];
+        assert_eq!(decoder.get(&mut out).unwrap(), 5);
+        assert_eq!(out, expected[19..24]);
+
+        // Interleaved reads and skips.
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        decoder.set_data(encoded_page::<Int32Type>(&expected, 8), 40).unwrap();
+        let mut out = vec![0i32; 3];
+        decoder.get(&mut out).unwrap();
+        assert_eq!(out, expected[..3]);
+        assert_eq!(decoder.skip(30).unwrap(), 30);
+        let mut out = vec![0i32; 7];
+        assert_eq!(decoder.get(&mut out).unwrap(), 7);
+        assert_eq!(out, expected[33..]);
+
+        // A skip past the end reports what it could actually skip.
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        decoder.set_data(encoded_page::<Int32Type>(&expected, 8), 40).unwrap();
+        assert_eq!(decoder.skip(100).unwrap(), 40);
+        assert_eq!(decoder.values_left(), 0);
+        assert_eq!(decoder.get(&mut out).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_set_data_rejects_a_header_it_cannot_read() {
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        // Shorter than a header.
+        assert!(decoder.set_data(Bytes::from(vec![0u8; 3]), 0).is_err());
+        // An INT64 page handed to an INT32 column.
+        let page = page(3, 8, 0, &[]);
+        assert!(decoder.set_data(Bytes::from(page), 0).is_err());
+    }
+
+    #[test]
+    fn test_set_data_rejects_more_elements_than_the_page_has_room_for() {
+        // The header claims eight values where the caller knows there are four. Believing it would
+        // hand out values built from whatever follows.
+        let mut page = page(3, 4, 8, &[vec![0u8; 7]]);
+        page[3] = 8;
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        assert!(decoder.set_data(Bytes::from(page), 4).is_err());
+    }
+
+    #[test]
+    fn test_set_data_rejects_a_truncated_offset_array() {
+        // Two vectors' worth of header, and not enough page left to hold their offsets.
+        let mut page = page(3, 4, 16, &[vec![0u8; 7], vec![0u8; 7]]);
+        page.truncate(HEADER_SIZE + OFFSET_SIZE);
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        assert!(decoder.set_data(Bytes::from(page), 16).is_err());
+    }
+
+    #[test]
+    fn test_set_data_rejects_a_broken_offset_chain() {
+        let good = page(3, 4, 16, &[vec![0u8; 7], vec![0u8; 7]]);
+
+        // The second vector starting inside the first.
+        let mut broken = good.clone();
+        broken[HEADER_SIZE + OFFSET_SIZE..HEADER_SIZE + 2 * OFFSET_SIZE]
+            .copy_from_slice(&4u32.to_le_bytes());
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        assert!(decoder.set_data(Bytes::from(broken), 16).is_err());
+
+        // The first vector not landing just past the offset array.
+        let mut broken = good.clone();
+        broken[HEADER_SIZE..HEADER_SIZE + OFFSET_SIZE].copy_from_slice(&99u32.to_le_bytes());
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        assert!(decoder.set_data(Bytes::from(broken), 16).is_err());
+
+        // An offset past the end of the payload.
+        let mut broken = good;
+        broken[HEADER_SIZE + OFFSET_SIZE..HEADER_SIZE + 2 * OFFSET_SIZE]
+            .copy_from_slice(&10_000u32.to_le_bytes());
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        assert!(decoder.set_data(Bytes::from(broken), 16).is_err());
+    }
+
+    #[test]
+    fn test_decode_rejects_a_width_the_type_cannot_hold() {
+        // Width 33 on an INT32 column. Nothing packs to it, and honouring it would read past the
+        // vector.
+        let mut vector = vec![0u8; 7];
+        vector[4] = 33;
+        vector.extend_from_slice(&[0u8; 64]);
+        let err = decode::<Int32Type>(&page(3, 4, 8, &[vector]), 8).unwrap_err();
+        assert!(err.to_string().contains("bit_width"), "{err}");
+    }
+
+    #[test]
+    fn test_decode_rejects_an_exception_position_outside_the_vector() {
+        // Position 8 in a vector of eight: one past the end, and so a write past the end of the
+        // decoded buffer.
+        #[rustfmt::skip]
+        let vector = vec![
+            0x00, 0x00, 0x00, 0x00, 0x03, 0x01, 0x00, // width 3, one exception
+            0x00, 0x00, 0x00,                         // eight residuals at 3 bits
+            0x08, 0x00,                               // position 8, which does not exist
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let err = decode::<Int32Type>(&page(3, 4, 8, &[vector]), 8).unwrap_err();
+        assert!(err.to_string().contains("outside a vector"), "{err}");
+    }
+
+    #[test]
+    fn test_decode_rejects_a_vector_that_runs_off_the_page() {
+        // The info block promises eight 32-bit residuals and the page ends after three bytes of
+        // them. Every section a vector claims is bounded against what is left of the page.
+        #[rustfmt::skip]
+        let vector = vec![
+            0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, // width 32
+            0x00, 0x00, 0x00,
+        ];
+        assert!(decode::<Int32Type>(&page(3, 4, 8, &[vector]), 8).is_err());
+
+        // The same for the exception sections, which sit after the residuals.
+        #[rustfmt::skip]
+        let vector = vec![
+            0x00, 0x00, 0x00, 0x00, 0x03, 0x02, 0x00, // width 3, two exceptions
+            0x00, 0x00, 0x00,                         // the residuals, and then nothing
+            0x00, 0x00,
+        ];
+        assert!(decode::<Int32Type>(&page(3, 4, 8, &[vector]), 8).is_err());
+    }
+
+    #[test]
+    fn test_decode_rejects_a_truncated_info_block() {
+        assert!(decode::<Int32Type>(&page(3, 4, 8, &[vec![0u8; 6]]), 8).is_err());
+    }
+
+    /// Encode `values` with the Rust encoder, for the tests that are about reading rather than
+    /// about the byte layout.
+    fn encoded_page<T: DataType>(values: &[T::T], vector_size: usize) -> Bytes
+    where
+        T::T: PforInt,
+    {
+        use crate::encodings::encoding::{Encoder, PforEncoder};
+        let mut encoder = PforEncoder::<T>::new()
+            .with_vector_size(vector_size)
+            .unwrap();
+        encoder.put(values).unwrap();
+        encoder.flush_buffer().unwrap()
+    }
+}

--- a/parquet/src/encodings/decoding/pfor_decoder.rs
+++ b/parquet/src/encodings/decoding/pfor_decoder.rs
@@ -343,6 +343,15 @@ impl<V: PforInt> VectorLayout<V> {
 ///
 /// The add is modular in the unsigned domain, so the bits the unpacker wrote are the signed values
 /// once the frame is on them, exactly as the encoder produced them.
+///
+/// TODO: fuse the frame add into the unpacking kernel. Paired per column against the C++
+/// implementation of this format on 29 shared int32 columns, this decoder runs at 0.37x of it
+/// (0.32x-0.70x, slower on all 29), while `DELTA_BINARY_PACKED` in this crate runs at 1.55x of
+/// the same C++ benchmark on 29 of 29 -- so the gap is this inner loop, not the machine or the
+/// harness. Two candidates, not yet separated: the C++ side adds the frame inside its vectorized
+/// unpack kernel where this makes a second pass over the whole vector, and `unpack32` here is
+/// scalar code left to the autovectorizer. A fused variant would settle how much of the 2.7x is
+/// the extra pass.
 fn unpack_residuals<V: PforInt>(
     out: &mut [V],
     packed: Bytes,

--- a/parquet/src/encodings/decoding/pfor_decoder.rs
+++ b/parquet/src/encodings/decoding/pfor_decoder.rs
@@ -30,8 +30,8 @@ use crate::util::bit_util::BitReader;
 
 /// Decoder for [`Encoding::PFOR`].
 ///
-/// A page is decoded one vector at a time into [`Self::vector`], and callers are served out of
-/// that buffer. Decoding a whole vector at once is what the format asks for -- the residuals are
+/// A page is decoded one vector at a time into a buffer of the decoder's own, and callers are
+/// served out of that buffer. Decoding a whole vector at once is what the format asks for -- the residuals are
 /// bit-packed as one run and the exceptions patched over the result -- and buffering it is what
 /// lets [`Decoder::get`] stop mid-vector and resume where it left off.
 pub struct PforDecoder<T: DataType> {
@@ -215,8 +215,7 @@ where
 
             for i in 0..num_exceptions {
                 let at = i * POSITION_SIZE;
-                let position =
-                    u16::from_le_bytes([positions[at], positions[at + 1]]) as usize;
+                let position = u16::from_le_bytes([positions[at], positions[at + 1]]) as usize;
                 // The exception carries whatever the packed stream carries: a value in a plain
                 // vector, a difference in a differenced one.
                 self.vector[position] = T::T::read_le(&values[i * T::T::BYTE_WIDTH..]);
@@ -377,7 +376,12 @@ mod tests {
     /// The offsets are the one part of a page that cannot be written by hand without recomputing
     /// them on every edit; the vector bodies below are literal bytes, so what is being tested is
     /// still the format and not our encoder.
-    fn page(log_vector_size: u8, value_byte_width: u8, num_elements: i32, vectors: &[Vec<u8>]) -> Vec<u8> {
+    fn page(
+        log_vector_size: u8,
+        value_byte_width: u8,
+        num_elements: i32,
+        vectors: &[Vec<u8>],
+    ) -> Vec<u8> {
         let mut out = vec![PACKING_MODE_FOR_BIT_PACK, log_vector_size, value_byte_width];
         out.extend_from_slice(&num_elements.to_le_bytes());
         let offset_array_at = out.len();
@@ -515,7 +519,10 @@ mod tests {
         for value in &values {
             vector.extend_from_slice(&(value.wrapping_sub(frame) as u64).to_le_bytes());
         }
-        assert_eq!(decode::<Int64Type>(&page(3, 8, 8, &[vector]), 8).unwrap(), values);
+        assert_eq!(
+            decode::<Int64Type>(&page(3, 8, 8, &[vector]), 8).unwrap(),
+            values
+        );
     }
 
     #[test]
@@ -556,7 +563,9 @@ mod tests {
 
         // A skip landing exactly on a vector boundary, which decodes nothing at all.
         let mut decoder = PforDecoder::<Int32Type>::new();
-        decoder.set_data(encoded_page::<Int32Type>(&expected, 8), 40).unwrap();
+        decoder
+            .set_data(encoded_page::<Int32Type>(&expected, 8), 40)
+            .unwrap();
         assert_eq!(decoder.skip(16).unwrap(), 16);
         assert_eq!(decoder.values_left(), 24);
         let mut out = vec![0i32; 24];
@@ -565,7 +574,9 @@ mod tests {
 
         // A skip stopping part-way into a vector, then a read that continues from there.
         let mut decoder = PforDecoder::<Int32Type>::new();
-        decoder.set_data(encoded_page::<Int32Type>(&expected, 8), 40).unwrap();
+        decoder
+            .set_data(encoded_page::<Int32Type>(&expected, 8), 40)
+            .unwrap();
         assert_eq!(decoder.skip(19).unwrap(), 19);
         let mut out = vec![0i32; 5];
         assert_eq!(decoder.get(&mut out).unwrap(), 5);
@@ -573,7 +584,9 @@ mod tests {
 
         // Interleaved reads and skips.
         let mut decoder = PforDecoder::<Int32Type>::new();
-        decoder.set_data(encoded_page::<Int32Type>(&expected, 8), 40).unwrap();
+        decoder
+            .set_data(encoded_page::<Int32Type>(&expected, 8), 40)
+            .unwrap();
         let mut out = vec![0i32; 3];
         decoder.get(&mut out).unwrap();
         assert_eq!(out, expected[..3]);
@@ -584,7 +597,9 @@ mod tests {
 
         // A skip past the end reports what it could actually skip.
         let mut decoder = PforDecoder::<Int32Type>::new();
-        decoder.set_data(encoded_page::<Int32Type>(&expected, 8), 40).unwrap();
+        decoder
+            .set_data(encoded_page::<Int32Type>(&expected, 8), 40)
+            .unwrap();
         assert_eq!(decoder.skip(100).unwrap(), 40);
         assert_eq!(decoder.values_left(), 0);
         assert_eq!(decoder.get(&mut out).unwrap(), 0);

--- a/parquet/src/encodings/decoding/pfor_decoder.rs
+++ b/parquet/src/encodings/decoding/pfor_decoder.rs
@@ -24,16 +24,19 @@ use bytes::Bytes;
 use super::Decoder;
 use crate::basic::Encoding;
 use crate::data_type::DataType;
-use crate::encodings::pfor::*;
+use crate::encodings::pfor::{
+    DEFAULT_LOG_VECTOR_SIZE, HEADER_SIZE, OFFSET_SIZE, PACKING_MODE_FOR_BIT_PACK, POSITION_SIZE,
+    PforHeader, PforInt, PforVectorInfo, bytes_for_bits, read_offset, validate_offsets,
+};
 use crate::errors::{ParquetError, Result};
 use crate::util::bit_util::BitReader;
 
 /// Decoder for [`Encoding::PFOR`].
 ///
 /// A page is decoded one vector at a time into a buffer of the decoder's own, and callers are
-/// served out of that buffer. Decoding a whole vector at once is what the format asks for -- the residuals are
-/// bit-packed as one run and the exceptions patched over the result -- and buffering it is what
-/// lets [`Decoder::get`] stop mid-vector and resume where it left off.
+/// served out of that buffer. Decoding a whole vector at once is what the format asks for -- the
+/// residuals are bit-packed as one run and the exceptions patched over the result -- and buffering
+/// it is what lets [`Decoder::get`] stop mid-vector and resume where it left off.
 pub struct PforDecoder<T: DataType> {
     /// The page, from its header on. `None` until [`Decoder::set_data`].
     data: Option<Bytes>,
@@ -89,7 +92,10 @@ where
         std::cmp::min(vector_size, self.header.num_elements as usize - start)
     }
 
-    /// Decode vector `index` into [`Self::vector`], replacing whatever it held.
+    /// Decode vector `index` into the decoder's buffer, replacing whatever it held.
+    ///
+    /// The work runs in the order the format lays the vector out: locate and check it, then
+    /// residuals, then exceptions, then -- for a differenced vector -- the running sum.
     fn decode_vector(&mut self, index: usize) -> Result<()> {
         let data = self
             .data
@@ -99,140 +105,51 @@ where
 
         // Offsets count from the start of the offset array, which follows the header.
         let payload = &data[HEADER_SIZE..];
-        let offset = read_offset(payload, index);
-        let src = &payload[offset..];
+        let vector_at = read_offset(payload, index);
+        let src = &payload[vector_at..];
 
-        let info = PforVectorInfo::<T::T>::read(src)?;
-        let info_bytes = info.stored_bytes();
-        if info_bytes > src.len() {
-            return Err(general_err!(
-                "PFOR delta vector needs {} bytes of metadata but only {} remain",
-                info_bytes,
-                src.len()
-            ));
-        }
-
-        // A differenced vector stores its own first value, which is what lets it decode without
-        // the vector before it -- the property the mode exists for.
-        let start_value = if info.is_delta {
-            T::T::read_le(&src[T::T::INFO_SIZE..])
-        } else {
-            T::T::default()
-        };
-
-        // Everything below is sized by fields that came off the wire, so check them against the
-        // vector's element count and against the bytes that remain before reading any of them.
-        if info.num_exceptions as usize > num_elements {
-            return Err(general_err!(
-                "PFOR vector has {} exceptions but only {} elements",
-                info.num_exceptions,
-                num_elements
-            ));
-        }
-        let packed_bytes = bytes_for_bits(num_elements * info.bit_width as usize);
-        let exception_bytes = info.num_exceptions as usize * (POSITION_SIZE + T::T::BYTE_WIDTH);
-        if info_bytes + packed_bytes + exception_bytes > src.len() {
-            return Err(general_err!(
-                "PFOR vector needs {} bytes but only {} remain",
-                info_bytes + packed_bytes + exception_bytes,
-                src.len()
-            ));
-        }
+        let layout = VectorLayout::read(src, num_elements)?;
+        let info = layout.info;
+        let frame = info.frame_of_reference;
 
         self.vector.clear();
         self.vector.resize(num_elements, T::T::default());
-        let frame_bits = info.frame_of_reference.to_bits();
 
         // A constant vector, which is the whole of what it stores.
         if info.bit_width == 0 && info.num_exceptions == 0 {
             if info.is_delta {
-                // Every difference is the frame, so the values step by it from the start value.
-                // Slot 0 always holds a difference of zero, so a frame other than zero cannot
-                // occur here, but the running sum reconstructs the sequence either way rather
-                // than assuming it.
-                let mut acc = start_value.to_bits();
-                for (i, slot) in self.vector.iter_mut().enumerate() {
-                    if i > 0 {
-                        acc = acc.wrapping_add(frame_bits);
-                    }
-                    *slot = T::T::from_bits(acc);
-                }
+                step_by(&mut self.vector, layout.start_value, frame);
             } else {
-                self.vector.fill(info.frame_of_reference);
+                self.vector.fill(frame);
             }
             return Ok(());
         }
 
-        // Unpack the residuals, then add the frame back. The add is modular in the unsigned
-        // domain, so the bits the unpacker wrote are the signed values once the frame is on them,
-        // exactly as the encoder produced them.
         if info.bit_width > 0 {
-            let packed_start = HEADER_SIZE + offset + info_bytes;
-            let mut reader = BitReader::new(data.slice(packed_start..packed_start + packed_bytes));
-            let unpacked = reader.get_batch(&mut self.vector, info.bit_width as usize);
-            if unpacked != num_elements {
-                return Err(general_err!(
-                    "PFOR vector unpacked {} of {} values",
-                    unpacked,
-                    num_elements
-                ));
-            }
-            if frame_bits != 0 {
-                for slot in &mut self.vector {
-                    *slot = T::T::from_bits(slot.to_bits().wrapping_add(frame_bits));
-                }
-            }
+            // Slice out of the page rather than out of `src`: BitReader wants an owned `Bytes`.
+            let packed_at = HEADER_SIZE + vector_at + layout.packed_at;
+            let packed = data.slice(packed_at..packed_at + layout.packed_bytes);
+            unpack_residuals(&mut self.vector, packed, info.bit_width, frame)?;
         } else {
             // Width zero with exceptions: every unpatched slot is the frame itself.
-            self.vector.fill(info.frame_of_reference);
+            self.vector.fill(frame);
         }
 
-        // Patch the exceptions in. They are stored as two arrays, positions then values, both at
-        // the end of the vector.
         if info.num_exceptions > 0 {
-            let num_exceptions = info.num_exceptions as usize;
-            let positions_at = info_bytes + packed_bytes;
-            let values_at = positions_at + num_exceptions * POSITION_SIZE;
-            let positions = &src[positions_at..values_at];
-            let values = &src[values_at..values_at + num_exceptions * T::T::BYTE_WIDTH];
-
-            // Every position indexes the vector, so one past its end would be an out-of-bounds
-            // write. Take the maximum first: a reduction still vectorizes, where a bounds check
-            // inside the patch loop would not.
-            let mut max_position = 0u16;
-            for i in 0..num_exceptions {
-                let at = i * POSITION_SIZE;
-                let position = u16::from_le_bytes([positions[at], positions[at + 1]]);
-                max_position = max_position.max(position);
-            }
-            if max_position as usize >= num_elements {
-                return Err(general_err!(
-                    "PFOR exception position {} is outside a vector of {} elements",
-                    max_position,
-                    num_elements
-                ));
-            }
-
-            for i in 0..num_exceptions {
-                let at = i * POSITION_SIZE;
-                let position = u16::from_le_bytes([positions[at], positions[at + 1]]) as usize;
-                // The exception carries whatever the packed stream carries: a value in a plain
-                // vector, a difference in a differenced one.
-                self.vector[position] = T::T::read_le(&values[i * T::T::BYTE_WIDTH..]);
-            }
+            patch_exceptions(
+                &mut self.vector,
+                &src[layout.positions_at..layout.values_at],
+                &src[layout.values_at..layout.values_end],
+            )?;
         }
 
         // In a differenced vector, everything above produced differences. Sum them.
         //
         // This has to come after the patch: an exception in a differenced vector is a difference
         // too, and summing before patching would carry the placeholder zero into every value that
-        // follows. The sum runs in the unsigned domain for the same reason the frame add does.
+        // follows.
         if info.is_delta {
-            let mut acc = start_value.to_bits();
-            for slot in &mut self.vector {
-                acc = acc.wrapping_add(slot.to_bits());
-                *slot = T::T::from_bits(acc);
-            }
+            accumulate(&mut self.vector, layout.start_value);
         }
 
         Ok(())
@@ -352,6 +269,164 @@ where
     }
 }
 
+/// Where the parts of one encoded vector sit, once their sizes have been checked.
+///
+/// Every field below is sized by numbers that came off the wire, so they are checked here --
+/// against the vector's element count and against the bytes that remain -- before anything reads
+/// through them. Offsets are relative to the start of the vector, not of the page.
+#[derive(Debug, Clone, Copy)]
+struct VectorLayout<V> {
+    info: PforVectorInfo<V>,
+    /// First value of a differenced vector, zero otherwise.
+    start_value: V,
+    packed_at: usize,
+    packed_bytes: usize,
+    positions_at: usize,
+    values_at: usize,
+    values_end: usize,
+}
+
+impl<V: PforInt> VectorLayout<V> {
+    fn read(src: &[u8], num_elements: usize) -> Result<Self> {
+        let info = PforVectorInfo::<V>::read(src)?;
+        let info_bytes = info.stored_bytes();
+        if info_bytes > src.len() {
+            return Err(general_err!(
+                "PFOR delta vector needs {} bytes of metadata but only {} remain",
+                info_bytes,
+                src.len()
+            ));
+        }
+
+        // A differenced vector stores its own first value, which is what lets it decode without
+        // the vector before it -- the property the mode exists for.
+        let start_value = if info.is_delta {
+            V::read_le(&src[V::INFO_SIZE..])
+        } else {
+            V::default()
+        };
+
+        if info.num_exceptions as usize > num_elements {
+            return Err(general_err!(
+                "PFOR vector has {} exceptions but only {} elements",
+                info.num_exceptions,
+                num_elements
+            ));
+        }
+
+        let num_exceptions = info.num_exceptions as usize;
+        let packed_bytes = bytes_for_bits(num_elements * info.bit_width as usize);
+        let positions_at = info_bytes + packed_bytes;
+        let values_at = positions_at + num_exceptions * POSITION_SIZE;
+        let values_end = values_at + num_exceptions * V::BYTE_WIDTH;
+        if values_end > src.len() {
+            return Err(general_err!(
+                "PFOR vector needs {} bytes but only {} remain",
+                values_end,
+                src.len()
+            ));
+        }
+
+        Ok(Self {
+            info,
+            start_value,
+            packed_at: info_bytes,
+            packed_bytes,
+            positions_at,
+            values_at,
+            values_end,
+        })
+    }
+}
+
+/// Unpack the residuals into `out` and add the frame back.
+///
+/// The add is modular in the unsigned domain, so the bits the unpacker wrote are the signed values
+/// once the frame is on them, exactly as the encoder produced them.
+fn unpack_residuals<V: PforInt>(
+    out: &mut [V],
+    packed: Bytes,
+    bit_width: u8,
+    frame: V,
+) -> Result<()> {
+    let mut reader = BitReader::new(packed);
+    let unpacked = reader.get_batch(out, bit_width as usize);
+    if unpacked != out.len() {
+        return Err(general_err!(
+            "PFOR vector unpacked {} of {} values",
+            unpacked,
+            out.len()
+        ));
+    }
+    let frame_bits = frame.to_bits();
+    if frame_bits != 0 {
+        for slot in out {
+            *slot = V::from_bits(slot.to_bits().wrapping_add(frame_bits));
+        }
+    }
+    Ok(())
+}
+
+/// Patch the exceptions over `out`, taking their positions and values from the two arrays that
+/// close the vector.
+///
+/// An exception carries whatever the packed stream carries: a value in a plain vector, a difference
+/// in a differenced one.
+fn patch_exceptions<V: PforInt>(out: &mut [V], positions: &[u8], values: &[u8]) -> Result<()> {
+    let num_exceptions = positions.len() / POSITION_SIZE;
+
+    // Every position indexes the vector, so one past its end would be an out-of-bounds write. Take
+    // the maximum first: a reduction still vectorizes, where a bounds check inside the patch loop
+    // would not.
+    let mut max_position = 0u16;
+    for i in 0..num_exceptions {
+        let at = i * POSITION_SIZE;
+        let position = u16::from_le_bytes([positions[at], positions[at + 1]]);
+        max_position = max_position.max(position);
+    }
+    if max_position as usize >= out.len() {
+        return Err(general_err!(
+            "PFOR exception position {} is outside a vector of {} elements",
+            max_position,
+            out.len()
+        ));
+    }
+
+    for i in 0..num_exceptions {
+        let at = i * POSITION_SIZE;
+        let position = u16::from_le_bytes([positions[at], positions[at + 1]]) as usize;
+        out[position] = V::read_le(&values[i * V::BYTE_WIDTH..]);
+    }
+    Ok(())
+}
+
+/// Turn the differences in `out` into values, starting from `start`.
+///
+/// The sum runs in the unsigned domain for the same reason the frame add does.
+fn accumulate<V: PforInt>(out: &mut [V], start: V) {
+    let mut acc = start.to_bits();
+    for slot in out {
+        acc = acc.wrapping_add(slot.to_bits());
+        *slot = V::from_bits(acc);
+    }
+}
+
+/// Fill `out` with the sequence that steps from `start` by `step`.
+///
+/// This is a differenced vector whose every difference is the frame. Slot 0 always holds a
+/// difference of zero, so a frame other than zero cannot occur here, but the running sum
+/// reconstructs the sequence either way rather than assuming it.
+fn step_by<V: PforInt>(out: &mut [V], start: V, step: V) {
+    let step_bits = step.to_bits();
+    let mut acc = start.to_bits();
+    for (i, slot) in out.iter_mut().enumerate() {
+        if i > 0 {
+            acc = acc.wrapping_add(step_bits);
+        }
+        *slot = V::from_bits(acc);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -393,6 +468,74 @@ mod tests {
             out.extend_from_slice(body);
         }
         out
+    }
+
+    // The four phases of `decode_vector` are exercised through whole pages below. These tests
+    // reach them directly, which is the only way to cover an argument no encoder of ours produces.
+
+    #[test]
+    fn test_patch_exceptions_writes_positions_and_values() {
+        let mut out = vec![0i32; 4];
+        let positions = [1u16, 3]
+            .iter()
+            .flat_map(|p| p.to_le_bytes())
+            .collect::<Vec<_>>();
+        let values = [-7i32, 9]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect::<Vec<_>>();
+        patch_exceptions(&mut out, &positions, &values).unwrap();
+        assert_eq!(out, vec![0, -7, 0, 9]);
+    }
+
+    #[test]
+    fn test_patch_exceptions_rejects_a_position_one_past_the_end() {
+        let mut out = vec![0i32; 4];
+        let err = patch_exceptions(&mut out, &4u16.to_le_bytes(), &0i32.to_le_bytes()).unwrap_err();
+        assert!(
+            err.to_string().contains("outside a vector of 4 elements"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn test_accumulate_sums_differences_and_wraps_at_the_type_width() {
+        let mut out = vec![0i32, 5, -2, 7];
+        accumulate(&mut out, 10);
+        assert_eq!(out, vec![10, 15, 13, 20]);
+
+        // A sum past the type's range wraps, matching what the encoder differenced.
+        let mut out = vec![0i32, 1];
+        accumulate(&mut out, i32::MAX);
+        assert_eq!(out, vec![i32::MAX, i32::MIN]);
+    }
+
+    #[test]
+    fn test_step_by_reconstructs_a_constant_delta_vector() {
+        let mut out = vec![0i64; 4];
+        step_by(&mut out, 100, 7);
+        assert_eq!(out, vec![100, 107, 114, 121]);
+
+        // The legal case: every difference is zero, so the vector is constant.
+        let mut out = vec![0i64; 3];
+        step_by(&mut out, -5, 0);
+        assert_eq!(out, vec![-5, -5, -5]);
+    }
+
+    #[test]
+    fn test_unpack_residuals_adds_the_frame_back() {
+        // Four 4-bit residuals 1, 2, 3, 4 over a frame of 1000.
+        let packed = Bytes::from(vec![0x21u8, 0x43]);
+        let mut out = vec![0i32; 4];
+        unpack_residuals(&mut out, packed, 4, 1000).unwrap();
+        assert_eq!(out, vec![1001, 1002, 1003, 1004]);
+    }
+
+    #[test]
+    fn test_unpack_residuals_rejects_a_buffer_that_runs_short() {
+        let mut out = vec![0i32; 8];
+        let err = unpack_residuals(&mut out, Bytes::from(vec![0u8]), 4, 0).unwrap_err();
+        assert!(err.to_string().contains("unpacked 2 of 8 values"), "{err}");
     }
 
     #[test]

--- a/parquet/src/encodings/decoding/pfor_decoder.rs
+++ b/parquet/src/encodings/decoding/pfor_decoder.rs
@@ -266,7 +266,7 @@ where
         // it is what the decoder reads. `num_values` is the level count when a V1 page does not
         // give a value count of its own, and that includes nulls, which PFOR does not store -- so
         // the two are equal only for a required column. What cannot happen either way is a page
-        // claiming more values than there are levels to put them in.
+        // claiming more values than the levels leave room for.
         if header.num_elements as usize > num_values {
             return Err(general_err!(
                 "PFOR header element count {} exceeds the {} values the page has room for",
@@ -494,7 +494,7 @@ mod tests {
     #[test]
     fn test_decode_delta_vector_at_width_zero() {
         // A constant difference needs no residuals at all: the values are the start value plus the
-        // frame, stepped. This is the fast path in the decoder, so it gets a page of its own.
+        // frame, stepped. That skip is the decoder's fast path, so it gets a page of its own.
         #[rustfmt::skip]
         let vector = vec![
             0x03, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, // frame 3, width 0 with the delta flag
@@ -617,8 +617,8 @@ mod tests {
 
     #[test]
     fn test_set_data_rejects_more_elements_than_the_page_has_room_for() {
-        // The header claims eight values where the caller knows there are four. Believing it would
-        // hand out values built from whatever follows.
+        // The header claims eight values where the caller knows of four. Believing it would hand
+        // out values built from whatever follows.
         let mut page = page(3, 4, 8, &[vec![0u8; 7]]);
         page[3] = 8;
         let mut decoder = PforDecoder::<Int32Type>::new();

--- a/parquet/src/encodings/decoding/pfor_decoder.rs
+++ b/parquet/src/encodings/decoding/pfor_decoder.rs
@@ -25,8 +25,9 @@ use super::Decoder;
 use crate::basic::Encoding;
 use crate::data_type::DataType;
 use crate::encodings::pfor::{
-    DEFAULT_LOG_VECTOR_SIZE, HEADER_SIZE, OFFSET_SIZE, PACKING_MODE_FOR_BIT_PACK, POSITION_SIZE,
-    PforHeader, PforInt, PforVectorInfo, bytes_for_bits, read_offset, validate_offsets,
+    DEFAULT_LOG_VECTOR_SIZE, DEFAULT_VECTOR_SIZE, HEADER_SIZE, OFFSET_SIZE, PACKING_MODE_FASTLANES,
+    PACKING_MODE_FOR_BIT_PACK, POSITION_SIZE, PforHeader, PforInt, PforVectorInfo, bytes_for_bits,
+    read_offset, validate_offsets,
 };
 use crate::errors::{ParquetError, Result};
 use crate::util::bit_util::BitReader;
@@ -129,7 +130,11 @@ where
             // Slice out of the page rather than out of `src`: BitReader wants an owned `Bytes`.
             let packed_at = HEADER_SIZE + vector_at + layout.packed_at;
             let packed = data.slice(packed_at..packed_at + layout.packed_bytes);
-            unpack_residuals(&mut self.vector, packed, info.bit_width, frame)?;
+            if self.header.packing_mode == PACKING_MODE_FASTLANES {
+                unpack_fastlanes_residuals(&mut self.vector, packed, info.bit_width, frame)?;
+            } else {
+                unpack_residuals(&mut self.vector, packed, info.bit_width, frame)?;
+            }
         } else {
             // Width zero with exceptions: every unpatched slot is the frame itself.
             self.vector.fill(frame);
@@ -372,6 +377,33 @@ fn unpack_residuals<V: PforInt>(
         for slot in out {
             *slot = V::from_bits(slot.to_bits().wrapping_add(frame_bits));
         }
+    }
+    Ok(())
+}
+
+/// Complete blocks use the byte-oriented FastLanes kernel. The remaining
+/// elements use the original format, so a short final vector needs no padding.
+fn unpack_fastlanes_residuals<V: PforInt>(
+    out: &mut [V],
+    packed: Bytes,
+    bit_width: u8,
+    frame: V,
+) -> Result<()> {
+    let block_bytes = DEFAULT_VECTOR_SIZE * bit_width as usize / 8;
+    let mut offset = 0;
+    let mut blocks = out.chunks_exact_mut(DEFAULT_VECTOR_SIZE);
+    for block in &mut blocks {
+        V::unpack_fastlanes(
+            bit_width as usize,
+            &packed[offset..offset + block_bytes],
+            frame,
+            block,
+        );
+        offset += block_bytes;
+    }
+    let tail = blocks.into_remainder();
+    if !tail.is_empty() {
+        unpack_residuals(tail, packed.slice(offset..), bit_width, frame)?;
     }
     Ok(())
 }

--- a/parquet/src/encodings/decoding/pfor_decoder.rs
+++ b/parquet/src/encodings/decoding/pfor_decoder.rs
@@ -26,8 +26,8 @@ use crate::basic::Encoding;
 use crate::data_type::DataType;
 use crate::encodings::pfor::{
     DEFAULT_LOG_VECTOR_SIZE, DEFAULT_VECTOR_SIZE, HEADER_SIZE, OFFSET_SIZE, PACKING_MODE_FASTLANES,
-    PACKING_MODE_FOR_BIT_PACK, POSITION_SIZE, PforHeader, PforInt, PforVectorInfo, bytes_for_bits,
-    read_offset, validate_offsets,
+    PACKING_MODE_FASTLANES_DELTA, PACKING_MODE_FOR_BIT_PACK, POSITION_SIZE, PforHeader, PforInt,
+    PforVectorInfo, bytes_for_bits, delta_start_count, read_offset, validate_offsets,
 };
 use crate::errors::{ParquetError, Result};
 use crate::util::bit_util::BitReader;
@@ -109,12 +109,28 @@ where
         let vector_at = read_offset(payload, index);
         let src = &payload[vector_at..];
 
-        let layout = VectorLayout::read(src, num_elements)?;
+        let layout = VectorLayout::read(src, num_elements, self.header.packing_mode)?;
         let info = layout.info;
         let frame = info.frame_of_reference;
+        let utl_delta = self.header.packing_mode == PACKING_MODE_FASTLANES_DELTA && info.is_delta;
 
         self.vector.clear();
         self.vector.resize(num_elements, T::T::default());
+
+        // With no patches, unpacking, frame addition, and the independent lane
+        // sums are fused. A partial block retains a scalar sum of its own.
+        if utl_delta && info.num_exceptions == 0 {
+            let packed_at = HEADER_SIZE + vector_at + layout.packed_at;
+            let packed = data.slice(packed_at..packed_at + layout.packed_bytes);
+            unpack_utl_delta(
+                &mut self.vector,
+                packed,
+                info.bit_width,
+                frame,
+                &src[T::T::INFO_SIZE..layout.packed_at],
+            )?;
+            return Ok(());
+        }
 
         // A constant vector, which is the whole of what it stores.
         if info.bit_width == 0 && info.num_exceptions == 0 {
@@ -130,7 +146,10 @@ where
             // Slice out of the page rather than out of `src`: BitReader wants an owned `Bytes`.
             let packed_at = HEADER_SIZE + vector_at + layout.packed_at;
             let packed = data.slice(packed_at..packed_at + layout.packed_bytes);
-            if self.header.packing_mode == PACKING_MODE_FASTLANES {
+            if matches!(
+                self.header.packing_mode,
+                PACKING_MODE_FASTLANES | PACKING_MODE_FASTLANES_DELTA
+            ) {
                 unpack_fastlanes_residuals(&mut self.vector, packed, info.bit_width, frame)?;
             } else {
                 unpack_residuals(&mut self.vector, packed, info.bit_width, frame)?;
@@ -153,7 +172,18 @@ where
         // This has to come after the patch: an exception in a differenced vector is a difference
         // too, and summing before patching would carry the placeholder zero into every value that
         // follows.
-        if info.is_delta {
+        if utl_delta {
+            let starts = &src[T::T::INFO_SIZE..layout.packed_at];
+            let mut blocks = self.vector.chunks_exact_mut(DEFAULT_VECTOR_SIZE);
+            for (block, out) in blocks.by_ref().enumerate() {
+                T::T::restore_fastlanes_delta(&starts[block * 128..][..128], out);
+            }
+            let tail = blocks.into_remainder();
+            if !tail.is_empty() {
+                let at = num_elements / DEFAULT_VECTOR_SIZE * 128;
+                accumulate(tail, T::T::read_le(&starts[at..]));
+            }
+        } else if info.is_delta {
             accumulate(&mut self.vector, layout.start_value);
         }
 
@@ -292,9 +322,13 @@ struct VectorLayout<V> {
 }
 
 impl<V: PforInt> VectorLayout<V> {
-    fn read(src: &[u8], num_elements: usize) -> Result<Self> {
+    fn read(src: &[u8], num_elements: usize, packing_mode: u8) -> Result<Self> {
         let info = PforVectorInfo::<V>::read(src)?;
-        let info_bytes = info.stored_bytes();
+        let info_bytes = if info.is_delta {
+            V::INFO_SIZE + delta_start_count::<V>(packing_mode, num_elements) * V::BYTE_WIDTH
+        } else {
+            info.stored_bytes()
+        };
         if info_bytes > src.len() {
             return Err(general_err!(
                 "PFOR delta vector needs {} bytes of metadata but only {} remain",
@@ -381,8 +415,43 @@ fn unpack_residuals<V: PforInt>(
     Ok(())
 }
 
-/// Complete blocks use the byte-oriented FastLanes kernel. The remaining
-/// elements use the original format, so a short final vector needs no padding.
+/// Fuse unpacking and lane sums for unpatched blocks, then restore original
+/// order. Each partial block has its own scalar delta start.
+fn unpack_utl_delta<V: PforInt>(
+    out: &mut [V],
+    packed: Bytes,
+    bit_width: u8,
+    frame: V,
+    starts: &[u8],
+) -> Result<()> {
+    let block_bytes = DEFAULT_VECTOR_SIZE * bit_width as usize / 8;
+    let mut packed_at = 0;
+    let mut starts_at = 0;
+    let mut blocks = out.chunks_exact_mut(DEFAULT_VECTOR_SIZE);
+    for block in &mut blocks {
+        V::unpack_fastlanes_delta(
+            bit_width as usize,
+            &packed[packed_at..packed_at + block_bytes],
+            frame,
+            &starts[starts_at..starts_at + 128],
+            block,
+        );
+        packed_at += block_bytes;
+        starts_at += 128;
+    }
+    let tail = blocks.into_remainder();
+    if !tail.is_empty() {
+        if bit_width == 0 {
+            tail.fill(frame);
+        } else {
+            unpack_residuals(tail, packed.slice(packed_at..), bit_width, frame)?;
+        }
+        accumulate(tail, V::read_le(&starts[starts_at..]));
+    }
+    Ok(())
+}
+
+/// Complete blocks use FastLanes; a short final block needs no padding.
 fn unpack_fastlanes_residuals<V: PforInt>(
     out: &mut [V],
     packed: Bytes,
@@ -513,6 +582,76 @@ mod tests {
 
     // The four phases of `decode_vector` are exercised through whole pages below. These tests
     // reach them directly, which is the only way to cover an argument no encoder of ours produces.
+
+    #[test]
+    fn test_utl_delta_literal_starts_patches_and_tail() {
+        fn check<T: DataType>()
+        where
+            T::T: PforInt,
+        {
+            let rows = T::T::MAX_BIT_WIDTH as usize;
+            for patched in [false, true] {
+                let mut body = Vec::new();
+                PforVectorInfo::<T::T> {
+                    frame_of_reference: T::T::from_bits(3),
+                    bit_width: 0,
+                    num_exceptions: u16::from(patched),
+                    is_delta: true,
+                }
+                .write(&mut body);
+                let mut expected = Vec::new();
+                for lane in 0..1024 / rows {
+                    let start = (lane as u64 * 1000).wrapping_add(u64::MAX - 500);
+                    T::T::from_bits(start).write_le(&mut body);
+                    for row in 0..rows {
+                        // Position 263 is row 2, lane 7 in UTL. Only this lane's
+                        // suffix receives the patch, not adjacent output lanes.
+                        let extra = if patched && lane == 7 && row >= 2 {
+                            96
+                        } else {
+                            0
+                        };
+                        expected.push(T::T::from_bits(
+                            start.wrapping_add((row as u64 + 1) * 3 + extra),
+                        ));
+                    }
+                }
+                T::T::from_bits(777).write_le(&mut body);
+                expected.extend((1..=7).map(|i| T::T::from_bits(777 + i * 3)));
+                if patched {
+                    body.extend_from_slice(&263u16.to_le_bytes());
+                    T::T::from_bits(99).write_le(&mut body);
+                }
+                let mut encoded = page(11, T::T::BYTE_WIDTH as u8, 1031, &[body]);
+                encoded[0] = PACKING_MODE_FASTLANES_DELTA;
+                let mut decoder = PforDecoder::<T>::new();
+                decoder.set_data(encoded.into(), 1031).unwrap();
+                let mut out = vec![T::T::default(); 1031];
+                assert_eq!(decoder.get(&mut out).unwrap(), 1031);
+                assert_eq!(out, expected);
+            }
+            // In particular, a scalar-sized start field is insufficient for a
+            // full UTL block. Reject every truncated lane-start array.
+            for bytes in 0..128 {
+                let mut body = Vec::new();
+                PforVectorInfo::<T::T> {
+                    frame_of_reference: T::T::default(),
+                    bit_width: 0,
+                    num_exceptions: 0,
+                    is_delta: true,
+                }
+                .write(&mut body);
+                body.resize(body.len() + bytes, 0);
+                let mut encoded = page(10, T::T::BYTE_WIDTH as u8, 1024, &[body]);
+                encoded[0] = PACKING_MODE_FASTLANES_DELTA;
+                let mut decoder = PforDecoder::<T>::new();
+                decoder.set_data(encoded.into(), 1024).unwrap();
+                assert!(decoder.get(&mut [T::T::default(); 1024]).is_err());
+            }
+        }
+        check::<Int32Type>();
+        check::<Int64Type>();
+    }
 
     #[test]
     fn test_patch_exceptions_writes_positions_and_values() {

--- a/parquet/src/encodings/encoding/mod.rs
+++ b/parquet/src/encodings/encoding/mod.rs
@@ -34,6 +34,9 @@ pub use dict_encoder::DictEncoder;
 
 mod byte_stream_split_encoder;
 mod dict_encoder;
+mod pfor_encoder;
+
+pub use pfor_encoder::PforEncoder;
 
 // ----------------------------------------------------------------------
 // Encoders
@@ -85,27 +88,95 @@ pub fn get_encoder<T: DataType>(
     encoding: Encoding,
     descr: &ColumnDescPtr,
 ) -> Result<Box<dyn Encoder<T>>> {
-    let encoder: Box<dyn Encoder<T>> = match encoding {
-        Encoding::PLAIN => Box::new(PlainEncoder::new()),
-        Encoding::RLE_DICTIONARY | Encoding::PLAIN_DICTIONARY => {
-            return Err(general_err!(
-                "Cannot initialize this encoding through this function"
-            ));
+    use self::private::GetEncoder;
+    T::T::get_encoder(encoding, descr)
+}
+
+pub(crate) mod private {
+    use super::*;
+
+    /// A trait that allows getting an [`Encoder`] implementation for a [`DataType`] with the
+    /// corresponding [`ParquetValueType`]. This is necessary to support [`Encoder`]
+    /// implementations that are not applicable to every [`DataType`], and by extension not to
+    /// every [`ParquetValueType`].
+    ///
+    /// The mirror of [`crate::encodings::decoding::private::GetDecoder`], and introduced for the
+    /// same reason: a flat `match` on [`Encoding`] alone cannot express "this encoding exists
+    /// only for these physical types", so an encoding so restricted has to dispatch on the value
+    /// type first and the encoding second.
+    pub trait GetEncoder {
+        fn get_encoder<T: DataType<T = Self>>(
+            encoding: Encoding,
+            descr: &ColumnDescPtr,
+        ) -> Result<Box<dyn Encoder<T>>> {
+            get_encoder_default(encoding, descr)
         }
-        Encoding::RLE => Box::new(RleValueEncoder::new()),
-        Encoding::DELTA_BINARY_PACKED => Box::new(DeltaBitPackEncoder::new()),
-        Encoding::DELTA_LENGTH_BYTE_ARRAY => Box::new(DeltaLengthByteArrayEncoder::new()),
-        Encoding::DELTA_BYTE_ARRAY => Box::new(DeltaByteArrayEncoder::new()),
-        Encoding::BYTE_STREAM_SPLIT => match T::get_physical_type() {
-            Type::FIXED_LEN_BYTE_ARRAY => Box::new(VariableWidthByteStreamSplitEncoder::new(
-                descr.type_length(),
-            )),
-            _ => Box::new(ByteStreamSplitEncoder::new()),
-        },
-        #[expect(deprecated, reason = "BIT_PACKED is the encoding we reject here")]
-        e @ Encoding::BIT_PACKED => return Err(nyi_err!("Encoding {} is not supported", e)),
-    };
-    Ok(encoder)
+    }
+
+    fn get_encoder_default<T: DataType>(
+        encoding: Encoding,
+        descr: &ColumnDescPtr,
+    ) -> Result<Box<dyn Encoder<T>>> {
+        let encoder: Box<dyn Encoder<T>> = match encoding {
+            Encoding::PLAIN => Box::new(PlainEncoder::new()),
+            Encoding::RLE_DICTIONARY | Encoding::PLAIN_DICTIONARY => {
+                return Err(general_err!(
+                    "Cannot initialize this encoding through this function"
+                ));
+            }
+            Encoding::RLE => Box::new(RleValueEncoder::new()),
+            Encoding::DELTA_BINARY_PACKED => Box::new(DeltaBitPackEncoder::new()),
+            Encoding::DELTA_LENGTH_BYTE_ARRAY => Box::new(DeltaLengthByteArrayEncoder::new()),
+            Encoding::DELTA_BYTE_ARRAY => Box::new(DeltaByteArrayEncoder::new()),
+            Encoding::BYTE_STREAM_SPLIT => match T::get_physical_type() {
+                Type::FIXED_LEN_BYTE_ARRAY => Box::new(VariableWidthByteStreamSplitEncoder::new(
+                    descr.type_length(),
+                )),
+                _ => Box::new(ByteStreamSplitEncoder::new()),
+            },
+            Encoding::PFOR => {
+                return Err(general_err!(
+                    "Encoding {} is not supported for type",
+                    encoding
+                ));
+            }
+            #[expect(deprecated, reason = "BIT_PACKED is the encoding we reject here")]
+            e @ Encoding::BIT_PACKED => return Err(nyi_err!("Encoding {} is not supported", e)),
+        };
+        Ok(encoder)
+    }
+
+    impl GetEncoder for bool {}
+
+    impl GetEncoder for i32 {
+        fn get_encoder<T: DataType<T = Self>>(
+            encoding: Encoding,
+            descr: &ColumnDescPtr,
+        ) -> Result<Box<dyn Encoder<T>>> {
+            match encoding {
+                Encoding::PFOR => Ok(Box::new(PforEncoder::new())),
+                _ => get_encoder_default(encoding, descr),
+            }
+        }
+    }
+
+    impl GetEncoder for i64 {
+        fn get_encoder<T: DataType<T = Self>>(
+            encoding: Encoding,
+            descr: &ColumnDescPtr,
+        ) -> Result<Box<dyn Encoder<T>>> {
+            match encoding {
+                Encoding::PFOR => Ok(Box::new(PforEncoder::new())),
+                _ => get_encoder_default(encoding, descr),
+            }
+        }
+    }
+
+    impl GetEncoder for f32 {}
+    impl GetEncoder for f64 {}
+    impl GetEncoder for ByteArray {}
+    impl GetEncoder for FixedLenByteArray {}
+    impl GetEncoder for Int96 {}
 }
 
 // ----------------------------------------------------------------------

--- a/parquet/src/encodings/encoding/pfor_encoder.rs
+++ b/parquet/src/encodings/encoding/pfor_encoder.rs
@@ -210,8 +210,8 @@ fn choose_frame_and_width<T: PforInt>(values: &[T], bounds: MinMax<T>) -> FrameC
     }
 
     // Slide a `2^w`-wide window over the buckets and keep the position that costs least. Widths
-    // below the bucket size cannot be resolved at this granularity, and once one window spans every
-    // bucket there are no exceptions left to remove, so the loop covers only the
+    // below the bucket size cannot be resolved at this granularity, and a window spanning every
+    // bucket has no exceptions left to remove, so the loop covers only the
     // `FRAME_SEARCH_BITS`-odd widths in between -- fixed work, and none of it touching the data
     // again.
     //
@@ -314,7 +314,7 @@ fn choose_frame_and_width<T: PforInt>(values: &[T], bounds: MinMax<T>) -> FrameC
 ///
 /// # Panics
 ///
-/// Panics on an empty slice: there is no frame of reference for an empty vector.
+/// Panics on an empty slice: an empty vector has no frame of reference.
 fn min_max<T: PforInt>(values: &[T]) -> MinMax<T> {
     let mut bounds = MinMax {
         min: values[0],

--- a/parquet/src/encodings/encoding/pfor_encoder.rs
+++ b/parquet/src/encodings/encoding/pfor_encoder.rs
@@ -660,10 +660,8 @@ where
         };
         let num_vectors = header.num_vectors();
 
-        let mut out = Vec::with_capacity(max_compressed_size::<T::T>(
-            num_values,
-            self.vector_size,
-        )?);
+        let mut out =
+            Vec::with_capacity(max_compressed_size::<T::T>(num_values, self.vector_size)?);
         header.write(&mut out);
 
         // The offset array is reserved now and filled in as each vector is written. An all-null
@@ -764,19 +762,27 @@ mod tests {
                     })
                     .collect(),
             ),
-            (
-                "random",
-                (0..1000).map(|_| rng.next() as i32).collect(),
-            ),
+            ("random", (0..1000).map(|_| rng.next() as i32).collect()),
             (
                 "small random",
                 (0..1000).map(|_| (rng.next() % 256) as i32).collect(),
             ),
-            ("extremes", vec![i32::MIN, i32::MAX, 0, -1, 1, i32::MIN, i32::MAX]),
+            (
+                "extremes",
+                vec![i32::MIN, i32::MAX, 0, -1, 1, i32::MIN, i32::MAX],
+            ),
             // A vector whose span covers the whole type, so the residuals need every bit.
             (
                 "full span",
-                (0..64).map(|i| if i % 2 == 0 { i32::MIN + i } else { i32::MAX - i }).collect(),
+                (0..64)
+                    .map(|i| {
+                        if i % 2 == 0 {
+                            i32::MIN + i
+                        } else {
+                            i32::MAX - i
+                        }
+                    })
+                    .collect(),
             ),
             ("sawtooth", (0..1000).map(|i| (i % 37) * 3).collect()),
             // Steps: long runs of one value, which differencing turns into runs of zero.
@@ -807,7 +813,15 @@ mod tests {
             ("extremes", vec![i64::MIN, i64::MAX, 0, -1, 1]),
             (
                 "full span",
-                (0..64).map(|i| if i % 2 == 0 { i64::MIN + i } else { i64::MAX - i }).collect(),
+                (0..64)
+                    .map(|i| {
+                        if i % 2 == 0 {
+                            i64::MIN + i
+                        } else {
+                            i64::MAX - i
+                        }
+                    })
+                    .collect(),
             ),
         ];
 
@@ -832,7 +846,11 @@ mod tests {
         // One vector per width, built so the planner has to choose that width: values spanning
         // exactly `w` bits with nothing to gain from a frame or from differencing.
         for w in 1..=32u32 {
-            let span: u64 = if w == 32 { u32::MAX as u64 } else { (1u64 << w) - 1 };
+            let span: u64 = if w == 32 {
+                u32::MAX as u64
+            } else {
+                (1u64 << w) - 1
+            };
             let values: Vec<i32> = (0..64)
                 .map(|i| ((i as u64 * 2_654_435_761) % (span + 1)) as u32 as i32)
                 .collect();
@@ -868,7 +886,10 @@ mod tests {
         assert_eq!(info.frame_of_reference, 777);
         assert!(!info.is_delta);
         // Header, one offset, and an info block holding the value: nothing else is needed.
-        assert_eq!(page.len(), HEADER_SIZE + OFFSET_SIZE + <i32 as PforInt>::INFO_SIZE);
+        assert_eq!(
+            page.len(),
+            HEADER_SIZE + OFFSET_SIZE + <i32 as PforInt>::INFO_SIZE
+        );
     }
 
     #[test]
@@ -1050,9 +1071,7 @@ mod tests {
 
     #[test]
     fn test_encoder_is_reusable_after_a_flush() {
-        let mut encoder = PforEncoder::<Int32Type>::new()
-            .with_vector_size(8)
-            .unwrap();
+        let mut encoder = PforEncoder::<Int32Type>::new().with_vector_size(8).unwrap();
 
         let first: Vec<i32> = (0..20).collect();
         encoder.put(&first).unwrap();
@@ -1075,9 +1094,7 @@ mod tests {
 
     #[test]
     fn test_put_accumulates_across_calls() {
-        let mut encoder = PforEncoder::<Int32Type>::new()
-            .with_vector_size(8)
-            .unwrap();
+        let mut encoder = PforEncoder::<Int32Type>::new().with_vector_size(8).unwrap();
         let values: Vec<i32> = (0..20).collect();
         for chunk in values.chunks(3) {
             encoder.put(chunk).unwrap();
@@ -1105,9 +1122,17 @@ mod tests {
 
     #[test]
     fn test_rejects_a_vector_size_the_header_cannot_describe() {
-        assert!(PforEncoder::<Int32Type>::new().with_vector_size(1000).is_err());
+        assert!(
+            PforEncoder::<Int32Type>::new()
+                .with_vector_size(1000)
+                .is_err()
+        );
         assert!(PforEncoder::<Int32Type>::new().with_vector_size(4).is_err());
-        assert!(PforEncoder::<Int32Type>::new().with_vector_size(1 << 16).is_err());
+        assert!(
+            PforEncoder::<Int32Type>::new()
+                .with_vector_size(1 << 16)
+                .is_err()
+        );
         assert!(PforEncoder::<Int32Type>::new().with_vector_size(8).is_ok());
     }
 
@@ -1195,8 +1220,8 @@ mod tests {
         // shape whose vectors do not all plan the same way.
         let values: Vec<i32> = (0..10_000i32)
             .map(|i| match i / 8 % 3 {
-                0 => i,               // a ramp
-                1 => 500,             // a constant
+                0 => i,                                  // a ramp
+                1 => 500,                                // a constant
                 _ => (i.wrapping_mul(2_654_435)) % 1024, // scattered
             })
             .collect();

--- a/parquet/src/encodings/encoding/pfor_encoder.rs
+++ b/parquet/src/encodings/encoding/pfor_encoder.rs
@@ -30,9 +30,12 @@ use bytes::Bytes;
 use super::Encoder;
 use crate::basic::Encoding;
 use crate::data_type::DataType;
-use crate::encodings::pfor::*;
+use crate::encodings::pfor::{
+    DEFAULT_VECTOR_SIZE, MAX_VECTOR_SIZE, OFFSET_SIZE, PACKING_MODE_FOR_BIT_PACK, PforHeader,
+    PforInt, PforVectorInfo, exception_bits, low_mask, max_compressed_size, validate_vector_size,
+};
 use crate::errors::{ParquetError, Result};
-use crate::util::bit_util::BitWriter;
+use crate::util::bit_util::{BitWriter, num_required_bits};
 
 /// Buckets used by the frame search, as a shift and as a count.
 ///
@@ -57,11 +60,11 @@ fn build_offset_histogram<T: PforInt>(values: &[T], frame: T, out: &mut [i32; 65
     let mut chunks = values.chunks_exact(4);
     for chunk in &mut chunks {
         for (lane, value) in chunk.iter().enumerate() {
-            h[lane][bits_required(value.residual_from(frame_bits)) as usize] += 1;
+            h[lane][num_required_bits(value.residual_from(frame_bits)) as usize] += 1;
         }
     }
     for value in chunks.remainder() {
-        h[0][bits_required(value.residual_from(frame_bits)) as usize] += 1;
+        h[0][num_required_bits(value.residual_from(frame_bits)) as usize] += 1;
     }
     for b in 0..=64 {
         out[b] = h[0][b] + h[1][b] + h[2][b] + h[3][b];
@@ -84,7 +87,7 @@ fn best_width_from_histogram<T: PforInt>(histogram: &[i32; 65], num_elements: us
     for b in 0..=max_bits {
         exceptions_above -= histogram[b as usize] as i64;
 
-        // A vector holds at most `MAX_VECTOR_SIZE` elements, so that is also the most exceptions one
+        // A vector holds at most `MAX_VECTOR_SIZE` elements, so that is also the most exceptions
         // can name. The full-width candidate has none at all, so a best is always found.
         if exceptions_above > MAX_VECTOR_SIZE as i64 {
             continue;
@@ -119,7 +122,7 @@ fn build_frame_search_histograms<T: PforInt>(
     let mut h = [[0i32; 65]; 4];
     for (i, value) in values.iter().enumerate() {
         let offset = value.residual_from(frame_bits);
-        h[i & 3][bits_required(offset) as usize] += 1;
+        h[i & 3][num_required_bits(offset) as usize] += 1;
         buckets[(offset >> shift) as usize] += 1;
     }
     for b in 0..=64 {
@@ -177,7 +180,7 @@ fn choose_frame_and_width<T: PforInt>(values: &[T], bounds: MinMax<T>) -> FrameC
         };
     }
 
-    let range_bits = bits_required(range) as u32;
+    let range_bits = num_required_bits(range) as u32;
     let shift = range_bits.saturating_sub(FRAME_SEARCH_BITS);
 
     // One walk serves both halves of the search: the bit-width histogram costs the minimum as a
@@ -401,7 +404,7 @@ fn estimate_delta_cost_bits<T: PforInt>(values: &[T]) -> i64 {
     let mut i = stride;
     while i < num_elements {
         let d = T::from_bits(values[i].to_bits().wrapping_sub(values[i - 1].to_bits()));
-        h[sampled & 3][bits_required(zigzag(d)) as usize] += 1;
+        h[sampled & 3][num_required_bits(zigzag(d)) as usize] += 1;
         sampled += 1;
         i += stride;
     }
@@ -691,6 +694,9 @@ mod tests {
     use super::*;
     use crate::data_type::{Int32Type, Int64Type};
     use crate::encodings::decoding::{Decoder, PforDecoder};
+    use crate::encodings::pfor::{
+        HEADER_SIZE, MAX_LOG_VECTOR_SIZE, MIN_LOG_VECTOR_SIZE, read_offset,
+    };
 
     /// Encode then decode, asserting the values survive and reporting the page.
     fn round_trip<T: DataType>(values: &[T::T], vector_size: usize) -> Bytes
@@ -1195,7 +1201,7 @@ mod tests {
 
     #[test]
     fn test_build_offset_histogram_wraps_below_the_frame() {
-        // A value below the frame lands in the top bin rather than in a low one, which is what makes
+        // A value below the frame lands in the top bin rather than in a low one, which is what
         // it fail the width test and become a patch.
         let mut histogram = [0i32; 65];
         build_offset_histogram(&[10i32, 11, 9], 10, &mut histogram);

--- a/parquet/src/encodings/encoding/pfor_encoder.rs
+++ b/parquet/src/encodings/encoding/pfor_encoder.rs
@@ -1,0 +1,1207 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! PFOR encoder. See [`crate::encodings::pfor`] for the wire format.
+//!
+//! The encoder decides three things per vector, and most of this file is the search over them:
+//!
+//!   1. whether to difference the values first,
+//!   2. the frame of reference, which is not required to be the minimum,
+//!   3. the bit width, from a histogram cost model.
+
+use std::marker::PhantomData;
+
+use bytes::Bytes;
+
+use super::Encoder;
+use crate::basic::Encoding;
+use crate::data_type::DataType;
+use crate::encodings::pfor::*;
+use crate::errors::{ParquetError, Result};
+use crate::util::bit_util::BitWriter;
+
+/// Buckets used by the frame search, as a shift and as a count.
+///
+/// 256 keeps the scan in [`choose_frame_and_width`] at roughly two passes' worth of work over a
+/// 1024-value vector.
+const FRAME_SEARCH_BITS: u32 = 8;
+const FRAME_SEARCH_BUCKETS: usize = 1 << FRAME_SEARCH_BITS;
+
+/// Histogram of the bit widths needed by `values` reduced by `frame`.
+///
+/// `out[b]` counts the residuals that need exactly `b` bits. The subtraction is modular, so a value
+/// below the frame wraps to a huge residual and lands in the top bin -- which is what makes a frame
+/// above the minimum work at all: below-frame values are counted as exceptions here and then
+/// patched on the way out, with no separate sign or direction to track.
+fn build_offset_histogram<T: PforInt>(values: &[T], frame: T, out: &mut [i32; 65]) {
+    let frame_bits = frame.to_bits();
+    // Four independent accumulators so repeated bins do not serialize the read-modify-write and the
+    // load/count-leading-zeros/bump chains overlap. This loop is about half of encode time; a
+    // single array runs scalar and stalls on any column whose residuals share a width, which is
+    // most of them.
+    let mut h = [[0i32; 65]; 4];
+    let mut chunks = values.chunks_exact(4);
+    for chunk in &mut chunks {
+        for (lane, value) in chunk.iter().enumerate() {
+            h[lane][bits_required(value.residual_from(frame_bits)) as usize] += 1;
+        }
+    }
+    for value in chunks.remainder() {
+        h[0][bits_required(value.residual_from(frame_bits)) as usize] += 1;
+    }
+    for b in 0..=64 {
+        out[b] = h[0][b] + h[1][b] + h[2][b] + h[3][b];
+    }
+}
+
+/// Pick the width that minimises packed bits plus exception bits.
+///
+/// Returns the width and its cost in bits. The width is what the caller needs; the exception count
+/// is not returned because the pass that writes the vector out recomputes it from the mask, and one
+/// count on the wire is better than two that could ever disagree.
+fn best_width_from_histogram<T: PforInt>(histogram: &[i32; 65], num_elements: usize) -> (u8, i64) {
+    let max_bits = T::MAX_BIT_WIDTH;
+    let exception_cost = exception_bits(T::BYTE_WIDTH);
+
+    let mut best_cost = i64::MAX;
+    let mut best_width = max_bits;
+
+    let mut exceptions_above = num_elements as i64;
+    for b in 0..=max_bits {
+        exceptions_above -= histogram[b as usize] as i64;
+
+        // A vector holds at most `MAX_VECTOR_SIZE` elements, so that is also the most exceptions one
+        // can name. The full-width candidate has none at all, so a best is always found.
+        if exceptions_above > MAX_VECTOR_SIZE as i64 {
+            continue;
+        }
+
+        let total_cost = num_elements as i64 * b as i64 + exceptions_above * exception_cost;
+        if total_cost < best_cost {
+            best_cost = total_cost;
+            best_width = b;
+        }
+    }
+
+    (best_width, best_cost)
+}
+
+/// One walk producing both histograms the frame search needs.
+///
+/// The bit-width histogram costs the frame it is given; the bucket counts cost every other frame.
+/// They are gathered together because each needs the same residual, and computing that residual
+/// twice was measurably the larger half of the search.
+///
+/// Bucketing is by shift rather than division: `1 << shift` values per bucket keeps the count at or
+/// below [`FRAME_SEARCH_BUCKETS`] without a per-element divide.
+fn build_frame_search_histograms<T: PforInt>(
+    values: &[T],
+    frame: T,
+    shift: u32,
+    width_hist: &mut [i32; 65],
+    buckets: &mut [i32; FRAME_SEARCH_BUCKETS + 1],
+) {
+    let frame_bits = frame.to_bits();
+    let mut h = [[0i32; 65]; 4];
+    for (i, value) in values.iter().enumerate() {
+        let offset = value.residual_from(frame_bits);
+        h[i & 3][bits_required(offset) as usize] += 1;
+        buckets[(offset >> shift) as usize] += 1;
+    }
+    for b in 0..=64 {
+        width_hist[b] = h[0][b] + h[1][b] + h[2][b] + h[3][b];
+    }
+}
+
+/// The extremes of a run of values.
+#[derive(Debug, Clone, Copy)]
+struct MinMax<T> {
+    min: T,
+    max: T,
+}
+
+/// A frame of reference together with the width that suits it.
+#[derive(Debug, Clone, Copy)]
+struct FrameChoice<T> {
+    frame_of_reference: T,
+    bit_width: u8,
+    cost_bits: i64,
+}
+
+/// Choose a frame of reference and a bit width together.
+///
+/// The frame PFOR has always used is the minimum, which makes every exception an overshoot: one
+/// value far below the cluster drags the whole packed window down with it and nothing can patch it
+/// back. Treating the frame as a free parameter instead -- any lower bound, not the lowest -- lets
+/// the window sit where the values actually are and patch on both sides.
+///
+/// Storage is unaffected: the frame field already holds a full-width value, and the decoder only
+/// ever adds it. The whole cost is this search.
+///
+/// The search is approximate by design. An exact answer needs the values sorted; instead the range
+/// is bucketed with a shift, and for each candidate width a window is slid over the bucket counts.
+/// Only whole buckets count as covered, so the exception estimate is an upper bound -- never
+/// optimistic. The minimum-frame answer is always among the candidates, and it alone is costed from
+/// a real histogram, so the search can never do worse than what a plain cost model would pick.
+fn choose_frame_and_width<T: PforInt>(values: &[T], bounds: MinMax<T>) -> FrameChoice<T> {
+    let num_elements = values.len();
+    let max_bits = T::MAX_BIT_WIDTH;
+    let exception_cost = exception_bits(T::BYTE_WIDTH);
+
+    let min_val = bounds.min;
+    let range = bounds.max.residual_from(min_val.to_bits());
+
+    // A constant vector is already at the floor, and min/max has just proved it constant, so it
+    // needs no histogram to find that out. Worth the special case for its own sake: a run of equal
+    // values sends every element to one histogram bin, where the read-modify-write serializes and
+    // the pass runs at a fraction of its usual rate.
+    if range == 0 {
+        return FrameChoice {
+            frame_of_reference: min_val,
+            bit_width: 0,
+            cost_bits: 0,
+        };
+    }
+
+    let range_bits = bits_required(range) as u32;
+    let shift = range_bits.saturating_sub(FRAME_SEARCH_BITS);
+
+    // One walk serves both halves of the search: the bit-width histogram costs the minimum as a
+    // frame, the bucket counts cost every other frame.
+    let mut histogram = [0i32; 65];
+    let mut counts = [0i32; FRAME_SEARCH_BUCKETS + 1];
+    build_frame_search_histograms(values, min_val, shift, &mut histogram, &mut counts);
+
+    // Candidate 0: the minimum, i.e. what PFOR has always done. Costed unconditionally, and from a
+    // real histogram, so the search cannot regress against it.
+    let (bit_width, cost_bits) = best_width_from_histogram::<T>(&histogram, num_elements);
+    let mut best = FrameChoice {
+        frame_of_reference: min_val,
+        bit_width,
+        cost_bits,
+    };
+
+    // Already at width 0, with a handful of patches carrying the rest. Nothing a frame can do about
+    // it. Note this is not the same as having no exceptions: the whole point of a frame above the
+    // minimum is to trade a narrower width for a few patches, so an exception-free choice is where
+    // the search starts, not a reason to skip it.
+    if best.bit_width == 0 {
+        return best;
+    }
+
+    let num_buckets = (range >> shift) as usize + 1;
+    let mut prefix = [0i32; FRAME_SEARCH_BUCKETS + 2];
+    for b in 0..num_buckets {
+        prefix[b + 1] = prefix[b] + counts[b];
+    }
+
+    // Slide a `2^w`-wide window over the buckets and keep the position that costs least. Widths
+    // below the bucket size cannot be resolved at this granularity, and once one window spans every
+    // bucket there are no exceptions left to remove, so the loop covers only the
+    // `FRAME_SEARCH_BITS`-odd widths in between -- fixed work, and none of it touching the data
+    // again.
+    //
+    // What comes out of this is a frame, not a width. Only whole buckets count as covered, so `w`
+    // here is an upper bound on the width the frame really needs, and the exception count an upper
+    // bound too. The exact pass below is what turns the frame into a plan.
+    //
+    // Seeded with the incumbent's cost, so a window only registers if it beats the minimum as a
+    // frame. Everything after this loop -- the walk that lowers the frame onto a real value, and
+    // the exact pass that turns it into a width -- is then skipped entirely on a column the frame
+    // cannot help, which is most of them. Seeding it costs the conservative direction: the scan
+    // over-counts exceptions, so it can decline a frame whose exact cost would have won, but it
+    // cannot accept one that loses.
+    let mut best_start: Option<usize> = None;
+    let mut best_end = 0usize;
+    let mut scan_cost = best.cost_bits;
+    for w in shift..=max_bits as u32 {
+        let whole_buckets = 1u64 << (w - shift);
+        let k = std::cmp::min(whole_buckets as usize, num_buckets);
+        for s in 0..num_buckets {
+            let end = std::cmp::min(s + k, num_buckets);
+            let exceptions = num_elements as i64 - (prefix[end] - prefix[s]) as i64;
+            if exceptions > MAX_VECTOR_SIZE as i64 {
+                continue;
+            }
+            let cost = num_elements as i64 * w as i64 + exceptions * exception_cost;
+            if cost < scan_cost {
+                scan_cost = cost;
+                best_start = Some(s);
+                best_end = end;
+            }
+        }
+        if k >= num_buckets {
+            break; // one window already spans the data
+        }
+    }
+
+    let Some(best_start) = best_start else {
+        return best;
+    };
+
+    // Lower the frame from the boundary of the winning window onto the smallest value the window
+    // actually covers. Bucket boundaries stand `2^shift` apart, which on a wide column is
+    // thousands, and a cluster sitting just above one would otherwise pay those bits for nothing.
+    //
+    // A walk of its own, rather than per-bucket minima kept by the pass above: tracking them there
+    // costs every vector a compare and a store per element, including the vectors where the scan
+    // finds nothing and the minima are discarded. Here only a vector the search has already won
+    // pays, and it pays one traversal.
+    let window_lo = (best_start as u64) << shift;
+    // A window reaching the last bucket has no upper edge to test against: the edge would be
+    // `num_buckets << shift`, which is one past the representable range whenever the residuals span
+    // the whole type.
+    let bounded_above = best_end < num_buckets;
+    let window_hi = if bounded_above {
+        (best_end as u64) << shift
+    } else {
+        0
+    };
+
+    let min_bits = min_val.to_bits();
+    let mut frame_offset = 0u64;
+    let mut covers_anything = false;
+    for value in values {
+        let offset = value.residual_from(min_bits);
+        if offset < window_lo || (bounded_above && offset >= window_hi) {
+            continue;
+        }
+        if !covers_anything || offset < frame_offset {
+            frame_offset = offset;
+            covers_anything = true;
+        }
+    }
+    if !covers_anything {
+        return best;
+    }
+
+    let scan_frame = T::from_bits(min_bits.wrapping_add(frame_offset));
+    if scan_frame == min_val {
+        return best;
+    }
+
+    // Cost the winning frame exactly. This pass is not bookkeeping -- it is where the width and the
+    // exception count are actually decided. The scan works at bucket granularity and so cannot see
+    // a window narrower than one bucket, which is exactly where the answers worth having tend to
+    // be.
+    build_offset_histogram(values, scan_frame, &mut histogram);
+    let (bit_width, exact_cost) = best_width_from_histogram::<T>(&histogram, num_elements);
+    if exact_cost < best.cost_bits {
+        best = FrameChoice {
+            frame_of_reference: scan_frame,
+            bit_width,
+            cost_bits: exact_cost,
+        };
+    }
+    best
+}
+
+/// The bounds of `values`.
+///
+/// # Panics
+///
+/// Panics on an empty slice: there is no frame of reference for an empty vector.
+fn min_max<T: PforInt>(values: &[T]) -> MinMax<T> {
+    let mut bounds = MinMax {
+        min: values[0],
+        max: values[0],
+    };
+    for &value in &values[1..] {
+        if value < bounds.min {
+            bounds.min = value;
+        }
+        if value > bounds.max {
+            bounds.max = value;
+        }
+    }
+    bounds
+}
+
+/// Map a signed value onto an unsigned one of the same magnitude.
+///
+/// Negative values interleave with positive ones instead of wrapping to the top of the range, so a
+/// small negative difference needs few bits rather than all of them. Used only by
+/// [`estimate_delta_cost_bits`]; nothing on the wire is zigzagged.
+#[inline]
+fn zigzag<T: PforInt>(value: T) -> u64 {
+    let bits = value.to_bits();
+    let sign_bits = T::BYTE_WIDTH * 8;
+    let sign_mask = 0u64.wrapping_sub(bits >> (sign_bits - 1));
+    let shifted = (bits << 1) & low_mask(sign_bits as u8);
+    (shifted ^ sign_mask) & low_mask(sign_bits as u8)
+}
+
+/// Fill `deltas` with the backward differences of `values`, and return their bounds.
+///
+/// `deltas[0]` is zero: the first value travels in the plan's start value, and giving slot 0 a real
+/// difference would mean either a shorter packed run or a value that is not a difference sitting in
+/// the width histogram. Zero costs `bit_width` bits and distorts nothing.
+///
+/// Subtraction is modular, because a column that spans the type's range will wrap and the decoder
+/// sums the same way.
+fn compute_deltas<T: PforInt>(values: &[T], deltas: &mut Vec<T>) -> MinMax<T> {
+    deltas.clear();
+    deltas.push(T::default());
+    let mut bounds = MinMax {
+        min: T::default(),
+        max: T::default(),
+    };
+    for i in 1..values.len() {
+        let d = T::from_bits(values[i].to_bits().wrapping_sub(values[i - 1].to_bits()));
+        deltas.push(d);
+        if d < bounds.min {
+            bounds.min = d;
+        }
+        if d > bounds.max {
+            bounds.max = d;
+        }
+    }
+    bounds
+}
+
+/// Estimate what packing the differences of `values` would cost, in bits.
+///
+/// The full decision needs the differences written out and searched, which is most of what encoding
+/// a vector costs. This reaches an answer good enough to decline the mode from a strided sample,
+/// without writing anything.
+///
+/// The sample is of widths, not of a span. A gate on the span of the differences was tried first
+/// and had to go: a sawtooth is a tight cluster of small positive differences with a handful of
+/// large negative ones, so its span is as wide as its raw span while its cost is a fraction of it.
+/// Feeding widths to the same cost model the search uses keeps that shape, because the model can
+/// trade a wide bin against a patch.
+///
+/// Zigzagging is what lets a histogram stand in for a frame search that has not run. Differences in
+/// `[-k, k]` zigzag into `[0, 2k]`, and a frame at `-k` maps them onto the same `[0, 2k]`, so for a
+/// range that straddles zero evenly the estimated width is the width the search would find. Where
+/// the range leans one way the estimate runs a bit or two wide.
+fn estimate_delta_cost_bits<T: PforInt>(values: &[T]) -> i64 {
+    // Enough of a sample to place a distribution across the width bins, and few enough that the
+    // pass is a fraction of the one it is deciding against.
+    const SAMPLE_TARGET: usize = 128;
+    let num_elements = values.len();
+    let stride = std::cmp::max(1, num_elements / SAMPLE_TARGET);
+
+    let mut h = [[0i32; 65]; 4];
+    let mut sampled = 0usize;
+    let mut i = stride;
+    while i < num_elements {
+        let d = T::from_bits(values[i].to_bits().wrapping_sub(values[i - 1].to_bits()));
+        h[sampled & 3][bits_required(zigzag(d)) as usize] += 1;
+        sampled += 1;
+        i += stride;
+    }
+    if sampled == 0 {
+        return 0;
+    }
+
+    let mut histogram = [0i32; 65];
+    for b in 0..=64 {
+        histogram[b] = h[0][b] + h[1][b] + h[2][b] + h[3][b];
+    }
+    let (_, sample_cost) = best_width_from_histogram::<T>(&histogram, sampled);
+
+    // Scale to the whole vector. Both terms of the model are per-element -- a width costs its bits
+    // every element, an exception costs its slot every time it occurs -- so the sample cost scales
+    // with the count.
+    sample_cost * num_elements as i64 / sampled as i64
+}
+
+/// Everything the encoder decided about one vector.
+#[derive(Debug, Clone, Copy)]
+struct PforVectorPlan<T> {
+    /// Difference the values before framing and packing them.
+    delta: bool,
+    /// Subtracted from every element before packing; added back on decode.
+    frame_of_reference: T,
+    /// First value of the vector, stored only when `delta` is set. It is what makes a differenced
+    /// vector decodable on its own, without the vector before it.
+    start_value: T,
+    bit_width: u8,
+    cost_bits: i64,
+}
+
+/// Decide how to encode one vector.
+///
+/// On return `delta_scratch` holds the differences if the plan chose them, and is clobbered either
+/// way.
+///
+/// Both transforms are costed with the same model and the cheaper one wins, so the mode is a
+/// per-vector decision. It has to be: differencing loses on every unclustered draw, and a column is
+/// rarely all one shape.
+fn choose_vector_plan<T: PforInt>(
+    values: &[T],
+    delta_scratch: &mut Vec<T>,
+    delta_enabled: bool,
+) -> PforVectorPlan<T> {
+    let raw = choose_frame_and_width(values, min_max(values));
+
+    let mut plan = PforVectorPlan {
+        delta: false,
+        frame_of_reference: raw.frame_of_reference,
+        start_value: T::default(),
+        bit_width: raw.bit_width,
+        cost_bits: raw.cost_bits,
+    };
+
+    // One element has no difference to take, and a vector already packing at width 0 cannot be
+    // improved on.
+    if !delta_enabled || values.len() < 2 || raw.bit_width == 0 {
+        return plan;
+    }
+
+    // A differenced vector carries its own first value, so it starts one full-width value behind
+    // whatever its differences pack to.
+    let start_value_bits = (T::BYTE_WIDTH * 8) as i64;
+
+    // Estimate the mode before paying for it, and drop it here if the estimate cannot reach the
+    // incumbent. What is skipped is the whole of the rest of the mode: the pass that writes the
+    // differences out, and the frame search over them. The estimate is deliberately loose, so it
+    // declines only where the two modes are more than a sampling error apart -- which is where the
+    // choice matters least.
+    if estimate_delta_cost_bits(values) + start_value_bits >= plan.cost_bits {
+        return plan;
+    }
+
+    let delta_bounds = compute_deltas(values, delta_scratch);
+    let delta = choose_frame_and_width(delta_scratch, delta_bounds);
+
+    let delta_cost = delta.cost_bits + start_value_bits;
+    if delta_cost < plan.cost_bits {
+        plan = PforVectorPlan {
+            delta: true,
+            frame_of_reference: delta.frame_of_reference,
+            start_value: values[0],
+            bit_width: delta.bit_width,
+            cost_bits: delta_cost,
+        };
+    }
+    plan
+}
+
+/// Encoder for [`Encoding::PFOR`].
+///
+/// Values are buffered until [`Encoder::flush_buffer`], because a page's offset array is sized by
+/// the number of vectors and so cannot be written before the last value has arrived.
+pub struct PforEncoder<T: DataType> {
+    /// Values put so far, awaiting a flush.
+    values: Vec<T::T>,
+    /// Elements per vector.
+    vector_size: usize,
+    /// Whether the planner may difference a vector.
+    ///
+    /// Nothing here changes how a page is read: a decoder is told which mode each vector used by
+    /// the vector's own info block, so turning the mode off only narrows what the encoder will
+    /// choose, and pages written either way read the same.
+    delta_enabled: bool,
+    /// Scratch for one vector's differences, kept across vectors so the allocation is paid once.
+    delta_scratch: Vec<T::T>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: DataType> Default for PforEncoder<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: DataType> PforEncoder<T> {
+    /// Creates an encoder at the default vector size, with differencing enabled.
+    pub fn new() -> Self {
+        Self {
+            values: Vec::new(),
+            vector_size: DEFAULT_VECTOR_SIZE,
+            delta_enabled: true,
+            delta_scratch: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Sets the number of elements per vector, which must be a power of two the page header can
+    /// describe.
+    pub fn with_vector_size(mut self, vector_size: usize) -> Result<Self> {
+        validate_vector_size(vector_size)?;
+        self.vector_size = vector_size;
+        Ok(self)
+    }
+
+    /// Sets whether the planner may difference a vector.
+    pub fn with_delta_enabled(mut self, delta_enabled: bool) -> Self {
+        self.delta_enabled = delta_enabled;
+        self
+    }
+}
+
+impl<T: DataType> PforEncoder<T>
+where
+    T::T: PforInt,
+{
+    /// Encode one vector onto the end of `out`.
+    fn encode_vector(&mut self, values: &[T::T], out: &mut Vec<u8>) {
+        debug_assert!(!values.is_empty());
+        let plan = choose_vector_plan(values, &mut self.delta_scratch, self.delta_enabled);
+        let source: &[T::T] = if plan.delta {
+            &self.delta_scratch
+        } else {
+            values
+        };
+
+        // Reduce by the frame, collecting whatever will not fit.
+        //
+        // The comparison is against the packed mask in the unsigned domain, which is what lets the
+        // frame sit above the minimum: a source value below the frame wraps to a huge residual,
+        // fails the same test as one above the window, and is patched from the exception list like
+        // any other. No second test, no sign.
+        let frame_bits = plan.frame_of_reference.to_bits();
+        let mask = low_mask(plan.bit_width);
+        let mut residuals: Vec<u64> = Vec::with_capacity(values.len());
+        let mut exception_positions: Vec<u16> = Vec::new();
+        let mut exception_values: Vec<T::T> = Vec::new();
+
+        for (i, &value) in source.iter().enumerate() {
+            let mut offset = value.residual_from(frame_bits);
+            if offset > mask {
+                exception_positions.push(i as u16);
+                // The exception carries whatever the packed stream carries: a value in a plain
+                // vector, a difference in a differenced one. The decoder patches it in before the
+                // running sum, so a patched difference is summed like any other.
+                exception_values.push(value);
+                offset = 0;
+            }
+            residuals.push(offset);
+        }
+
+        let info = PforVectorInfo::<T::T> {
+            frame_of_reference: plan.frame_of_reference,
+            bit_width: plan.bit_width,
+            // Taken from the pass that just ran rather than from the plan, so the count on the wire
+            // is the count of exceptions actually written even if the two ever disagree.
+            num_exceptions: exception_positions.len() as u16,
+            is_delta: plan.delta,
+        };
+        info.write(out);
+
+        if plan.delta {
+            plan.start_value.write_le(out);
+        }
+
+        if plan.bit_width > 0 {
+            // `consume` flushes to a byte boundary, which is where the packed section ends.
+            let mut writer = BitWriter::new_from_buf(std::mem::take(out));
+            for &residual in &residuals {
+                writer.put_value(residual, plan.bit_width as usize);
+            }
+            *out = writer.consume();
+        }
+
+        for position in &exception_positions {
+            out.extend_from_slice(&position.to_le_bytes());
+        }
+        for value in &exception_values {
+            value.write_le(out);
+        }
+    }
+}
+
+impl<T: DataType> Encoder<T> for PforEncoder<T>
+where
+    T::T: PforInt,
+{
+    fn put(&mut self, values: &[T::T]) -> Result<()> {
+        self.values.extend_from_slice(values);
+        Ok(())
+    }
+
+    fn encoding(&self) -> Encoding {
+        Encoding::PFOR
+    }
+
+    fn estimated_data_encoded_size(&self) -> usize {
+        // Has to be O(1), and the real size is not known until the widths are chosen, so this is
+        // the unpacked size -- which the cost model guarantees the page will not exceed.
+        self.values.len() * T::T::BYTE_WIDTH
+    }
+
+    fn estimated_memory_size(&self) -> usize {
+        self.values.capacity() * std::mem::size_of::<T::T>()
+            + self.delta_scratch.capacity() * std::mem::size_of::<T::T>()
+    }
+
+    fn flush_buffer(&mut self) -> Result<Bytes> {
+        let num_values = self.values.len();
+        if num_values > i32::MAX as usize {
+            return Err(general_err!(
+                "PFOR page holds {} values, more than the {} its header can describe",
+                num_values,
+                i32::MAX
+            ));
+        }
+
+        let log_vector_size = validate_vector_size(self.vector_size)?;
+        let header = PforHeader {
+            packing_mode: PACKING_MODE_FOR_BIT_PACK,
+            log_vector_size,
+            value_byte_width: T::T::BYTE_WIDTH as u8,
+            num_elements: num_values as i32,
+        };
+        let num_vectors = header.num_vectors();
+
+        let mut out = Vec::with_capacity(max_compressed_size::<T::T>(
+            num_values,
+            self.vector_size,
+        )?);
+        header.write(&mut out);
+
+        // The offset array is reserved now and filled in as each vector is written. An all-null
+        // page holds no values and still has to be written, and a reader loads the header before it
+        // knows how many values a page has, so zero values encodes to a bare header rather than to
+        // nothing at all.
+        let offset_array_at = out.len();
+        out.resize(offset_array_at + num_vectors * OFFSET_SIZE, 0);
+
+        let values = std::mem::take(&mut self.values);
+        for (v, chunk) in values.chunks(self.vector_size).enumerate() {
+            // Offsets count from the start of the offset array, not from the start of the page.
+            let offset = (out.len() - offset_array_at) as u32;
+            let at = offset_array_at + v * OFFSET_SIZE;
+            out[at..at + OFFSET_SIZE].copy_from_slice(&offset.to_le_bytes());
+            self.encode_vector(chunk, &mut out);
+        }
+
+        self.values = values;
+        self.values.clear();
+        Ok(out.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_type::{Int32Type, Int64Type};
+    use crate::encodings::decoding::{Decoder, PforDecoder};
+
+    /// Encode then decode, asserting the values survive and reporting the page.
+    fn round_trip<T: DataType>(values: &[T::T], vector_size: usize) -> Bytes
+    where
+        T::T: PforInt,
+    {
+        let mut encoder = PforEncoder::<T>::new()
+            .with_vector_size(vector_size)
+            .unwrap();
+        encoder.put(values).unwrap();
+        let page = encoder.flush_buffer().unwrap();
+
+        assert!(
+            page.len() <= max_compressed_size::<T::T>(values.len(), vector_size).unwrap(),
+            "page of {} bytes exceeds the bound of {}",
+            page.len(),
+            max_compressed_size::<T::T>(values.len(), vector_size).unwrap()
+        );
+
+        let mut decoder = PforDecoder::<T>::new();
+        decoder.set_data(page.clone(), values.len()).unwrap();
+        let mut out = vec![T::T::default(); values.len()];
+        assert_eq!(decoder.get(&mut out).unwrap(), values.len());
+        assert_eq!(out, values);
+        assert_eq!(decoder.values_left(), 0);
+        page
+    }
+
+    /// The info block of vector `v` of a page, for the tests that assert what the planner chose.
+    fn vector_info<T: PforInt>(page: &[u8], v: usize) -> PforVectorInfo<T> {
+        let offsets = &page[HEADER_SIZE..];
+        let at = HEADER_SIZE + read_offset(offsets, v);
+        PforVectorInfo::<T>::read(&page[at..]).unwrap()
+    }
+
+    /// A deterministic pseudo-random sequence, so a failure is reproducible.
+    ///
+    /// A 64-bit xorshift, in the test rather than as a dependency.
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            self.0 ^= self.0 << 13;
+            self.0 ^= self.0 >> 7;
+            self.0 ^= self.0 << 17;
+            self.0
+        }
+    }
+
+    #[test]
+    fn test_round_trip_shapes_i32() {
+        let mut rng = Rng(0x2545F491_4F6CDD1D);
+        let shapes: Vec<(&str, Vec<i32>)> = vec![
+            ("empty", vec![]),
+            ("single", vec![42]),
+            ("constant", vec![7; 100]),
+            ("constant zero", vec![0; 100]),
+            ("ramp", (0..1000).collect()),
+            ("descending ramp", (0..1000).rev().collect()),
+            ("negative ramp", (-1000..0).collect()),
+            // A cluster with outliers on both sides of it, which is what a searched frame is for.
+            (
+                "two sided outliers",
+                (0..1000)
+                    .map(|i| match i % 100 {
+                        0 => -1_000_000,
+                        50 => 1_000_000,
+                        _ => 500 + (i % 7),
+                    })
+                    .collect(),
+            ),
+            (
+                "random",
+                (0..1000).map(|_| rng.next() as i32).collect(),
+            ),
+            (
+                "small random",
+                (0..1000).map(|_| (rng.next() % 256) as i32).collect(),
+            ),
+            ("extremes", vec![i32::MIN, i32::MAX, 0, -1, 1, i32::MIN, i32::MAX]),
+            // A vector whose span covers the whole type, so the residuals need every bit.
+            (
+                "full span",
+                (0..64).map(|i| if i % 2 == 0 { i32::MIN + i } else { i32::MAX - i }).collect(),
+            ),
+            ("sawtooth", (0..1000).map(|i| (i % 37) * 3).collect()),
+            // Steps: long runs of one value, which differencing turns into runs of zero.
+            ("steps", (0..1000).map(|i| (i / 50) * 1_000_000).collect()),
+        ];
+
+        for (name, values) in shapes {
+            for vector_size in [8usize, 64, 1024] {
+                let page = round_trip::<Int32Type>(&values, vector_size);
+                assert!(!page.is_empty(), "{name} at {vector_size} produced no page");
+            }
+        }
+    }
+
+    #[test]
+    fn test_round_trip_shapes_i64() {
+        let mut rng = Rng(0x9E3779B9_7F4A7C15);
+        let shapes: Vec<(&str, Vec<i64>)> = vec![
+            ("empty", vec![]),
+            ("constant", vec![-9; 100]),
+            ("ramp", (0..1000).collect()),
+            ("wide ramp", (0..1000).map(|i| i * 1_000_000_007).collect()),
+            ("random", (0..1000).map(|_| rng.next() as i64).collect()),
+            (
+                "random needing every bit",
+                (0..1000).map(|_| rng.next() as i64 | i64::MIN).collect(),
+            ),
+            ("extremes", vec![i64::MIN, i64::MAX, 0, -1, 1]),
+            (
+                "full span",
+                (0..64).map(|i| if i % 2 == 0 { i64::MIN + i } else { i64::MAX - i }).collect(),
+            ),
+        ];
+
+        for (name, values) in shapes {
+            for vector_size in [8usize, 1024] {
+                let page = round_trip::<Int64Type>(&values, vector_size);
+                assert!(!page.is_empty(), "{name} at {vector_size} produced no page");
+            }
+        }
+    }
+
+    #[test]
+    fn test_round_trip_every_vector_size() {
+        let values: Vec<i32> = (0..5000).map(|i| (i * 31) % 9973).collect();
+        for log_vector_size in MIN_LOG_VECTOR_SIZE..=MAX_LOG_VECTOR_SIZE {
+            round_trip::<Int32Type>(&values, 1 << log_vector_size);
+        }
+    }
+
+    #[test]
+    fn test_round_trip_every_bit_width() {
+        // One vector per width, built so the planner has to choose that width: values spanning
+        // exactly `w` bits with nothing to gain from a frame or from differencing.
+        for w in 1..=32u32 {
+            let span: u64 = if w == 32 { u32::MAX as u64 } else { (1u64 << w) - 1 };
+            let values: Vec<i32> = (0..64)
+                .map(|i| ((i as u64 * 2_654_435_761) % (span + 1)) as u32 as i32)
+                .collect();
+            let page = round_trip::<Int32Type>(&values, 64);
+            let info = vector_info::<i32>(&page, 0);
+            assert!(
+                info.bit_width <= 32,
+                "width {} at w={w} is not a width INT32 can hold",
+                info.bit_width
+            );
+        }
+        for w in 33..=64u32 {
+            let span: u64 = if w == 64 { u64::MAX } else { (1u64 << w) - 1 };
+            let values: Vec<i64> = (0..64)
+                .map(|i| ((i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) % span) as i64)
+                .collect();
+            let page = round_trip::<Int64Type>(&values, 64);
+            let info = vector_info::<i64>(&page, 0);
+            assert!(
+                info.bit_width <= 64,
+                "width {} at w={w} is not a width INT64 can hold",
+                info.bit_width
+            );
+        }
+    }
+
+    #[test]
+    fn test_constant_vector_packs_at_width_zero() {
+        let page = round_trip::<Int32Type>(&vec![777; 64], 64);
+        let info = vector_info::<i32>(&page, 0);
+        assert_eq!(info.bit_width, 0);
+        assert_eq!(info.num_exceptions, 0);
+        assert_eq!(info.frame_of_reference, 777);
+        assert!(!info.is_delta);
+        // Header, one offset, and an info block holding the value: nothing else is needed.
+        assert_eq!(page.len(), HEADER_SIZE + OFFSET_SIZE + <i32 as PforInt>::INFO_SIZE);
+    }
+
+    #[test]
+    fn test_frame_is_searched_not_taken_as_the_minimum() {
+        // A tight cluster with one value far below it. With the frame pinned to the minimum every
+        // packed value would have to span the gap; with the frame searched, the outlier becomes an
+        // exception and the width collapses to what the cluster needs.
+        let mut values: Vec<i32> = (0..1024).map(|i| 1_000_000 + (i % 16)).collect();
+        values[500] = -1_000_000;
+
+        let page = round_trip::<Int32Type>(&values, 1024);
+        let info = vector_info::<i32>(&page, 0);
+        assert!(
+            info.frame_of_reference > 0,
+            "frame {} was not lifted above the outlier",
+            info.frame_of_reference
+        );
+        assert!(
+            info.bit_width <= 5,
+            "width {} is wider than the cluster needs",
+            info.bit_width
+        );
+        assert_eq!(info.num_exceptions, 1);
+
+        // And the page is a fraction of what the minimum as a frame would have cost, which needs 21
+        // bits for the gap.
+        assert!(
+            page.len() < 1024 * 21 / 8,
+            "page of {} bytes did not beat a minimum frame",
+            page.len()
+        );
+    }
+
+    #[test]
+    fn test_frame_search_covers_outliers_on_both_sides() {
+        let mut values: Vec<i32> = (0..1024).map(|i| 500_000 + (i % 8)).collect();
+        values[100] = -2_000_000;
+        values[900] = 2_000_000;
+
+        let page = round_trip::<Int32Type>(&values, 1024);
+        let info = vector_info::<i32>(&page, 0);
+        // One frame, two patches, one of them from below it -- where the residual wraps.
+        assert_eq!(info.num_exceptions, 2);
+        assert!(info.bit_width <= 4, "width {} is too wide", info.bit_width);
+    }
+
+    #[test]
+    fn test_delta_is_chosen_on_a_ramp() {
+        // A ramp spans its whole range, so packing it directly costs the span; differenced it is a
+        // run of ones.
+        let values: Vec<i64> = (0..1024).map(|i| i * 1_000_003).collect();
+        let page = round_trip::<Int64Type>(&values, 1024);
+        let info = vector_info::<i64>(&page, 0);
+        assert!(info.is_delta, "differencing was not chosen for a ramp");
+        assert!(info.bit_width <= 2, "width {} is too wide", info.bit_width);
+    }
+
+    #[test]
+    fn test_delta_is_declined_on_unclustered_values() {
+        // Differencing roughly doubles the range of independent draws, so it has to lose here. This
+        // is the case the sampled prefilter exists to decline without paying for the mode.
+        let mut rng = Rng(0xDEAD_BEEF_CAFE_F00D);
+        let values: Vec<i32> = (0..1024).map(|_| (rng.next() % 4096) as i32).collect();
+        let page = round_trip::<Int32Type>(&values, 1024);
+        assert!(
+            !vector_info::<i32>(&page, 0).is_delta,
+            "differencing was chosen for unclustered values"
+        );
+    }
+
+    #[test]
+    fn test_delta_is_declined_on_a_sawtooth_that_a_span_gate_would_have_missed() {
+        // The point of gating on sampled widths rather than on the span of the differences: a
+        // sawtooth's differences are a tight cluster of small positives with a few large negatives,
+        // so its span is as wide as the raw span while its cost is a fraction of it. Here the mode
+        // still has to be evaluated, and whichever way it goes the values have to survive.
+        let values: Vec<i32> = (0..1024).map(|i| (i % 64) * 1_000_000).collect();
+        let page = round_trip::<Int32Type>(&values, 1024);
+        let info = vector_info::<i32>(&page, 0);
+        if info.is_delta {
+            // Differencing a sawtooth leaves one large negative difference per tooth, which is
+            // exactly what patching is for.
+            assert!(info.num_exceptions > 0);
+        }
+    }
+
+    #[test]
+    fn test_delta_can_be_turned_off() {
+        let values: Vec<i32> = (0..1024).map(|i| i * 7).collect();
+
+        let mut encoder = PforEncoder::<Int32Type>::new();
+        encoder.put(&values).unwrap();
+        let with_delta = encoder.flush_buffer().unwrap();
+        assert!(vector_info::<i32>(&with_delta, 0).is_delta);
+
+        let mut encoder = PforEncoder::<Int32Type>::new().with_delta_enabled(false);
+        encoder.put(&values).unwrap();
+        let without_delta = encoder.flush_buffer().unwrap();
+        assert!(!vector_info::<i32>(&without_delta, 0).is_delta);
+
+        // Turning the mode off narrows what the encoder will choose and changes nothing about how a
+        // page is read, because each vector says which mode it used.
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        let mut out = vec![0i32; values.len()];
+        decoder.set_data(without_delta, values.len()).unwrap();
+        decoder.get(&mut out).unwrap();
+        assert_eq!(out, values);
+    }
+
+    #[test]
+    fn test_delta_start_value_makes_each_vector_self_contained() {
+        // Two differenced vectors, read starting from the second one, which only decodes because it
+        // carries its own start value.
+        // A stride wide enough that differencing wins outright. On a short vector the two modes
+        // can tie -- eight values of a gentle ramp cost the same either way, because the start
+        // value costs as much as the width it saves -- and the planner keeps the plain form on a
+        // tie.
+        let values: Vec<i32> = (0..128).map(|i| 1000 + i * 100_000).collect();
+        let page = round_trip::<Int32Type>(&values, 64);
+        assert!(vector_info::<i32>(&page, 1).is_delta);
+
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        decoder.set_data(page, values.len()).unwrap();
+        assert_eq!(decoder.skip(64).unwrap(), 64);
+        let mut out = vec![0i32; 64];
+        decoder.get(&mut out).unwrap();
+        assert_eq!(out, values[64..]);
+    }
+
+    #[test]
+    fn test_mode_is_decided_per_vector() {
+        // A ramp followed by unclustered draws. One page, and the two vectors have to disagree.
+        let mut rng = Rng(0x0123_4567_89AB_CDEF);
+        let mut values: Vec<i32> = (0..1024).map(|i| i * 1000).collect();
+        values.extend((0..1024).map(|_| (rng.next() % 1_000_000) as i32));
+
+        let page = round_trip::<Int32Type>(&values, 1024);
+        assert!(vector_info::<i32>(&page, 0).is_delta);
+        assert!(!vector_info::<i32>(&page, 1).is_delta);
+    }
+
+    #[test]
+    fn test_exception_values_in_a_delta_vector_are_differences() {
+        // A ramp with one jump in it. Differencing wins, and the jump has to travel as a difference
+        // rather than as a value -- the decoder patches before it sums.
+        let mut values: Vec<i32> = (0..1024).map(|i| i * 3).collect();
+        values[512] += 10_000_000;
+        for value in values.iter_mut().skip(513) {
+            *value += 10_000_000;
+        }
+
+        let page = round_trip::<Int32Type>(&values, 1024);
+        let info = vector_info::<i32>(&page, 0);
+        assert!(info.is_delta);
+        assert_eq!(info.num_exceptions, 1);
+    }
+
+    #[test]
+    fn test_page_with_a_partial_final_vector() {
+        // Not a multiple of the vector size, so the last vector is short. Its offset still has to
+        // land where the header says, and its element count comes from the header rather than from
+        // anything in the vector itself.
+        let values: Vec<i32> = (0..100).collect();
+        let page = round_trip::<Int32Type>(&values, 64);
+        let header = PforHeader::read::<i32>(&page).unwrap();
+        assert_eq!(header.num_vectors(), 2);
+        assert_eq!(header.num_elements, 100);
+    }
+
+    #[test]
+    fn test_empty_page_is_a_bare_header() {
+        let mut encoder = PforEncoder::<Int32Type>::new();
+        let page = encoder.flush_buffer().unwrap();
+        assert_eq!(page.len(), HEADER_SIZE);
+        let header = PforHeader::read::<i32>(&page).unwrap();
+        assert_eq!(header.num_elements, 0);
+        assert_eq!(header.num_vectors(), 0);
+    }
+
+    #[test]
+    fn test_encoder_is_reusable_after_a_flush() {
+        let mut encoder = PforEncoder::<Int32Type>::new()
+            .with_vector_size(8)
+            .unwrap();
+
+        let first: Vec<i32> = (0..20).collect();
+        encoder.put(&first).unwrap();
+        let page = encoder.flush_buffer().unwrap();
+        assert_eq!(PforHeader::read::<i32>(&page).unwrap().num_elements, 20);
+
+        // The buffer has to be empty again, not carrying the first page's values into the second.
+        assert_eq!(encoder.estimated_data_encoded_size(), 0);
+        let second: Vec<i32> = (100..105).collect();
+        encoder.put(&second).unwrap();
+        let page = encoder.flush_buffer().unwrap();
+        assert_eq!(PforHeader::read::<i32>(&page).unwrap().num_elements, 5);
+
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        decoder.set_data(page, second.len()).unwrap();
+        let mut out = vec![0i32; second.len()];
+        decoder.get(&mut out).unwrap();
+        assert_eq!(out, second);
+    }
+
+    #[test]
+    fn test_put_accumulates_across_calls() {
+        let mut encoder = PforEncoder::<Int32Type>::new()
+            .with_vector_size(8)
+            .unwrap();
+        let values: Vec<i32> = (0..20).collect();
+        for chunk in values.chunks(3) {
+            encoder.put(chunk).unwrap();
+        }
+        let page = encoder.flush_buffer().unwrap();
+
+        let mut decoder = PforDecoder::<Int32Type>::new();
+        decoder.set_data(page, values.len()).unwrap();
+        let mut out = vec![0i32; values.len()];
+        decoder.get(&mut out).unwrap();
+        assert_eq!(out, values);
+    }
+
+    #[test]
+    fn test_estimated_sizes() {
+        let mut encoder = PforEncoder::<Int64Type>::new();
+        assert_eq!(encoder.encoding(), Encoding::PFOR);
+        assert_eq!(encoder.estimated_data_encoded_size(), 0);
+        encoder.put(&(0..100).collect::<Vec<i64>>()).unwrap();
+        // Unpacked size: the real one is not known until the widths are chosen, and this has to be
+        // O(1). It is an upper bound, which is the direction that matters to a writer sizing pages.
+        assert_eq!(encoder.estimated_data_encoded_size(), 800);
+        assert!(encoder.estimated_memory_size() >= 800);
+    }
+
+    #[test]
+    fn test_rejects_a_vector_size_the_header_cannot_describe() {
+        assert!(PforEncoder::<Int32Type>::new().with_vector_size(1000).is_err());
+        assert!(PforEncoder::<Int32Type>::new().with_vector_size(4).is_err());
+        assert!(PforEncoder::<Int32Type>::new().with_vector_size(1 << 16).is_err());
+        assert!(PforEncoder::<Int32Type>::new().with_vector_size(8).is_ok());
+    }
+
+    #[test]
+    fn test_zigzag() {
+        assert_eq!(zigzag(0i32), 0);
+        assert_eq!(zigzag(-1i32), 1);
+        assert_eq!(zigzag(1i32), 2);
+        assert_eq!(zigzag(-2i32), 3);
+        assert_eq!(zigzag(i32::MAX), u32::MAX as u64 - 1);
+        assert_eq!(zigzag(i32::MIN), u32::MAX as u64);
+        assert_eq!(zigzag(-1i64), 1);
+        assert_eq!(zigzag(i64::MIN), u64::MAX);
+        assert_eq!(zigzag(i64::MAX), u64::MAX - 1);
+    }
+
+    #[test]
+    fn test_compute_deltas() {
+        let mut deltas = Vec::new();
+        let bounds = compute_deltas(&[10i32, 13, 11, 11], &mut deltas);
+        // The first slot is zero: the value it would hold travels in the start value instead.
+        assert_eq!(deltas, vec![0, 3, -2, 0]);
+        assert_eq!(bounds.min, -2);
+        assert_eq!(bounds.max, 3);
+
+        // Differencing across the range of the type wraps, and the decoder sums the same way.
+        let mut deltas = Vec::new();
+        compute_deltas(&[i32::MIN, i32::MAX], &mut deltas);
+        assert_eq!(deltas, vec![0, -1]);
+    }
+
+    #[test]
+    fn test_min_max() {
+        let bounds = min_max(&[3i32, -1, 7, 7, 0]);
+        assert_eq!(bounds.min, -1);
+        assert_eq!(bounds.max, 7);
+        let bounds = min_max(&[5i64]);
+        assert_eq!(bounds.min, 5);
+        assert_eq!(bounds.max, 5);
+    }
+
+    #[test]
+    fn test_best_width_from_histogram_prefers_patching() {
+        // 1000 values needing 4 bits and one needing 30. Packing all of them costs 30 bits each;
+        // packing at 4 and patching the one costs 4 bits each plus one exception slot.
+        let mut histogram = [0i32; 65];
+        histogram[4] = 1000;
+        histogram[30] = 1;
+        let (width, cost) = best_width_from_histogram::<i32>(&histogram, 1001);
+        assert_eq!(width, 4);
+        assert_eq!(cost, 1001 * 4 + exception_bits(4));
+
+        // With enough of them, the wide values stop being exceptions and set the width.
+        let mut histogram = [0i32; 65];
+        histogram[4] = 10;
+        histogram[30] = 1000;
+        let (width, _) = best_width_from_histogram::<i32>(&histogram, 1010);
+        assert_eq!(width, 30);
+    }
+
+    #[test]
+    fn test_build_offset_histogram_wraps_below_the_frame() {
+        // A value below the frame lands in the top bin rather than in a low one, which is what makes
+        // it fail the width test and become a patch.
+        let mut histogram = [0i32; 65];
+        build_offset_histogram(&[10i32, 11, 9], 10, &mut histogram);
+        assert_eq!(histogram[0], 1); // 10 - 10
+        assert_eq!(histogram[1], 1); // 11 - 10
+        // 9 - 10 wraps to a 32-bit residual, not a 64-bit one, so it needs 32 bits. Wrapping at 64
+        // would put it past every width INT32 has, and the full-width candidate would then look
+        // like it needed exceptions.
+        assert_eq!(histogram[32], 1);
+        assert_eq!(histogram[64], 0);
+
+        // The same on INT64, where the wrap is at the full width.
+        let mut histogram = [0i32; 65];
+        build_offset_histogram(&[10i64, 9], 10, &mut histogram);
+        assert_eq!(histogram[0], 1);
+        assert_eq!(histogram[64], 1);
+    }
+
+    #[test]
+    fn test_round_trip_a_page_of_many_vectors() {
+        // Enough vectors that the offset array is a real structure rather than one entry, over a
+        // shape whose vectors do not all plan the same way.
+        let values: Vec<i32> = (0..10_000i32)
+            .map(|i| match i / 8 % 3 {
+                0 => i,               // a ramp
+                1 => 500,             // a constant
+                _ => (i.wrapping_mul(2_654_435)) % 1024, // scattered
+            })
+            .collect();
+        let page = round_trip::<Int32Type>(&values, 8);
+        let header = PforHeader::read::<i32>(&page).unwrap();
+        assert_eq!(header.num_vectors(), 1250);
+    }
+}

--- a/parquet/src/encodings/encoding/pfor_encoder.rs
+++ b/parquet/src/encodings/encoding/pfor_encoder.rs
@@ -30,10 +30,11 @@ use bytes::Bytes;
 use super::Encoder;
 use crate::basic::Encoding;
 use crate::data_type::DataType;
+use crate::encodings::fastlanes::utl_index;
 use crate::encodings::pfor::{
     DEFAULT_VECTOR_SIZE, MAX_VECTOR_SIZE, OFFSET_SIZE, PACKING_MODE_FASTLANES,
-    PACKING_MODE_FOR_BIT_PACK, PforHeader, PforInt, PforVectorInfo, exception_bits, low_mask,
-    max_compressed_size, validate_vector_size,
+    PACKING_MODE_FASTLANES_DELTA, PACKING_MODE_FOR_BIT_PACK, PforHeader, PforInt, PforVectorInfo,
+    delta_start_count, exception_bits, low_mask, max_compressed_size, validate_vector_size,
 };
 use crate::errors::{ParquetError, Result};
 use crate::util::bit_util::{BitWriter, num_required_bits};
@@ -393,7 +394,7 @@ fn compute_deltas<T: PforInt>(values: &[T], deltas: &mut Vec<T>) -> MinMax<T> {
 /// `[-k, k]` zigzag into `[0, 2k]`, and a frame at `-k` maps them onto the same `[0, 2k]`, so for a
 /// range that straddles zero evenly the estimated width is the width the search would find. Where
 /// the range leans one way the estimate runs a bit or two wide.
-fn estimate_delta_cost_bits<T: PforInt>(values: &[T]) -> i64 {
+fn estimate_delta_cost_bits<T: PforInt>(values: &[T], utl_delta: bool) -> i64 {
     // Enough of a sample to place a distribution across the width bins, and few enough that the
     // pass is a fraction of the one it is deciding against.
     const SAMPLE_TARGET: usize = 128;
@@ -404,7 +405,14 @@ fn estimate_delta_cost_bits<T: PforInt>(values: &[T]) -> i64 {
     let mut sampled = 0usize;
     let mut i = stride;
     while i < num_elements {
-        let d = T::from_bits(values[i].to_bits().wrapping_sub(values[i - 1].to_bits()));
+        let full_len = values.len() / DEFAULT_VECTOR_SIZE * DEFAULT_VECTOR_SIZE;
+        let is_start = utl_delta
+            && ((i < full_len && i.is_multiple_of(T::MAX_BIT_WIDTH as usize)) || i == full_len);
+        let d = if is_start {
+            T::default()
+        } else {
+            T::from_bits(values[i].to_bits().wrapping_sub(values[i - 1].to_bits()))
+        };
         h[sampled & 3][num_required_bits(zigzag(d)) as usize] += 1;
         sampled += 1;
         i += stride;
@@ -423,6 +431,33 @@ fn estimate_delta_cost_bits<T: PforInt>(values: &[T]) -> i64 {
     // every element, an exception costs its slot every time it occurs -- so the sample cost scales
     // with the count.
     sample_cost * num_elements as i64 / sampled as i64
+}
+
+/// Adjacent differences within independent contiguous chains, placed in UTL
+/// order for complete blocks. Each chain starts with zero; its first value is
+/// stored separately. An incomplete block remains in sequential order.
+fn compute_utl_deltas<T: PforInt>(values: &[T], deltas: &mut Vec<T>) -> MinMax<T> {
+    deltas.resize(values.len(), T::default());
+    let mut blocks = values.chunks_exact(DEFAULT_VECTOR_SIZE);
+    for (block, values) in blocks.by_ref().enumerate() {
+        let out = &mut deltas[block * DEFAULT_VECTOR_SIZE..][..DEFAULT_VECTOR_SIZE];
+        for (lane, chain) in values.chunks_exact(T::MAX_BIT_WIDTH as usize).enumerate() {
+            out[utl_index(0, lane)] = T::default();
+            for row in 1..chain.len() {
+                out[utl_index(row, lane)] =
+                    T::from_bits(chain[row].to_bits().wrapping_sub(chain[row - 1].to_bits()));
+            }
+        }
+    }
+    let tail = blocks.remainder();
+    if !tail.is_empty() {
+        let at = values.len() - tail.len();
+        deltas[at] = T::default();
+        for i in 1..tail.len() {
+            deltas[at + i] = T::from_bits(tail[i].to_bits().wrapping_sub(tail[i - 1].to_bits()));
+        }
+    }
+    min_max(deltas)
 }
 
 /// Everything the encoder decided about one vector.
@@ -451,6 +486,7 @@ fn choose_vector_plan<T: PforInt>(
     values: &[T],
     delta_scratch: &mut Vec<T>,
     delta_enabled: bool,
+    utl_delta: bool,
 ) -> PforVectorPlan<T> {
     let raw = choose_frame_and_width(values, min_max(values));
 
@@ -468,20 +504,29 @@ fn choose_vector_plan<T: PforInt>(
         return plan;
     }
 
-    // A differenced vector carries its own first value, so it starts one full-width value behind
-    // whatever its differences pack to.
-    let start_value_bits = (T::BYTE_WIDTH * 8) as i64;
+    // Include every independent chain's start in the cost; UTL starts occupy
+    // 128 bytes per complete block, versus one value for ordinary delta.
+    let mode = if utl_delta {
+        PACKING_MODE_FASTLANES_DELTA
+    } else {
+        PACKING_MODE_FOR_BIT_PACK
+    };
+    let start_value_bits = (delta_start_count::<T>(mode, values.len()) * T::BYTE_WIDTH * 8) as i64;
 
     // Estimate the mode before paying for it, and drop it here if the estimate cannot reach the
     // incumbent. What is skipped is the whole of the rest of the mode: the pass that writes the
     // differences out, and the frame search over them. The estimate is deliberately loose, so it
     // declines only where the two modes are more than a sampling error apart -- which is where the
     // choice matters least.
-    if estimate_delta_cost_bits(values) + start_value_bits >= plan.cost_bits {
+    if estimate_delta_cost_bits(values, utl_delta) + start_value_bits >= plan.cost_bits {
         return plan;
     }
 
-    let delta_bounds = compute_deltas(values, delta_scratch);
+    let delta_bounds = if utl_delta {
+        compute_utl_deltas(values, delta_scratch)
+    } else {
+        compute_deltas(values, delta_scratch)
+    };
     let delta = choose_frame_and_width(delta_scratch, delta_bounds);
 
     let delta_cost = delta.cost_bits + start_value_bits;
@@ -508,6 +553,8 @@ pub struct PforEncoder<T: DataType> {
     vector_size: usize,
     /// Whether to use the experimental FastLanes packed representation.
     fastlanes_enabled: bool,
+    /// Use independent UTL delta lanes instead of one sum per vector.
+    fastlanes_delta_enabled: bool,
     /// Whether the planner may difference a vector.
     ///
     /// Nothing here changes how a page is read: a decoder is told which mode each vector used by
@@ -532,6 +579,7 @@ impl<T: DataType> PforEncoder<T> {
             values: Vec::new(),
             vector_size: DEFAULT_VECTOR_SIZE,
             fastlanes_enabled: false,
+            fastlanes_delta_enabled: false,
             delta_enabled: true,
             delta_scratch: Vec::new(),
             _phantom: PhantomData,
@@ -560,6 +608,17 @@ impl<T: DataType> PforEncoder<T> {
         self.fastlanes_enabled = enabled;
         self
     }
+
+    /// Select experimental packing mode 2: FastLanes packing and independent
+    /// UTL delta chains in complete 1024-value blocks. This implies FastLanes
+    /// packing even if `with_fastlanes_enabled` is false. Differencing is still
+    /// selected per vector by the cost model and requires `with_delta_enabled`.
+    /// Each complete delta block carries 128 bytes of chain starts; partial
+    /// blocks use the ordinary delta representation with one start value.
+    pub fn with_fastlanes_delta_enabled(mut self, enabled: bool) -> Self {
+        self.fastlanes_delta_enabled = enabled;
+        self
+    }
 }
 
 impl<T: DataType> PforEncoder<T>
@@ -569,7 +628,12 @@ where
     /// Encode one vector onto the end of `out`.
     fn encode_vector(&mut self, values: &[T::T], out: &mut Vec<u8>) {
         debug_assert!(!values.is_empty());
-        let plan = choose_vector_plan(values, &mut self.delta_scratch, self.delta_enabled);
+        let plan = choose_vector_plan(
+            values,
+            &mut self.delta_scratch,
+            self.delta_enabled,
+            self.fastlanes_delta_enabled,
+        );
         let source: &[T::T] = if plan.delta {
             &self.delta_scratch
         } else {
@@ -612,11 +676,23 @@ where
         info.write(out);
 
         if plan.delta {
-            plan.start_value.write_le(out);
+            if self.fastlanes_delta_enabled {
+                let mut blocks = values.chunks_exact(DEFAULT_VECTOR_SIZE);
+                for block in &mut blocks {
+                    for chain in block.chunks_exact(T::T::MAX_BIT_WIDTH as usize) {
+                        chain[0].write_le(out);
+                    }
+                }
+                if let Some(&start) = blocks.remainder().first() {
+                    start.write_le(out);
+                }
+            } else {
+                plan.start_value.write_le(out);
+            }
         }
 
         if plan.bit_width > 0 {
-            let sequential = if self.fastlanes_enabled {
+            let sequential = if self.fastlanes_enabled || self.fastlanes_delta_enabled {
                 let mut blocks = residuals.chunks_exact(DEFAULT_VECTOR_SIZE);
                 for block in &mut blocks {
                     T::T::pack_fastlanes(plan.bit_width as usize, block, out);
@@ -680,7 +756,9 @@ where
 
         let log_vector_size = validate_vector_size(self.vector_size)?;
         let header = PforHeader {
-            packing_mode: if self.fastlanes_enabled {
+            packing_mode: if self.fastlanes_delta_enabled {
+                PACKING_MODE_FASTLANES_DELTA
+            } else if self.fastlanes_enabled {
                 PACKING_MODE_FASTLANES
             } else {
                 PACKING_MODE_FOR_BIT_PACK
@@ -762,6 +840,18 @@ mod tests {
         assert_eq!(fastlanes[0], PACKING_MODE_FASTLANES);
         assert_eq!(fastlanes.len(), page.len());
         decoder.set_data(fastlanes, values.len()).unwrap();
+        assert_eq!(decoder.get(&mut out).unwrap(), values.len());
+        assert_eq!(out, values);
+        assert_eq!(decoder.values_left(), 0);
+        let mut encoder = PforEncoder::<T>::new()
+            .with_vector_size(vector_size)
+            .unwrap()
+            .with_fastlanes_delta_enabled(true);
+        encoder.put(values).unwrap();
+        let utl = encoder.flush_buffer().unwrap();
+        assert_eq!(utl[0], PACKING_MODE_FASTLANES_DELTA);
+        assert!(utl.len() <= max_compressed_size::<T::T>(values.len(), vector_size).unwrap());
+        decoder.set_data(utl, values.len()).unwrap();
         assert_eq!(decoder.get(&mut out).unwrap(), values.len());
         assert_eq!(out, values);
         assert_eq!(decoder.values_left(), 0);
@@ -1120,6 +1210,53 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_utl_delta_streaming_and_skipping() {
+        fn check<T: DataType>()
+        where
+            T::T: PforInt,
+        {
+            let values: Vec<T::T> = (0..8199u64)
+                .map(|i| {
+                    T::T::from_bits(
+                        (i * 100_003 + if i % 1024 >= 513 { 10_000_000 } else { 0 })
+                            .wrapping_add(i64::MAX as u64 - 1_000_000),
+                    )
+                })
+                .collect();
+            for vector_size in [1024, 2048, 4096, 8192] {
+                let mut encoder = PforEncoder::<T>::new()
+                    .with_vector_size(vector_size)
+                    .unwrap()
+                    .with_fastlanes_delta_enabled(true);
+                for _ in 0..2 {
+                    for part in values.chunks(317) {
+                        encoder.put(part).unwrap();
+                    }
+                    let encoded = encoder.flush_buffer().unwrap();
+                    assert!(vector_info::<T::T>(&encoded, 0).is_delta);
+                    for skip in [0, 1, 31, 32, 63, 64, 1023, 1024, 1025, 2048, 8192, 8199] {
+                        let mut decoder = PforDecoder::<T>::new();
+                        decoder.set_data(encoded.clone(), values.len()).unwrap();
+                        assert_eq!(decoder.skip(skip).unwrap(), skip);
+                        let mut output = Vec::new();
+                        let mut batch = vec![T::T::default(); 317];
+                        loop {
+                            let read = decoder.get(&mut batch).unwrap();
+                            if read == 0 {
+                                break;
+                            }
+                            output.extend_from_slice(&batch[..read]);
+                        }
+                        assert_eq!(output, values[skip..]);
+                    }
+                }
+            }
+        }
+        check::<Int32Type>();
+        check::<Int64Type>();
     }
 
     #[test]

--- a/parquet/src/encodings/encoding/pfor_encoder.rs
+++ b/parquet/src/encodings/encoding/pfor_encoder.rs
@@ -31,8 +31,9 @@ use super::Encoder;
 use crate::basic::Encoding;
 use crate::data_type::DataType;
 use crate::encodings::pfor::{
-    DEFAULT_VECTOR_SIZE, MAX_VECTOR_SIZE, OFFSET_SIZE, PACKING_MODE_FOR_BIT_PACK, PforHeader,
-    PforInt, PforVectorInfo, exception_bits, low_mask, max_compressed_size, validate_vector_size,
+    DEFAULT_VECTOR_SIZE, MAX_VECTOR_SIZE, OFFSET_SIZE, PACKING_MODE_FASTLANES,
+    PACKING_MODE_FOR_BIT_PACK, PforHeader, PforInt, PforVectorInfo, exception_bits, low_mask,
+    max_compressed_size, validate_vector_size,
 };
 use crate::errors::{ParquetError, Result};
 use crate::util::bit_util::{BitWriter, num_required_bits};
@@ -505,6 +506,8 @@ pub struct PforEncoder<T: DataType> {
     values: Vec<T::T>,
     /// Elements per vector.
     vector_size: usize,
+    /// Whether to use the experimental FastLanes packed representation.
+    fastlanes_enabled: bool,
     /// Whether the planner may difference a vector.
     ///
     /// Nothing here changes how a page is read: a decoder is told which mode each vector used by
@@ -528,6 +531,7 @@ impl<T: DataType> PforEncoder<T> {
         Self {
             values: Vec::new(),
             vector_size: DEFAULT_VECTOR_SIZE,
+            fastlanes_enabled: false,
             delta_enabled: true,
             delta_scratch: Vec::new(),
             _phantom: PhantomData,
@@ -545,6 +549,15 @@ impl<T: DataType> PforEncoder<T> {
     /// Sets whether the planner may difference a vector.
     pub fn with_delta_enabled(mut self, delta_enabled: bool) -> Self {
         self.delta_enabled = delta_enabled;
+        self
+    }
+
+    /// Select the experimental FastLanes packing mode. Pages written with this
+    /// mode require a decoder supporting packing mode 1. The frame/delta planner
+    /// is unchanged; complete 1024-value blocks use FastLanes and tails retain
+    /// sequential packing without padding.
+    pub fn with_fastlanes_enabled(mut self, enabled: bool) -> Self {
+        self.fastlanes_enabled = enabled;
         self
     }
 }
@@ -603,12 +616,23 @@ where
         }
 
         if plan.bit_width > 0 {
+            let sequential = if self.fastlanes_enabled {
+                let mut blocks = residuals.chunks_exact(DEFAULT_VECTOR_SIZE);
+                for block in &mut blocks {
+                    T::T::pack_fastlanes(plan.bit_width as usize, block, out);
+                }
+                blocks.remainder()
+            } else {
+                &residuals
+            };
             // `consume` flushes to a byte boundary, which is where the packed section ends.
-            let mut writer = BitWriter::new_from_buf(std::mem::take(out));
-            for &residual in &residuals {
-                writer.put_value(residual, plan.bit_width as usize);
+            if !sequential.is_empty() {
+                let mut writer = BitWriter::new_from_buf(std::mem::take(out));
+                for &residual in sequential {
+                    writer.put_value(residual, plan.bit_width as usize);
+                }
+                *out = writer.consume();
             }
-            *out = writer.consume();
         }
 
         for position in &exception_positions {
@@ -656,7 +680,11 @@ where
 
         let log_vector_size = validate_vector_size(self.vector_size)?;
         let header = PforHeader {
-            packing_mode: PACKING_MODE_FOR_BIT_PACK,
+            packing_mode: if self.fastlanes_enabled {
+                PACKING_MODE_FASTLANES
+            } else {
+                PACKING_MODE_FOR_BIT_PACK
+            },
             log_vector_size,
             value_byte_width: T::T::BYTE_WIDTH as u8,
             num_elements: num_values as i32,
@@ -719,6 +747,21 @@ mod tests {
         let mut decoder = PforDecoder::<T>::new();
         decoder.set_data(page.clone(), values.len()).unwrap();
         let mut out = vec![T::T::default(); values.len()];
+        assert_eq!(decoder.get(&mut out).unwrap(), values.len());
+        assert_eq!(out, values);
+        assert_eq!(decoder.values_left(), 0);
+
+        // Exercise the same shapes, widths, vector sizes and tails through the
+        // new layout as well. Layout changes must not change the planner or size.
+        let mut encoder = PforEncoder::<T>::new()
+            .with_vector_size(vector_size)
+            .unwrap()
+            .with_fastlanes_enabled(true);
+        encoder.put(values).unwrap();
+        let fastlanes = encoder.flush_buffer().unwrap();
+        assert_eq!(fastlanes[0], PACKING_MODE_FASTLANES);
+        assert_eq!(fastlanes.len(), page.len());
+        decoder.set_data(fastlanes, values.len()).unwrap();
         assert_eq!(decoder.get(&mut out).unwrap(), values.len());
         assert_eq!(out, values);
         assert_eq!(decoder.values_left(), 0);
@@ -1035,6 +1078,48 @@ mod tests {
         let page = round_trip::<Int32Type>(&values, 1024);
         assert!(vector_info::<i32>(&page, 0).is_delta);
         assert!(!vector_info::<i32>(&page, 1).is_delta);
+    }
+
+    #[test]
+    fn test_fastlanes_streaming_and_skipping_across_blocks_and_tails() {
+        let values: Vec<i64> = (0..8199)
+            .map(|i| match i % 1024 {
+                17 => i64::MIN,
+                900 => i64::MAX,
+                _ => -1_000_000 + (i % 37),
+            })
+            .collect();
+        for vector_size in [8, 1024, 2048, 4096] {
+            for delta in [false, true] {
+                let mut encoder = PforEncoder::<Int64Type>::new()
+                    .with_vector_size(vector_size)
+                    .unwrap()
+                    .with_delta_enabled(delta)
+                    .with_fastlanes_enabled(true);
+                for _ in 0..2 {
+                    for part in values.chunks(317) {
+                        encoder.put(part).unwrap();
+                    }
+                    let page = encoder.flush_buffer().unwrap();
+                    for skip in [0, 1, 1023, 1024, 1025, 2048, 8192, 8199] {
+                        let mut decoder = PforDecoder::<Int64Type>::new();
+                        decoder.set_data(page.clone(), values.len()).unwrap();
+                        assert_eq!(decoder.skip(skip).unwrap(), skip);
+                        let mut output = Vec::new();
+                        let mut batch = [0; 317];
+                        loop {
+                            let read = decoder.get(&mut batch).unwrap();
+                            if read == 0 {
+                                break;
+                            }
+                            output.extend_from_slice(&batch[..read]);
+                        }
+                        assert_eq!(output, values[skip..]);
+                        assert_eq!(decoder.values_left(), 0);
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/parquet/src/encodings/fastlanes.rs
+++ b/parquet/src/encodings/fastlanes.rs
@@ -1,0 +1,346 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Byte-oriented FastLanes bit packing.
+//!
+//! The upstream FastLanes API exposes packed data as typed words to ensure
+//! alignment. PFOR puts variable-sized vectors after a 7-byte page header and
+//! a byte-offset array, with no alignment padding. Packed values therefore have
+//! no general `u32`/`u64` alignment guarantee. These kernels preserve the FastLanes
+//! transposed wire order while loading and storing little-endian words directly
+//! from potentially unaligned bytes.
+//!
+//! Adapted from the ALP experiment on `alp-benchmark-fastlanes`, commit
+//! e97ae0dbb74dfcd4d4109afbe3dec78598de0900. Frame addition is fused into
+//! unpacking here; the packing order is unchanged.
+
+const FL_ORDER: [usize; 8] = [0, 4, 2, 6, 1, 5, 3, 7];
+const VECTOR_SIZE: usize = 1024;
+
+pub(crate) trait FastLanesBitPacking: Copy + Default {
+    /// Pack one 1024-value vector and append its transposed bytes to `out`.
+    fn pack_bytes(width: usize, input: &[Self], out: &mut Vec<u8>);
+
+    /// Unpack one complete vector and add the frame with wrapping arithmetic.
+    fn unpack_for_bytes(width: usize, input: &[u8], frame: Self, output: &mut [Self]);
+
+    #[cfg(test)]
+    fn unpack_bytes(width: usize, input: &[u8], output: &mut [Self]) {
+        Self::unpack_for_bytes(width, input, Self::default(), output);
+    }
+
+    /// Read one value without unpacking the rest of its vector.
+    #[cfg(test)]
+    fn unpack_single_bytes(width: usize, input: &[u8], index: usize) -> Self;
+}
+
+macro_rules! impl_fastlanes_bitpacking {
+    ($ty:ty, $bits:literal, $load:ident, $store:ident, $pack:ident, $unpack:ident) => {
+        const _: () = assert!(VECTOR_SIZE % $bits == 0);
+
+        impl FastLanesBitPacking for $ty {
+            fn pack_bytes(width: usize, input: &[Self], out: &mut Vec<u8>) {
+                assert!(width <= $bits);
+                assert_eq!(input.len(), VECTOR_SIZE);
+
+                seq_macro::seq!(W in 0..=$bits {
+                    match width {
+                        #(W => $pack::<W>(input, out),)*
+                        _ => unreachable!("invalid FastLanes bit width {width}"),
+                    }
+                })
+            }
+
+            fn unpack_for_bytes(width: usize, input: &[u8], frame: Self, output: &mut [Self]) {
+                assert!(width <= $bits);
+                assert_eq!(input.len(), VECTOR_SIZE * width / 8);
+                assert_eq!(output.len(), VECTOR_SIZE);
+
+                seq_macro::seq!(W in 0..=$bits {
+                    match width {
+                        #(W => $unpack::<W>(input, frame, output),)*
+                        _ => unreachable!("invalid FastLanes bit width {width}"),
+                    }
+                })
+            }
+
+            #[cfg(test)]
+            fn unpack_single_bytes(width: usize, input: &[u8], index: usize) -> Self {
+                assert!(width <= $bits);
+                assert_eq!(input.len(), VECTOR_SIZE * width / 8);
+                assert!(index < VECTOR_SIZE);
+                if width == 0 {
+                    return 0;
+                }
+
+                const LANES: usize = VECTOR_SIZE / $bits;
+                let lane = index % LANES;
+                let sub_row = index / 128;
+                let order = (index - sub_row * 128 - lane) / 16;
+                let row = FL_ORDER[order] * 8 + sub_row;
+
+                if width == $bits {
+                    return $load(input, LANES * row + lane);
+                }
+
+                let mask = (<$ty>::from(1u8) << width) - 1;
+                let start_bit = row * width;
+                let start_word = start_bit / $bits;
+                let lo_shift = start_bit % $bits;
+                let remaining_bits = $bits - lo_shift;
+                let lo = $load(input, LANES * start_word + lane) >> lo_shift;
+                if remaining_bits >= width {
+                    lo & mask
+                } else {
+                    let hi = $load(input, LANES * (start_word + 1) + lane)
+                        << remaining_bits;
+                    (lo | hi) & mask
+                }
+            }
+        }
+
+        #[inline(always)]
+        fn $load(input: &[u8], word: usize) -> $ty {
+            let offset = word * std::mem::size_of::<$ty>();
+            debug_assert!(offset + std::mem::size_of::<$ty>() <= input.len());
+            // SAFETY: the caller validates the complete packed byte length. The
+            // pointer may be unaligned, which is exactly why `read_unaligned`
+            // is used. Every bit pattern is valid for an unsigned integer.
+            unsafe {
+                input.as_ptr().add(offset).cast::<$ty>()
+                    .read_unaligned()
+                    .to_le()
+            }
+        }
+
+        #[inline(always)]
+        fn $store(output: &mut [u8], word: usize, value: $ty) {
+            let offset = word * std::mem::size_of::<$ty>();
+            debug_assert!(offset + std::mem::size_of::<$ty>() <= output.len());
+            // SAFETY: the caller sized the packed byte output in advance. The
+            // destination may be unaligned, so use `write_unaligned`.
+            unsafe {
+                output.as_mut_ptr().add(offset).cast::<$ty>().write_unaligned(value.to_le());
+            }
+        }
+
+        #[inline(never)]
+        #[expect(unused_assignments, reason = "The final unrolled row does not consume the next accumulator")]
+        fn $pack<const W: usize>(input: &[$ty], out: &mut Vec<u8>) {
+            const LANES: usize = VECTOR_SIZE / $bits;
+            let start = out.len();
+            out.resize(start + VECTOR_SIZE * W / 8, 0);
+            let packed = &mut out[start..];
+
+            if W == 0 {
+                return;
+            }
+
+            for lane in 0..LANES {
+                if W == $bits {
+                    seq_macro::seq!(ROW in 0..$bits {
+                        let order = ROW / 8;
+                        let sub_row = ROW % 8;
+                        let index = FL_ORDER[order] * 16 + sub_row * 128 + lane;
+                        $store(packed, LANES * ROW + lane, input[index]);
+                    });
+                } else {
+                    let mask: $ty = (<$ty>::from(1u8) << W) - 1;
+                    let mut tmp: $ty = 0;
+                    seq_macro::seq!(ROW in 0..$bits {
+                        let order = ROW / 8;
+                        let sub_row = ROW % 8;
+                        let index = FL_ORDER[order] * 16 + sub_row * 128 + lane;
+                        let src = input[index] & mask;
+                        if ROW == 0 {
+                            tmp = src;
+                        } else {
+                            tmp |= src << ((ROW * W) % $bits);
+                        }
+
+                        let current_word = ROW * W / $bits;
+                        let next_word = (ROW + 1) * W / $bits;
+                        if next_word > current_word {
+                            $store(packed, LANES * current_word + lane, tmp);
+                            let remaining_bits = ((ROW + 1) * W) % $bits;
+                            tmp = src >> (W - remaining_bits);
+                        }
+                    });
+                }
+            }
+        }
+
+        #[inline(never)]
+        fn $unpack<const W: usize>(input: &[u8], frame: $ty, output: &mut [$ty]) {
+            const LANES: usize = VECTOR_SIZE / $bits;
+            if W == 0 {
+                output.fill(frame);
+                return;
+            }
+
+            for lane in 0..LANES {
+                if W == $bits {
+                    seq_macro::seq!(ROW in 0..$bits {
+                        let order = ROW / 8;
+                        let sub_row = ROW % 8;
+                        let index = FL_ORDER[order] * 16 + sub_row * 128 + lane;
+                        output[index] = $load(input, LANES * ROW + lane).wrapping_add(frame);
+                    });
+                } else {
+                    let mask = |width: usize| (<$ty>::from(1u8) << width) - 1;
+                    let mut src = $load(input, lane);
+                    seq_macro::seq!(ROW in 0..$bits {
+                        let current_word = ROW * W / $bits;
+                        let next_word = (ROW + 1) * W / $bits;
+                        let shift = ROW * W % $bits;
+                        let value = if next_word > current_word {
+                            let remaining_bits = (ROW + 1) * W % $bits;
+                            let current_bits = W - remaining_bits;
+                            let mut tmp = (src >> shift) & mask(current_bits);
+                            if next_word < W {
+                                src = $load(input, LANES * next_word + lane);
+                                tmp |= (src & mask(remaining_bits)) << current_bits;
+                            }
+                            tmp
+                        } else {
+                            (src >> shift) & mask(W)
+                        };
+
+                        let order = ROW / 8;
+                        let sub_row = ROW % 8;
+                        let index = FL_ORDER[order] * 16 + sub_row * 128 + lane;
+                        output[index] = value.wrapping_add(frame);
+                    });
+                }
+            }
+        }
+    };
+}
+
+impl_fastlanes_bitpacking!(u32, 32, load_u32, store_u32, pack_impl_u32, unpack_impl_u32);
+impl_fastlanes_bitpacking!(u64, 64, load_u64, store_u64, pack_impl_u64, unpack_impl_u64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fastlanes::BitPacking;
+
+    fn check_u32(width: usize) {
+        let input: Vec<u32> = (0..VECTOR_SIZE)
+            .map(|i| (i as u32).wrapping_mul(0x9e37_79b9))
+            .collect();
+        let mut expected_words = vec![0u32; VECTOR_SIZE * width / 32];
+        unsafe { <u32 as BitPacking>::unchecked_pack(width, &input, &mut expected_words) };
+        let expected: Vec<u8> = expected_words
+            .iter()
+            .flat_map(|word| word.to_le_bytes())
+            .collect();
+
+        let mut packed = Vec::new();
+        u32::pack_bytes(width, &input, &mut packed);
+        assert_eq!(packed, expected, "u32 pack width {width}");
+
+        let mut output = vec![0; VECTOR_SIZE];
+        u32::unpack_bytes(width, &packed, &mut output);
+        let mask = if width == 32 {
+            u32::MAX
+        } else {
+            ((1u64 << width) - 1) as u32
+        };
+        for (index, (&actual, &original)) in output.iter().zip(&input).enumerate() {
+            assert_eq!(actual, original & mask, "u32 width {width}, index {index}");
+            assert_eq!(
+                u32::unpack_single_bytes(width, &packed, index),
+                actual,
+                "u32 point width {width}, index {index}"
+            );
+        }
+        // Exercise every byte alignment and modular addition, including the
+        // zero- and full-width specializations. Compare with the source values,
+        // not with a second invocation of our decoder.
+        for offset in 0..8 {
+            let mut unaligned = vec![0x5a; offset];
+            u32::pack_bytes(width, &input, &mut unaligned);
+            let frame = u32::MAX - 7;
+            u32::unpack_for_bytes(width, &unaligned[offset..], frame, &mut output);
+            for (actual, original) in output.iter().zip(&input) {
+                assert_eq!(*actual, (original & mask).wrapping_add(frame));
+            }
+        }
+    }
+
+    fn check_u64(width: usize) {
+        let input: Vec<u64> = (0..VECTOR_SIZE)
+            .map(|i| (i as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15))
+            .collect();
+        let mut expected_words = vec![0u64; VECTOR_SIZE * width / 64];
+        unsafe { <u64 as BitPacking>::unchecked_pack(width, &input, &mut expected_words) };
+        let expected: Vec<u8> = expected_words
+            .iter()
+            .flat_map(|word| word.to_le_bytes())
+            .collect();
+
+        let mut packed = Vec::new();
+        u64::pack_bytes(width, &input, &mut packed);
+        assert_eq!(packed, expected, "u64 pack width {width}");
+
+        let mut output = vec![0; VECTOR_SIZE];
+        u64::unpack_bytes(width, &packed, &mut output);
+        let mask = if width == 64 {
+            u64::MAX
+        } else {
+            ((1u128 << width) - 1) as u64
+        };
+        for (index, (&actual, &original)) in output.iter().zip(&input).enumerate() {
+            assert_eq!(actual, original & mask, "u64 width {width}, index {index}");
+            assert_eq!(
+                u64::unpack_single_bytes(width, &packed, index),
+                actual,
+                "u64 point width {width}, index {index}"
+            );
+        }
+        for offset in 0..8 {
+            let mut unaligned = vec![0x5a; offset];
+            u64::pack_bytes(width, &input, &mut unaligned);
+            let frame = u64::MAX - 7;
+            u64::unpack_for_bytes(width, &unaligned[offset..], frame, &mut output);
+            for (actual, original) in output.iter().zip(&input) {
+                assert_eq!(*actual, (original & mask).wrapping_add(frame));
+            }
+        }
+    }
+
+    #[test]
+    fn byte_kernels_match_fastlanes_wire_format() {
+        for width in 0..=32 {
+            check_u32(width);
+        }
+        for width in 0..=64 {
+            check_u64(width);
+        }
+    }
+
+    #[test]
+    fn decoding_does_not_require_alignment() {
+        let input: Vec<u64> = (0..VECTOR_SIZE).map(|i| i as u64).collect();
+        let mut packed = vec![0xff];
+        u64::pack_bytes(11, &input, &mut packed);
+        let mut output = vec![0; VECTOR_SIZE];
+        u64::unpack_bytes(11, &packed[1..], &mut output);
+        assert_eq!(output, input);
+    }
+}

--- a/parquet/src/encodings/fastlanes.rs
+++ b/parquet/src/encodings/fastlanes.rs
@@ -26,10 +26,40 @@
 //!
 //! Adapted from the ALP experiment on `alp-benchmark-fastlanes`, commit
 //! e97ae0dbb74dfcd4d4109afbe3dec78598de0900. Frame addition is fused into
-//! unpacking here; the packing order is unchanged.
+//! unpacking here; the packing order is unchanged. UTL delta kernels sum lanes
+//! in transposed order, then restore original order with a fully unrolled
+//! permutation, following FastLanes and Vortex's separate untranspose kernels.
 
 const FL_ORDER: [usize; 8] = [0, 4, 2, 6, 1, 5, 3, 7];
 const VECTOR_SIZE: usize = 1024;
+
+/// Position of a row/lane in the universal transposed layout. A delta lane
+/// contains 32 consecutive original i32 values or 64 consecutive i64 values.
+pub(crate) const fn utl_index(row: usize, lane: usize) -> usize {
+    FL_ORDER[row / 8] * 16 + (row % 8) * 128 + lane
+}
+
+const fn original_index(bits: usize, index: usize) -> usize {
+    let lane = index % (VECTOR_SIZE / bits);
+    let sub_row = index / 128;
+    let order = (index - sub_row * 128 - lane) / 16;
+    lane * bits + FL_ORDER[order] * 8 + sub_row
+}
+
+/// Generate the entire permutation, not just its rows. This follows
+/// vortex-fastlanes/src/transpose.rs and FastLanes' generated untranspose_i:
+/// constant source/destination indices let LLVM use contiguous loads/stores
+/// and register shuffles rather than a loop of gathers or scatters.
+///
+/// Mode 2's i32 lane numbering differs from the reference's universal
+/// permutation. Keep its published ordering here; the i64 mapping is identical.
+#[inline(never)]
+fn untranspose<T: Copy, const BITS: usize>(input: &[T; VECTOR_SIZE], output: &mut [T]) {
+    assert_eq!(output.len(), VECTOR_SIZE);
+    seq_macro::seq!(I in 0..1024 {
+        output[original_index(BITS, I)] = input[I];
+    });
+}
 
 pub(crate) trait FastLanesBitPacking: Copy + Default {
     /// Pack one 1024-value vector and append its transposed bytes to `out`.
@@ -37,6 +67,18 @@ pub(crate) trait FastLanesBitPacking: Copy + Default {
 
     /// Unpack one complete vector and add the frame with wrapping arithmetic.
     fn unpack_for_bytes(width: usize, input: &[u8], frame: Self, output: &mut [Self]);
+
+    /// Unpack and sum independent UTL lanes, then restore original value order.
+    fn unpack_delta_bytes(
+        width: usize,
+        input: &[u8],
+        frame: Self,
+        starts: &[u8],
+        output: &mut [Self],
+    );
+
+    /// Sum already unpacked and patched UTL differences and restore value order.
+    fn restore_delta(starts: &[u8], output: &mut [Self]);
 
     #[cfg(test)]
     fn unpack_bytes(width: usize, input: &[u8], output: &mut [Self]) {
@@ -72,10 +114,42 @@ macro_rules! impl_fastlanes_bitpacking {
 
                 seq_macro::seq!(W in 0..=$bits {
                     match width {
-                        #(W => $unpack::<W>(input, frame, output),)*
+                        #(W => $unpack::<W, false>(input, frame, &[], output),)*
                         _ => unreachable!("invalid FastLanes bit width {width}"),
                     }
                 })
+            }
+
+            fn unpack_delta_bytes(width: usize, input: &[u8], frame: Self, starts: &[u8], output: &mut [Self]) {
+                assert!(width <= $bits);
+                assert_eq!(input.len(), VECTOR_SIZE * width / 8);
+                assert_eq!(starts.len(), 128);
+                assert_eq!(output.len(), VECTOR_SIZE);
+                let mut transposed = [0; VECTOR_SIZE];
+                seq_macro::seq!(W in 0..=$bits {
+                    match width {
+                        #(W => $unpack::<W, true>(input, frame, starts, &mut transposed),)*
+                        _ => unreachable!("invalid FastLanes bit width {width}"),
+                    }
+                });
+                untranspose::<$ty, $bits>(&transposed, output);
+            }
+
+            fn restore_delta(starts: &[u8], output: &mut [Self]) {
+                assert_eq!(starts.len(), 128);
+                assert_eq!(output.len(), VECTOR_SIZE);
+                // Unroll each chain so the independent outer lane loop can be
+                // vectorized. Patch values have already replaced differences.
+                let mut transposed = [0; VECTOR_SIZE];
+                for lane in 0..VECTOR_SIZE / $bits {
+                    let mut acc = $load(starts, lane);
+                    seq_macro::seq!(ROW in 0..$bits {
+                        let index = utl_index(ROW, lane);
+                        acc = acc.wrapping_add(output[index]);
+                        transposed[index] = acc;
+                    });
+                }
+                untranspose::<$ty, $bits>(&transposed, output);
             }
 
             #[cfg(test)]
@@ -185,20 +259,37 @@ macro_rules! impl_fastlanes_bitpacking {
         }
 
         #[inline(never)]
-        fn $unpack<const W: usize>(input: &[u8], frame: $ty, output: &mut [$ty]) {
+        fn $unpack<const W: usize, const DELTA: bool>(input: &[u8], frame: $ty, starts: &[u8], output: &mut [$ty]) {
             const LANES: usize = VECTOR_SIZE / $bits;
             if W == 0 {
-                output.fill(frame);
+                if DELTA {
+                    for lane in 0..LANES {
+                        let mut acc = $load(starts, lane);
+                        seq_macro::seq!(ROW in 0..$bits {
+                            acc = acc.wrapping_add(frame);
+                            output[utl_index(ROW, lane)] = acc;
+                        });
+                    }
+                } else {
+                    output.fill(frame);
+                }
                 return;
             }
 
             for lane in 0..LANES {
+                let mut acc = if DELTA { $load(starts, lane) } else { 0 };
                 if W == $bits {
                     seq_macro::seq!(ROW in 0..$bits {
                         let order = ROW / 8;
                         let sub_row = ROW % 8;
                         let index = FL_ORDER[order] * 16 + sub_row * 128 + lane;
-                        output[index] = $load(input, LANES * ROW + lane).wrapping_add(frame);
+                        let value = $load(input, LANES * ROW + lane).wrapping_add(frame);
+                        if DELTA {
+                            acc = acc.wrapping_add(value);
+                            output[index] = acc;
+                        } else {
+                            output[index] = value;
+                        }
                     });
                 } else {
                     let mask = |width: usize| (<$ty>::from(1u8) << width) - 1;
@@ -223,7 +314,13 @@ macro_rules! impl_fastlanes_bitpacking {
                         let order = ROW / 8;
                         let sub_row = ROW % 8;
                         let index = FL_ORDER[order] * 16 + sub_row * 128 + lane;
-                        output[index] = value.wrapping_add(frame);
+                        let value = value.wrapping_add(frame);
+                        if DELTA {
+                            acc = acc.wrapping_add(value);
+                            output[index] = acc;
+                        } else {
+                            output[index] = value;
+                        }
                     });
                 }
             }
@@ -237,7 +334,88 @@ impl_fastlanes_bitpacking!(u64, 64, load_u64, store_u64, pack_impl_u64, unpack_i
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fastlanes::BitPacking;
+    use fastlanes::{BitPacking, Delta, Transpose};
+
+    #[test]
+    fn utl_delta_kernels_match_independent_lane_sums_at_every_width() {
+        macro_rules! check {
+            ($ty:ty, $bits:literal) => {
+                for width in 0..=$bits {
+                    let mask = <$ty>::MAX >> ($bits - width).min($bits - 1);
+                    let mask = if width == 0 { 0 } else { mask };
+                    let frame = <$ty>::MAX - 7;
+                    let mut residuals: [$ty; VECTOR_SIZE] = [0; VECTOR_SIZE];
+                    let mut expected: [$ty; VECTOR_SIZE] = [0; VECTOR_SIZE];
+                    let mut starts = Vec::new();
+                    for lane in 0..VECTOR_SIZE / $bits {
+                        let mut acc = (<$ty>::MAX - lane as $ty).wrapping_mul(1009);
+                        starts.extend_from_slice(&acc.to_le_bytes());
+                        for row in 0..$bits {
+                            let residual =
+                                ((lane * $bits + row) as $ty).wrapping_mul(0x9e37_79b9) & mask;
+                            residuals[utl_index(row, lane)] = residual;
+                            acc = acc.wrapping_add(residual).wrapping_add(frame);
+                            expected[lane * $bits + row] = acc;
+                        }
+                    }
+                    // Also check the running sums and permutation against the
+                    // actual FastLanes implementation used by Vortex. Mode 2
+                    // numbers i32 chains consecutively; the universal reference
+                    // puts the two halves of each 64-value run 16 lanes apart.
+                    let deltas = std::array::from_fn(|i| residuals[i].wrapping_add(frame));
+                    let bases = std::array::from_fn(|i| {
+                        let at = i * std::mem::size_of::<$ty>();
+                        <$ty>::from_le_bytes(
+                            starts[at..at + std::mem::size_of::<$ty>()]
+                                .try_into()
+                                .unwrap(),
+                        )
+                    });
+                    let mut reference_transposed = [0; VECTOR_SIZE];
+                    <$ty as Delta>::undelta::<{ VECTOR_SIZE / $bits }>(
+                        &deltas,
+                        &bases,
+                        &mut reference_transposed,
+                    );
+                    let mut reference = [0; VECTOR_SIZE];
+                    <$ty as Transpose>::untranspose(&reference_transposed, &mut reference);
+                    for lane in 0..VECTOR_SIZE / $bits {
+                        for row in 0..$bits {
+                            assert_eq!(
+                                expected[lane * $bits + row],
+                                reference[(lane % 16) * 64 + (lane / 16) * $bits + row]
+                            );
+                        }
+                    }
+                    // The packed stream is produced by the independent upstream
+                    // bitpacking oracle, not our packer.
+                    let mut words: Vec<$ty> = vec![0; VECTOR_SIZE * width / $bits];
+                    unsafe { <$ty as BitPacking>::unchecked_pack(width, &residuals, &mut words) };
+                    let packed: Vec<u8> = words.iter().flat_map(|w| w.to_le_bytes()).collect();
+                    for offset in 0..8 {
+                        let mut unaligned = vec![0xa5; offset];
+                        unaligned.extend_from_slice(&packed);
+                        let mut unaligned_starts = vec![0xa5; offset];
+                        unaligned_starts.extend_from_slice(&starts);
+                        let mut out: [$ty; VECTOR_SIZE] = [0; VECTOR_SIZE];
+                        <$ty>::unpack_delta_bytes(
+                            width,
+                            &unaligned[offset..],
+                            frame,
+                            &unaligned_starts[offset..],
+                            &mut out,
+                        );
+                        assert_eq!(out, expected, "fused width {width}, offset {offset}");
+                        <$ty>::unpack_for_bytes(width, &unaligned[offset..], frame, &mut out);
+                        <$ty>::restore_delta(&unaligned_starts[offset..], &mut out);
+                        assert_eq!(out, expected, "separate width {width}, offset {offset}");
+                    }
+                }
+            };
+        }
+        check!(u32, 32);
+        check!(u64, 64);
+    }
 
     fn check_u32(width: usize) {
         let input: Vec<u32> = (0..VECTOR_SIZE)

--- a/parquet/src/encodings/mod.rs
+++ b/parquet/src/encodings/mod.rs
@@ -18,4 +18,5 @@
 pub mod decoding;
 pub mod encoding;
 pub mod levels;
+pub mod pfor;
 experimental!(pub(crate) mod rle);

--- a/parquet/src/encodings/mod.rs
+++ b/parquet/src/encodings/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod decoding;
 pub mod encoding;
+mod fastlanes;
 pub mod levels;
 pub mod pfor;
 experimental!(pub(crate) mod rle);

--- a/parquet/src/encodings/pfor.rs
+++ b/parquet/src/encodings/pfor.rs
@@ -1,0 +1,790 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Wire format shared by the PFOR encoder and decoder.
+//!
+//! PFOR (Patched Frame of Reference) compresses an integer column in fixed-size vectors. Each
+//! vector subtracts a frame of reference from its values, bit-packs the residuals at a width
+//! chosen by a cost model, and stores the values that do not fit at that width separately, as
+//! exceptions patched back in on the way out.
+//!
+//! A page is laid out as
+//!
+//! ```text
+//! [header: 7 bytes] [offset array: num_vectors * 4 bytes] [vector 0] [vector 1] ...
+//! ```
+//!
+//! and each vector as
+//!
+//! ```text
+//! [info block] [start value, only when differencing] [packed residuals]
+//! [exception positions] [exception values]
+//! ```
+//!
+//! Every multi-byte field is little-endian.
+
+use crate::errors::{ParquetError, Result};
+use crate::util::bit_util::FromBitpacked;
+
+/// Number of elements compressed together as a unit, by default.
+pub const DEFAULT_VECTOR_SIZE: usize = 1 << DEFAULT_LOG_VECTOR_SIZE;
+
+/// `log2` of [`DEFAULT_VECTOR_SIZE`].
+pub const DEFAULT_LOG_VECTOR_SIZE: u8 = 10;
+
+/// Smallest vector the page header can describe, as a log.
+pub const MIN_LOG_VECTOR_SIZE: u8 = 3;
+
+/// Largest vector the page header can describe, as a log.
+pub const MAX_LOG_VECTOR_SIZE: u8 = 15;
+
+/// Largest vector the format allows, in elements.
+pub const MAX_VECTOR_SIZE: usize = 1 << MAX_LOG_VECTOR_SIZE;
+
+/// Width of one entry in the per-page offset array.
+pub const OFFSET_SIZE: usize = std::mem::size_of::<u32>();
+
+/// Width of one exception position.
+pub const POSITION_SIZE: usize = std::mem::size_of::<u16>();
+
+/// Page header size in bytes: `packing_mode`, `log_vector_size` and `value_byte_width` one byte
+/// each, then `num_elements` as a four-byte little-endian signed integer.
+pub const HEADER_SIZE: usize = 3 + std::mem::size_of::<i32>();
+
+/// Packing mode: frame of reference plus bit-packing, currently the only mode.
+pub const PACKING_MODE_FOR_BIT_PACK: u8 = 0;
+
+/// Mask selecting the bit width out of the info block's width byte.
+pub const BIT_WIDTH_MASK: u8 = 0x7F;
+
+/// Bit of the info block's width byte that marks a differenced vector.
+pub const DELTA_FLAG: u8 = 0x80;
+
+/// Bits an exception costs on the wire: its position plus a full-width value.
+pub const fn exception_bits(byte_width: usize) -> i64 {
+    ((POSITION_SIZE + byte_width) * 8) as i64
+}
+
+/// The integer types PFOR encodes, and the arithmetic the codec needs from them.
+///
+/// PFOR does all of its arithmetic in the unsigned counterpart of the value type. Subtracting the
+/// frame wraps rather than overflows, which is what lets a frame sit above the minimum: a value
+/// below the frame wraps to a huge residual, fails the width test like any value above the window,
+/// and is patched from the exception list. Nothing here is exposed outside the crate.
+pub trait PforInt:
+    Copy + Default + Ord + Send + std::fmt::Debug + FromBitpacked + 'static
+{
+    /// Width of one value on the wire, in bytes: 4 for INT32, 8 for INT64.
+    const BYTE_WIDTH: usize;
+
+    /// Widest bit width the type can pack at, and the largest the width byte may hold.
+    const MAX_BIT_WIDTH: u8;
+
+    /// Bytes the info block occupies, start value excluded: frame, width byte, exception count.
+    const INFO_SIZE: usize = Self::BYTE_WIDTH + 1 + std::mem::size_of::<u16>();
+
+    /// Reinterpret as unsigned. Bit-preserving.
+    /// Mask of the bits a residual can occupy, which is the type's own width.
+    const RESIDUAL_MASK: u64 = low_mask(Self::MAX_BIT_WIDTH);
+
+    fn to_bits(self) -> u64;
+
+    /// Reinterpret from unsigned, taking the low [`Self::BYTE_WIDTH`] bytes. Bit-preserving.
+    fn from_bits(bits: u64) -> Self;
+
+    /// Read one value from the first [`Self::BYTE_WIDTH`] bytes of `bytes`, little-endian.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bytes` is shorter than [`Self::BYTE_WIDTH`]. Callers check the length of a
+    /// vector's sections against the buffer before reading any of them.
+    fn read_le(bytes: &[u8]) -> Self;
+
+    /// Append this value to `out`, little-endian.
+    fn write_le(self, out: &mut Vec<u8>);
+
+    /// `self - frame_bits`, in the type's own width.
+    ///
+    /// PFOR's residual test is a single unsigned comparison, and it only works if the subtraction
+    /// wraps at the column's width: on an INT32 column a value below the frame has to wrap to a
+    /// 32-bit residual. Wrapping at 64 bits instead puts it beyond every width the type has, which
+    /// makes even the full-width candidate look like it needs exceptions -- and that candidate
+    /// costing no more than the values unpacked is what bounds the size of a page.
+    #[inline]
+    fn residual_from(self, frame_bits: u64) -> u64 {
+        self.to_bits().wrapping_sub(frame_bits) & Self::RESIDUAL_MASK
+    }
+}
+
+impl PforInt for i32 {
+    const BYTE_WIDTH: usize = 4;
+    const MAX_BIT_WIDTH: u8 = 32;
+
+    #[inline]
+    fn to_bits(self) -> u64 {
+        self as u32 as u64
+    }
+
+    #[inline]
+    fn from_bits(bits: u64) -> Self {
+        bits as u32 as i32
+    }
+
+    #[inline]
+    fn read_le(bytes: &[u8]) -> Self {
+        i32::from_le_bytes(bytes[..4].try_into().unwrap())
+    }
+
+    #[inline]
+    fn write_le(self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.to_le_bytes());
+    }
+}
+
+impl PforInt for i64 {
+    const BYTE_WIDTH: usize = 8;
+    const MAX_BIT_WIDTH: u8 = 64;
+
+    #[inline]
+    fn to_bits(self) -> u64 {
+        self as u64
+    }
+
+    #[inline]
+    fn from_bits(bits: u64) -> Self {
+        bits as i64
+    }
+
+    #[inline]
+    fn read_le(bytes: &[u8]) -> Self {
+        i64::from_le_bytes(bytes[..8].try_into().unwrap())
+    }
+
+    #[inline]
+    fn write_le(self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.to_le_bytes());
+    }
+}
+
+/// Bits needed to hold `value`, i.e. the position of its highest set bit. Zero needs none.
+#[inline]
+pub fn bits_required(value: u64) -> u8 {
+    (u64::BITS - value.leading_zeros()) as u8
+}
+
+/// Mask of the low `bit_width` bits, saturating at all ones.
+#[inline]
+pub const fn low_mask(bit_width: u8) -> u64 {
+    if bit_width >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << bit_width) - 1
+    }
+}
+
+/// Bytes needed to hold `bits`, rounded up.
+#[inline]
+pub fn bytes_for_bits(bits: usize) -> usize {
+    bits.div_ceil(8)
+}
+
+/// Accept only the vector sizes the page header can describe.
+///
+/// A size outside this range would encode a page that the decoder then rejects, so refuse it up
+/// front.
+pub fn validate_vector_size(vector_size: usize) -> Result<u8> {
+    if !vector_size.is_power_of_two()
+        || !((1 << MIN_LOG_VECTOR_SIZE)..=MAX_VECTOR_SIZE).contains(&vector_size)
+    {
+        return Err(general_err!(
+            "PFOR vector_size must be a power of two in [{}, {}]: {}",
+            1 << MIN_LOG_VECTOR_SIZE,
+            MAX_VECTOR_SIZE,
+            vector_size
+        ));
+    }
+    Ok(vector_size.trailing_zeros() as u8)
+}
+
+/// The per-page header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PforHeader {
+    /// How the residuals are laid out. Always [`PACKING_MODE_FOR_BIT_PACK`] today.
+    pub packing_mode: u8,
+    /// `log2` of the number of elements per vector.
+    pub log_vector_size: u8,
+    /// Width of one value on the wire, in bytes.
+    pub value_byte_width: u8,
+    /// Total number of values the page holds, nulls excluded.
+    pub num_elements: i32,
+}
+
+impl PforHeader {
+    /// Number of elements per vector.
+    pub fn vector_size(&self) -> usize {
+        1usize << self.log_vector_size
+    }
+
+    /// Number of vectors the page holds.
+    pub fn num_vectors(&self) -> usize {
+        (self.num_elements as usize).div_ceil(self.vector_size())
+    }
+
+    /// Append this header to `out`.
+    pub fn write(&self, out: &mut Vec<u8>) {
+        out.push(self.packing_mode);
+        out.push(self.log_vector_size);
+        out.push(self.value_byte_width);
+        out.extend_from_slice(&self.num_elements.to_le_bytes());
+    }
+
+    /// Read and validate a header from the front of `src`.
+    ///
+    /// Every field is checked here rather than where it is used, because each of them sizes a read
+    /// further down: the packing mode selects the layout, the byte width has to match the column's
+    /// type, the vector size divides the page into vectors, and the element count bounds the
+    /// output.
+    pub fn read<T: PforInt>(src: &[u8]) -> Result<Self> {
+        if src.len() < HEADER_SIZE {
+            return Err(general_err!(
+                "PFOR compressed buffer too small for header: {} < {}",
+                src.len(),
+                HEADER_SIZE
+            ));
+        }
+        let header = PforHeader {
+            packing_mode: src[0],
+            log_vector_size: src[1],
+            value_byte_width: src[2],
+            num_elements: i32::from_le_bytes(src[3..7].try_into().unwrap()),
+        };
+        if header.packing_mode != PACKING_MODE_FOR_BIT_PACK {
+            return Err(general_err!(
+                "PFOR unsupported packing mode: {}",
+                header.packing_mode
+            ));
+        }
+        if header.value_byte_width as usize != T::BYTE_WIDTH {
+            return Err(general_err!(
+                "PFOR value_byte_width mismatch: {} vs expected {}",
+                header.value_byte_width,
+                T::BYTE_WIDTH
+            ));
+        }
+        if header.log_vector_size < MIN_LOG_VECTOR_SIZE
+            || header.log_vector_size > MAX_LOG_VECTOR_SIZE
+        {
+            return Err(general_err!(
+                "PFOR invalid log_vector_size: {}",
+                header.log_vector_size
+            ));
+        }
+        if header.num_elements < 0 {
+            return Err(general_err!(
+                "PFOR invalid num_elements: {}",
+                header.num_elements
+            ));
+        }
+        Ok(header)
+    }
+}
+
+/// The per-vector info block.
+///
+/// For INT32 it is 7 bytes, for INT64 11:
+///
+/// ```text
+/// [frame of reference: 4 or 8 bytes] [width byte] [exception count: 2 bytes]
+/// ```
+///
+/// The width byte holds the bit width in bits 0..6 and the differencing flag in bit 7. A vector
+/// with the flag set packs the backward differences of its values rather than the values, and
+/// carries one extra full-width field after this block -- the vector's first value -- so that it
+/// still decodes without reading the vector before it.
+///
+/// Seven bits for the width, not six: the range is 0..64 inclusive, and 64 does not fit in six. A
+/// six-bit field stored an INT64 vector whose differences need the full 64 bits as width 0, and
+/// since such a vector has no exceptions either, the decoder read it as a constant vector and
+/// filled the output with the frame of reference -- silently, with no error and no size mismatch.
+///
+/// The exception count is unsigned: a vector holds up to [`MAX_VECTOR_SIZE`] elements and every
+/// one of them can be an exception, so a count of 32768 has to be representable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PforVectorInfo<T> {
+    /// Subtracted from every element before packing; added back on decode.
+    pub frame_of_reference: T,
+    /// Bits each packed residual occupies. Zero means the vector packs nothing at all.
+    pub bit_width: u8,
+    /// Number of values that did not fit at `bit_width` and travel as exceptions.
+    pub num_exceptions: u16,
+    /// Whether the packed residuals are backward differences rather than values.
+    pub is_delta: bool,
+}
+
+impl<T: PforInt> PforVectorInfo<T> {
+    /// Bytes this info occupies on the wire, start value included.
+    ///
+    /// Not a constant: the start value is only present on a differenced vector. Paying for it
+    /// unconditionally would be free at a 1024-value vector and ruinous at the smallest one the
+    /// format allows, where eight bytes across eight values is a byte per value.
+    pub fn stored_bytes(&self) -> usize {
+        T::INFO_SIZE + if self.is_delta { T::BYTE_WIDTH } else { 0 }
+    }
+
+    /// Append this info to `out`.
+    ///
+    /// # Panics
+    ///
+    /// Panics on a width above the type's maximum. Such a width would lose its high bits to the
+    /// mask and set the differencing flag on the way out, turning an encoder bug into a page that
+    /// decodes to the wrong values with no error anywhere. [`Self::read`] rejects it on the way
+    /// in; this catches it on the way out, where the bug is.
+    pub fn write(&self, out: &mut Vec<u8>) {
+        assert!(
+            self.bit_width <= T::MAX_BIT_WIDTH,
+            "PFOR bit_width {} exceeds the {} the type allows",
+            self.bit_width,
+            T::MAX_BIT_WIDTH
+        );
+        self.frame_of_reference.write_le(out);
+        out.push((self.bit_width & BIT_WIDTH_MASK) | if self.is_delta { DELTA_FLAG } else { 0 });
+        out.extend_from_slice(&self.num_exceptions.to_le_bytes());
+    }
+
+    /// Read an info block from the front of `src`.
+    pub fn read(src: &[u8]) -> Result<Self> {
+        if src.len() < T::INFO_SIZE {
+            return Err(general_err!(
+                "PFOR vector info buffer too small: {} < {}",
+                src.len(),
+                T::INFO_SIZE
+            ));
+        }
+        let frame_of_reference = T::read_le(src);
+        let width_byte = src[T::BYTE_WIDTH];
+        let info = PforVectorInfo {
+            frame_of_reference,
+            bit_width: width_byte & BIT_WIDTH_MASK,
+            num_exceptions: u16::from_le_bytes(
+                src[T::BYTE_WIDTH + 1..T::BYTE_WIDTH + 3].try_into().unwrap(),
+            ),
+            is_delta: width_byte & DELTA_FLAG != 0,
+        };
+        if info.bit_width > T::MAX_BIT_WIDTH {
+            return Err(general_err!(
+                "PFOR bit_width out of range: {}",
+                info.bit_width
+            ));
+        }
+        // A count above the largest vector the format allows cannot be honest, whatever this
+        // vector's own element count turns out to be, and rejecting it here keeps the check off
+        // the per-vector path.
+        if info.num_exceptions as usize > MAX_VECTOR_SIZE {
+            return Err(general_err!(
+                "PFOR num_exceptions exceeds the maximum vector size: {}",
+                info.num_exceptions
+            ));
+        }
+        Ok(info)
+    }
+}
+
+/// Check the whole offset array before any of it steers a read.
+///
+/// The offsets are byte counts from the start of the offset array, and the vectors they point at
+/// were written back to back in order, so a well-formed page has the first offset landing just
+/// past the array and the rest strictly increasing. Checking the chain as a whole, before decoding
+/// any of it, keeps a page whose offsets overlap or run backwards from decoding part-way and
+/// emitting values built out of the wrong bytes.
+pub fn validate_offsets(offsets: &[u8], num_vectors: usize, payload_size: usize) -> Result<()> {
+    let offset_array_size = num_vectors * OFFSET_SIZE;
+    let mut previous = 0usize;
+    for v in 0..num_vectors {
+        let offset = read_offset(offsets, v);
+        if v == 0 {
+            if offset != offset_array_size {
+                return Err(general_err!(
+                    "PFOR first vector offset {} does not follow the {} byte offset array",
+                    offset,
+                    offset_array_size
+                ));
+            }
+        } else if offset <= previous {
+            return Err(general_err!(
+                "PFOR vector {} offset {} does not follow offset {} of the vector before it",
+                v,
+                offset,
+                previous
+            ));
+        }
+        if offset >= payload_size {
+            return Err(general_err!(
+                "PFOR vector {} offset {} is past the end of the {} byte payload",
+                v,
+                offset,
+                payload_size
+            ));
+        }
+        previous = offset;
+    }
+    Ok(())
+}
+
+/// Read entry `index` of an offset array.
+///
+/// # Panics
+///
+/// Panics if `offsets` is shorter than `(index + 1) * OFFSET_SIZE`. Callers check the array
+/// against the buffer before reading any of it.
+#[inline]
+pub fn read_offset(offsets: &[u8], index: usize) -> usize {
+    let at = index * OFFSET_SIZE;
+    u32::from_le_bytes(offsets[at..at + OFFSET_SIZE].try_into().unwrap()) as usize
+}
+
+/// Largest page `num_values` values can compress to, at `vector_size` values per vector.
+///
+/// A vector never serializes to more than its values occupy unpacked. The cost model minimises
+/// `num_elements * bit_width + num_exceptions * exception_bits`, and the full-width candidate
+/// scores `num_elements * 8 * byte_width` bits with no exceptions at all, so whatever width it
+/// does pick costs no more than that. Bit packing rounds the packed section up to a whole byte,
+/// hence the trailing byte. Differencing adds one full-width start value, and the model only
+/// chooses it when doing so still comes out cheaper, but the bound has to hold either way.
+pub fn max_compressed_size<T: PforInt>(num_values: usize, vector_size: usize) -> Result<usize> {
+    validate_vector_size(vector_size)?;
+    let num_vectors = num_values.div_ceil(vector_size);
+    let max_vector_size = T::INFO_SIZE + T::BYTE_WIDTH + vector_size * T::BYTE_WIDTH + 1;
+    Ok(HEADER_SIZE + num_vectors * (OFFSET_SIZE + max_vector_size))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bits_required() {
+        assert_eq!(bits_required(0), 0);
+        assert_eq!(bits_required(1), 1);
+        assert_eq!(bits_required(2), 2);
+        assert_eq!(bits_required(255), 8);
+        assert_eq!(bits_required(256), 9);
+        assert_eq!(bits_required(u64::MAX), 64);
+    }
+
+    #[test]
+    fn test_low_mask() {
+        assert_eq!(low_mask(0), 0);
+        assert_eq!(low_mask(1), 1);
+        assert_eq!(low_mask(8), 0xFF);
+        assert_eq!(low_mask(63), i64::MAX as u64);
+        // The shift that builds the mask overflows at the full width, so it is a special case.
+        assert_eq!(low_mask(64), u64::MAX);
+    }
+
+    #[test]
+    fn test_bytes_for_bits() {
+        assert_eq!(bytes_for_bits(0), 0);
+        assert_eq!(bytes_for_bits(1), 1);
+        assert_eq!(bytes_for_bits(8), 1);
+        assert_eq!(bytes_for_bits(9), 2);
+    }
+
+    #[test]
+    fn test_exception_bits() {
+        // A position plus a full-width value, in bits.
+        assert_eq!(exception_bits(4), 48);
+        assert_eq!(exception_bits(8), 80);
+    }
+
+    #[test]
+    fn test_validate_vector_size() {
+        assert_eq!(validate_vector_size(8).unwrap(), 3);
+        assert_eq!(validate_vector_size(1024).unwrap(), 10);
+        assert_eq!(validate_vector_size(1 << 15).unwrap(), 15);
+        // Below the minimum, above the maximum, and not a power of two.
+        assert!(validate_vector_size(4).is_err());
+        assert!(validate_vector_size(1 << 16).is_err());
+        assert!(validate_vector_size(1000).is_err());
+        assert!(validate_vector_size(0).is_err());
+    }
+
+    #[test]
+    fn test_header_round_trip() {
+        let header = PforHeader {
+            packing_mode: PACKING_MODE_FOR_BIT_PACK,
+            log_vector_size: DEFAULT_LOG_VECTOR_SIZE,
+            value_byte_width: 4,
+            num_elements: 3000,
+        };
+        let mut buf = Vec::new();
+        header.write(&mut buf);
+
+        // The byte layout is part of the format, so it is asserted rather than just round-tripped.
+        assert_eq!(buf.len(), HEADER_SIZE);
+        assert_eq!(buf, vec![0, 10, 4, 0xB8, 0x0B, 0x00, 0x00]);
+
+        let read = PforHeader::read::<i32>(&buf).unwrap();
+        assert_eq!(read, header);
+        assert_eq!(read.vector_size(), 1024);
+        assert_eq!(read.num_vectors(), 3);
+    }
+
+    #[test]
+    fn test_header_num_vectors() {
+        let header = |num_elements| PforHeader {
+            packing_mode: PACKING_MODE_FOR_BIT_PACK,
+            log_vector_size: 3,
+            value_byte_width: 4,
+            num_elements,
+        };
+        assert_eq!(header(0).num_vectors(), 0);
+        assert_eq!(header(1).num_vectors(), 1);
+        assert_eq!(header(8).num_vectors(), 1);
+        assert_eq!(header(9).num_vectors(), 2);
+    }
+
+    #[test]
+    fn test_header_rejections() {
+        let good = PforHeader {
+            packing_mode: PACKING_MODE_FOR_BIT_PACK,
+            log_vector_size: DEFAULT_LOG_VECTOR_SIZE,
+            value_byte_width: 4,
+            num_elements: 10,
+        };
+        let bytes = |header: &PforHeader| {
+            let mut buf = Vec::new();
+            header.write(&mut buf);
+            buf
+        };
+
+        // Truncated, one byte short of a header.
+        let buf = bytes(&good);
+        assert!(PforHeader::read::<i32>(&buf[..HEADER_SIZE - 1]).is_err());
+
+        // A packing mode this implementation does not have.
+        let mut buf = bytes(&good);
+        buf[0] = 1;
+        assert!(PforHeader::read::<i32>(&buf).is_err());
+
+        // An INT64 page read as INT32.
+        let mut buf = bytes(&good);
+        buf[2] = 8;
+        assert!(PforHeader::read::<i32>(&buf).is_err());
+        assert!(PforHeader::read::<i64>(&buf).is_ok());
+
+        // Vector sizes outside [2^3, 2^15].
+        for log_vector_size in [0u8, 2, 16, 63, 255] {
+            let mut buf = bytes(&good);
+            buf[1] = log_vector_size;
+            assert!(
+                PforHeader::read::<i32>(&buf).is_err(),
+                "log_vector_size {log_vector_size} should be rejected"
+            );
+        }
+
+        // A negative element count, which would otherwise size an allocation.
+        let mut buf = bytes(&good);
+        buf[3..7].copy_from_slice(&(-1i32).to_le_bytes());
+        assert!(PforHeader::read::<i32>(&buf).is_err());
+    }
+
+    #[test]
+    fn test_vector_info_round_trip_i32() {
+        let info = PforVectorInfo::<i32> {
+            frame_of_reference: -5,
+            bit_width: 9,
+            num_exceptions: 3,
+            is_delta: false,
+        };
+        let mut buf = Vec::new();
+        info.write(&mut buf);
+        assert_eq!(buf.len(), <i32 as PforInt>::INFO_SIZE);
+        assert_eq!(buf, vec![0xFB, 0xFF, 0xFF, 0xFF, 9, 3, 0]);
+        assert_eq!(PforVectorInfo::<i32>::read(&buf).unwrap(), info);
+        assert_eq!(info.stored_bytes(), 7);
+    }
+
+    #[test]
+    fn test_vector_info_round_trip_i64() {
+        let info = PforVectorInfo::<i64> {
+            frame_of_reference: 1,
+            bit_width: 33,
+            num_exceptions: 0,
+            is_delta: false,
+        };
+        let mut buf = Vec::new();
+        info.write(&mut buf);
+        assert_eq!(buf.len(), <i64 as PforInt>::INFO_SIZE);
+        assert_eq!(buf, vec![1, 0, 0, 0, 0, 0, 0, 0, 33, 0, 0]);
+        assert_eq!(PforVectorInfo::<i64>::read(&buf).unwrap(), info);
+        assert_eq!(info.stored_bytes(), 11);
+    }
+
+    #[test]
+    fn test_vector_info_delta_flag() {
+        let info = PforVectorInfo::<i32> {
+            frame_of_reference: 0,
+            bit_width: 7,
+            num_exceptions: 0,
+            is_delta: true,
+        };
+        let mut buf = Vec::new();
+        info.write(&mut buf);
+        // The flag rides in bit 7 of the width byte, leaving seven bits of width.
+        assert_eq!(buf[4], 7 | DELTA_FLAG);
+        let read = PforVectorInfo::<i32>::read(&buf).unwrap();
+        assert_eq!(read.bit_width, 7);
+        assert!(read.is_delta);
+    }
+
+    #[test]
+    fn test_vector_info_full_width() {
+        // Width 64 is a legal width for INT64 and needs all seven bits of the field. A six-bit
+        // field truncates it to 0, which decodes as a constant vector: silent corruption, so it is
+        // asserted on both sides.
+        let info = PforVectorInfo::<i64> {
+            frame_of_reference: 0,
+            bit_width: 64,
+            num_exceptions: 0,
+            is_delta: false,
+        };
+        let mut buf = Vec::new();
+        info.write(&mut buf);
+        assert_eq!(buf[8], 64);
+        assert_eq!(PforVectorInfo::<i64>::read(&buf).unwrap().bit_width, 64);
+
+        // The same width, with the delta flag beside it.
+        let info = PforVectorInfo::<i64> {
+            is_delta: true,
+            ..info
+        };
+        let mut buf = Vec::new();
+        info.write(&mut buf);
+        assert_eq!(buf[8], 64 | DELTA_FLAG);
+        let read = PforVectorInfo::<i64>::read(&buf).unwrap();
+        assert_eq!(read.bit_width, 64);
+        assert!(read.is_delta);
+    }
+
+    #[test]
+    fn test_vector_info_rejections() {
+        // Truncated info block.
+        let buf = vec![0u8; <i32 as PforInt>::INFO_SIZE - 1];
+        assert!(PforVectorInfo::<i32>::read(&buf).is_err());
+
+        // Width 33 on an INT32 column: nothing can pack to it, and it would size reads past the
+        // vector.
+        let mut buf = vec![0u8; <i32 as PforInt>::INFO_SIZE];
+        buf[4] = 33;
+        assert!(PforVectorInfo::<i32>::read(&buf).is_err());
+        buf[4] = 32;
+        assert!(PforVectorInfo::<i32>::read(&buf).is_ok());
+
+        // More exceptions than the largest vector the format allows.
+        let mut buf = vec![0u8; <i32 as PforInt>::INFO_SIZE];
+        buf[5..7].copy_from_slice(&((MAX_VECTOR_SIZE + 1) as u16).to_le_bytes());
+        assert!(PforVectorInfo::<i32>::read(&buf).is_err());
+    }
+
+    #[test]
+    fn test_vector_info_stored_bytes_covers_the_start_value() {
+        let info = PforVectorInfo::<i32> {
+            frame_of_reference: 0,
+            bit_width: 3,
+            num_exceptions: 2,
+            is_delta: false,
+        };
+        assert_eq!(info.stored_bytes(), <i32 as PforInt>::INFO_SIZE);
+        // Differencing puts one full-width start value between the info and the packed residuals,
+        // so the offset the packed section starts at moves.
+        let info = PforVectorInfo::<i32> {
+            is_delta: true,
+            ..info
+        };
+        assert_eq!(info.stored_bytes(), <i32 as PforInt>::INFO_SIZE + 4);
+
+        let info = PforVectorInfo::<i64> {
+            frame_of_reference: 0,
+            bit_width: 3,
+            num_exceptions: 0,
+            is_delta: true,
+        };
+        assert_eq!(info.stored_bytes(), <i64 as PforInt>::INFO_SIZE + 8);
+    }
+
+    /// An offset array holding `offsets`, as it appears on the wire.
+    fn offset_bytes(offsets: &[u32]) -> Vec<u8> {
+        offsets.iter().flat_map(|o| o.to_le_bytes()).collect()
+    }
+
+    #[test]
+    fn test_validate_offsets_accepts_well_formed() {
+        let offsets = offset_bytes(&[8, 20]);
+        assert!(validate_offsets(&offsets, 2, 40).is_ok());
+        // A page of one vector, whose single offset lands just past the array.
+        let offsets = offset_bytes(&[4]);
+        assert!(validate_offsets(&offsets, 1, 20).is_ok());
+        // No vectors at all: nothing to check, and nothing to reject.
+        assert!(validate_offsets(&[], 0, 0).is_ok());
+    }
+
+    #[test]
+    fn test_validate_offsets_rejections() {
+        // The first offset has to land exactly past the offset array, so neither a gap nor an
+        // overlap with the array itself is accepted.
+        assert!(validate_offsets(&offset_bytes(&[9, 20]), 2, 40).is_err());
+        assert!(validate_offsets(&offset_bytes(&[7, 20]), 2, 40).is_err());
+
+        // Equal offsets mean a zero-length vector; a decreasing pair means the second vector
+        // starts inside the first. Both would decode values out of the wrong bytes.
+        assert!(validate_offsets(&offset_bytes(&[8, 8]), 2, 40).is_err());
+        assert!(validate_offsets(&offset_bytes(&[8, 20, 12]), 3, 40).is_err());
+
+        // Past the end of the payload, and exactly at its end -- which leaves the vector no bytes.
+        assert!(validate_offsets(&offset_bytes(&[8, 41]), 2, 40).is_err());
+        assert!(validate_offsets(&offset_bytes(&[8, 40]), 2, 40).is_err());
+    }
+
+    #[test]
+    fn test_read_offset() {
+        let offsets = offset_bytes(&[8, 0x0102_0304]);
+        assert_eq!(read_offset(&offsets, 0), 8);
+        assert_eq!(read_offset(&offsets, 1), 0x0102_0304);
+    }
+
+    #[test]
+    fn test_max_compressed_size() {
+        // A page of one 8-value INT32 vector: header, one offset, info, a start value, the values
+        // unpacked, and the byte the packed section can round up to.
+        assert_eq!(
+            max_compressed_size::<i32>(8, 8).unwrap(),
+            HEADER_SIZE + 4 + 7 + 4 + 8 * 4 + 1
+        );
+        // Two vectors' worth, the second of them partial.
+        assert_eq!(
+            max_compressed_size::<i32>(9, 8).unwrap(),
+            HEADER_SIZE + 2 * (4 + 7 + 4 + 8 * 4 + 1)
+        );
+        assert_eq!(
+            max_compressed_size::<i64>(8, 8).unwrap(),
+            HEADER_SIZE + 4 + 11 + 8 + 8 * 8 + 1
+        );
+        // An empty page is a bare header.
+        assert_eq!(max_compressed_size::<i32>(0, 8).unwrap(), HEADER_SIZE);
+        assert!(max_compressed_size::<i32>(8, 1000).is_err());
+    }
+}

--- a/parquet/src/encodings/pfor.rs
+++ b/parquet/src/encodings/pfor.rs
@@ -41,41 +41,41 @@ use crate::errors::{ParquetError, Result};
 use crate::util::bit_util::FromBitpacked;
 
 /// Number of elements compressed together as a unit, by default.
-pub const DEFAULT_VECTOR_SIZE: usize = 1 << DEFAULT_LOG_VECTOR_SIZE;
+pub(crate) const DEFAULT_VECTOR_SIZE: usize = 1 << DEFAULT_LOG_VECTOR_SIZE;
 
 /// `log2` of [`DEFAULT_VECTOR_SIZE`].
-pub const DEFAULT_LOG_VECTOR_SIZE: u8 = 10;
+pub(crate) const DEFAULT_LOG_VECTOR_SIZE: u8 = 10;
 
 /// Smallest vector the page header can describe, as a log.
-pub const MIN_LOG_VECTOR_SIZE: u8 = 3;
+pub(crate) const MIN_LOG_VECTOR_SIZE: u8 = 3;
 
 /// Largest vector the page header can describe, as a log.
-pub const MAX_LOG_VECTOR_SIZE: u8 = 15;
+pub(crate) const MAX_LOG_VECTOR_SIZE: u8 = 15;
 
 /// Largest vector the format allows, in elements.
-pub const MAX_VECTOR_SIZE: usize = 1 << MAX_LOG_VECTOR_SIZE;
+pub(crate) const MAX_VECTOR_SIZE: usize = 1 << MAX_LOG_VECTOR_SIZE;
 
 /// Width of one entry in the per-page offset array.
-pub const OFFSET_SIZE: usize = std::mem::size_of::<u32>();
+pub(crate) const OFFSET_SIZE: usize = std::mem::size_of::<u32>();
 
 /// Width of one exception position.
-pub const POSITION_SIZE: usize = std::mem::size_of::<u16>();
+pub(crate) const POSITION_SIZE: usize = std::mem::size_of::<u16>();
 
 /// Page header size in bytes: `packing_mode`, `log_vector_size` and `value_byte_width` one byte
 /// each, then `num_elements` as a four-byte little-endian signed integer.
-pub const HEADER_SIZE: usize = 3 + std::mem::size_of::<i32>();
+pub(crate) const HEADER_SIZE: usize = 3 + std::mem::size_of::<i32>();
 
 /// Packing mode: frame of reference plus bit-packing, currently the only mode.
-pub const PACKING_MODE_FOR_BIT_PACK: u8 = 0;
+pub(crate) const PACKING_MODE_FOR_BIT_PACK: u8 = 0;
 
 /// Mask selecting the bit width out of the info block's width byte.
-pub const BIT_WIDTH_MASK: u8 = 0x7F;
+pub(crate) const BIT_WIDTH_MASK: u8 = 0x7F;
 
 /// Bit of the info block's width byte that marks a differenced vector.
-pub const DELTA_FLAG: u8 = 0x80;
+pub(crate) const DELTA_FLAG: u8 = 0x80;
 
 /// Bits an exception costs on the wire: its position plus a full-width value.
-pub const fn exception_bits(byte_width: usize) -> i64 {
+pub(crate) const fn exception_bits(byte_width: usize) -> i64 {
     ((POSITION_SIZE + byte_width) * 8) as i64
 }
 
@@ -178,15 +178,9 @@ impl PforInt for i64 {
     }
 }
 
-/// Bits needed to hold `value`, i.e. the position of its highest set bit. Zero needs none.
-#[inline]
-pub fn bits_required(value: u64) -> u8 {
-    (u64::BITS - value.leading_zeros()) as u8
-}
-
 /// Mask of the low `bit_width` bits, saturating at all ones.
 #[inline]
-pub const fn low_mask(bit_width: u8) -> u64 {
+pub(crate) const fn low_mask(bit_width: u8) -> u64 {
     if bit_width >= 64 {
         u64::MAX
     } else {
@@ -196,7 +190,7 @@ pub const fn low_mask(bit_width: u8) -> u64 {
 
 /// Bytes needed to hold `bits`, rounded up.
 #[inline]
-pub fn bytes_for_bits(bits: usize) -> usize {
+pub(crate) fn bytes_for_bits(bits: usize) -> usize {
     bits.div_ceil(8)
 }
 
@@ -204,7 +198,7 @@ pub fn bytes_for_bits(bits: usize) -> usize {
 ///
 /// A size outside this range would encode a page that the decoder then rejects, so refuse it up
 /// front.
-pub fn validate_vector_size(vector_size: usize) -> Result<u8> {
+pub(crate) fn validate_vector_size(vector_size: usize) -> Result<u8> {
     if !vector_size.is_power_of_two()
         || !((1 << MIN_LOG_VECTOR_SIZE)..=MAX_VECTOR_SIZE).contains(&vector_size)
     {
@@ -220,7 +214,7 @@ pub fn validate_vector_size(vector_size: usize) -> Result<u8> {
 
 /// The per-page header.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PforHeader {
+pub(crate) struct PforHeader {
     /// How the residuals are laid out. Always [`PACKING_MODE_FOR_BIT_PACK`] today.
     pub packing_mode: u8,
     /// `log2` of the number of elements per vector.
@@ -322,7 +316,7 @@ impl PforHeader {
 /// The exception count is unsigned: a vector holds up to [`MAX_VECTOR_SIZE`] elements and every
 /// one of them can be an exception, so a count of 32768 has to be representable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct PforVectorInfo<T> {
+pub(crate) struct PforVectorInfo<T> {
     /// Subtracted from every element before packing; added back on decode.
     pub frame_of_reference: T,
     /// Bits each packed residual occupies. Zero means the vector packs nothing at all.
@@ -410,7 +404,11 @@ impl<T: PforInt> PforVectorInfo<T> {
 /// past the array and the rest strictly increasing. Checking the chain as a whole, before decoding
 /// any of it, keeps a page whose offsets overlap or run backwards from decoding part-way and
 /// emitting values built out of the wrong bytes.
-pub fn validate_offsets(offsets: &[u8], num_vectors: usize, payload_size: usize) -> Result<()> {
+pub(crate) fn validate_offsets(
+    offsets: &[u8],
+    num_vectors: usize,
+    payload_size: usize,
+) -> Result<()> {
     let offset_array_size = num_vectors * OFFSET_SIZE;
     let mut previous = 0usize;
     for v in 0..num_vectors {
@@ -451,7 +449,7 @@ pub fn validate_offsets(offsets: &[u8], num_vectors: usize, payload_size: usize)
 /// Panics if `offsets` is shorter than `(index + 1) * OFFSET_SIZE`. Callers check the array
 /// against the buffer before reading any of it.
 #[inline]
-pub fn read_offset(offsets: &[u8], index: usize) -> usize {
+pub(crate) fn read_offset(offsets: &[u8], index: usize) -> usize {
     let at = index * OFFSET_SIZE;
     u32::from_le_bytes(offsets[at..at + OFFSET_SIZE].try_into().unwrap()) as usize
 }
@@ -464,7 +462,10 @@ pub fn read_offset(offsets: &[u8], index: usize) -> usize {
 /// does pick costs no more than that. Bit packing rounds the packed section up to a whole byte,
 /// hence the trailing byte. Differencing adds one full-width start value, and the model only
 /// chooses it when doing so still comes out cheaper, but the bound has to hold either way.
-pub fn max_compressed_size<T: PforInt>(num_values: usize, vector_size: usize) -> Result<usize> {
+pub(crate) fn max_compressed_size<T: PforInt>(
+    num_values: usize,
+    vector_size: usize,
+) -> Result<usize> {
     validate_vector_size(vector_size)?;
     let num_vectors = num_values.div_ceil(vector_size);
     let max_vector_size = T::INFO_SIZE + T::BYTE_WIDTH + vector_size * T::BYTE_WIDTH + 1;
@@ -474,16 +475,6 @@ pub fn max_compressed_size<T: PforInt>(num_values: usize, vector_size: usize) ->
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_bits_required() {
-        assert_eq!(bits_required(0), 0);
-        assert_eq!(bits_required(1), 1);
-        assert_eq!(bits_required(2), 2);
-        assert_eq!(bits_required(255), 8);
-        assert_eq!(bits_required(256), 9);
-        assert_eq!(bits_required(u64::MAX), 64);
-    }
 
     #[test]
     fn test_low_mask() {

--- a/parquet/src/encodings/pfor.rs
+++ b/parquet/src/encodings/pfor.rs
@@ -85,9 +85,7 @@ pub const fn exception_bits(byte_width: usize) -> i64 {
 /// frame wraps rather than overflows, which is what lets a frame sit above the minimum: a value
 /// below the frame wraps to a huge residual, fails the width test like any value above the window,
 /// and is patched from the exception list. Nothing here is exposed outside the crate.
-pub trait PforInt:
-    Copy + Default + Ord + Send + std::fmt::Debug + FromBitpacked + 'static
-{
+pub trait PforInt: Copy + Default + Ord + Send + std::fmt::Debug + FromBitpacked + 'static {
     /// Width of one value on the wire, in bytes: 4 for INT32, 8 for INT64.
     const BYTE_WIDTH: usize;
 
@@ -380,7 +378,9 @@ impl<T: PforInt> PforVectorInfo<T> {
             frame_of_reference,
             bit_width: width_byte & BIT_WIDTH_MASK,
             num_exceptions: u16::from_le_bytes(
-                src[T::BYTE_WIDTH + 1..T::BYTE_WIDTH + 3].try_into().unwrap(),
+                src[T::BYTE_WIDTH + 1..T::BYTE_WIDTH + 3]
+                    .try_into()
+                    .unwrap(),
             ),
             is_delta: width_byte & DELTA_FLAG != 0,
         };

--- a/parquet/src/encodings/pfor.rs
+++ b/parquet/src/encodings/pfor.rs
@@ -37,6 +37,7 @@
 //!
 //! Every multi-byte field is little-endian.
 
+use crate::encodings::fastlanes::FastLanesBitPacking;
 use crate::errors::{ParquetError, Result};
 use crate::util::bit_util::FromBitpacked;
 
@@ -65,8 +66,13 @@ pub(crate) const POSITION_SIZE: usize = std::mem::size_of::<u16>();
 /// each, then `num_elements` as a four-byte little-endian signed integer.
 pub(crate) const HEADER_SIZE: usize = 3 + std::mem::size_of::<i32>();
 
-/// Packing mode: frame of reference plus bit-packing, currently the only mode.
+/// Packing mode: frame of reference plus sequential bit-packing.
 pub(crate) const PACKING_MODE_FOR_BIT_PACK: u8 = 0;
+
+/// Experimental FastLanes layout: complete 1024-value blocks use interleaved
+/// packing; any remaining values in a vector use sequential packing. No padding
+/// is added, so both modes have the same encoded length and vector offsets.
+pub(crate) const PACKING_MODE_FASTLANES: u8 = 1;
 
 /// Mask selecting the bit width out of the info block's width byte.
 pub(crate) const BIT_WIDTH_MASK: u8 = 0x7F;
@@ -86,6 +92,14 @@ pub(crate) const fn exception_bits(byte_width: usize) -> i64 {
 /// below the frame wraps to a huge residual, fails the width test like any value above the window,
 /// and is patched from the exception list. Nothing here is exposed outside the crate.
 pub trait PforInt: Copy + Default + Ord + Send + std::fmt::Debug + FromBitpacked + 'static {
+    /// Pack a complete 1024-value block of unsigned residuals as FastLanes bytes.
+    #[doc(hidden)]
+    fn pack_fastlanes(width: usize, residuals: &[u64], out: &mut Vec<u8>);
+
+    /// Unpack a complete FastLanes block, fusing the wrapping frame addition.
+    #[doc(hidden)]
+    fn unpack_fastlanes(width: usize, packed: &[u8], frame: Self, out: &mut [Self]);
+
     /// Width of one value on the wire, in bytes: 4 for INT32, 8 for INT64.
     const BYTE_WIDTH: usize;
 
@@ -129,6 +143,20 @@ pub trait PforInt: Copy + Default + Ord + Send + std::fmt::Debug + FromBitpacked
 }
 
 impl PforInt for i32 {
+    fn pack_fastlanes(width: usize, residuals: &[u64], out: &mut Vec<u8>) {
+        assert_eq!(residuals.len(), DEFAULT_VECTOR_SIZE);
+        let input: [u32; DEFAULT_VECTOR_SIZE] = std::array::from_fn(|i| residuals[i] as u32);
+        u32::pack_bytes(width, &input, out);
+    }
+
+    fn unpack_fastlanes(width: usize, packed: &[u8], frame: Self, out: &mut [Self]) {
+        // SAFETY: i32 and u32 have identical size/alignment and accept all bit
+        // patterns. The mutable borrow remains exclusive for the entire call.
+        let out =
+            unsafe { std::slice::from_raw_parts_mut(out.as_mut_ptr().cast::<u32>(), out.len()) };
+        u32::unpack_for_bytes(width, packed, frame as u32, out);
+    }
+
     const BYTE_WIDTH: usize = 4;
     const MAX_BIT_WIDTH: u8 = 32;
 
@@ -154,6 +182,18 @@ impl PforInt for i32 {
 }
 
 impl PforInt for i64 {
+    fn pack_fastlanes(width: usize, residuals: &[u64], out: &mut Vec<u8>) {
+        u64::pack_bytes(width, residuals, out);
+    }
+
+    fn unpack_fastlanes(width: usize, packed: &[u8], frame: Self, out: &mut [Self]) {
+        // SAFETY: i64 and u64 have identical size/alignment and accept all bit
+        // patterns. The mutable borrow remains exclusive for the entire call.
+        let out =
+            unsafe { std::slice::from_raw_parts_mut(out.as_mut_ptr().cast::<u64>(), out.len()) };
+        u64::unpack_for_bytes(width, packed, frame as u64, out);
+    }
+
     const BYTE_WIDTH: usize = 8;
     const MAX_BIT_WIDTH: u8 = 64;
 
@@ -215,7 +255,7 @@ pub(crate) fn validate_vector_size(vector_size: usize) -> Result<u8> {
 /// The per-page header.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PforHeader {
-    /// How the residuals are laid out. Always [`PACKING_MODE_FOR_BIT_PACK`] today.
+    /// Sequential bit-packing or the experimental FastLanes block layout.
     pub packing_mode: u8,
     /// `log2` of the number of elements per vector.
     pub log_vector_size: u8,
@@ -264,7 +304,10 @@ impl PforHeader {
             value_byte_width: src[2],
             num_elements: i32::from_le_bytes(src[3..7].try_into().unwrap()),
         };
-        if header.packing_mode != PACKING_MODE_FOR_BIT_PACK {
+        if !matches!(
+            header.packing_mode,
+            PACKING_MODE_FOR_BIT_PACK | PACKING_MODE_FASTLANES
+        ) {
             return Err(general_err!(
                 "PFOR unsupported packing mode: {}",
                 header.packing_mode
@@ -568,7 +611,7 @@ mod tests {
 
         // A packing mode this implementation does not have.
         let mut buf = bytes(&good);
-        buf[0] = 1;
+        buf[0] = 2;
         assert!(PforHeader::read::<i32>(&buf).is_err());
 
         // An INT64 page read as INT32.

--- a/parquet/src/encodings/pfor.rs
+++ b/parquet/src/encodings/pfor.rs
@@ -31,11 +31,18 @@
 //! and each vector as
 //!
 //! ```text
-//! [info block] [start value, only when differencing] [packed residuals]
+//! [info block] [start value(s), only when differencing] [packed residuals]
 //! [exception positions] [exception values]
 //! ```
 //!
 //! Every multi-byte field is little-endian.
+//!
+//! Modes 0 and 1 use one start value and adjacent deltas per vector. Mode 2
+//! stores independent starts for each complete block's UTL lanes, plus one
+//! start for a partial block. For i32 there are 32 chains of 32 adjacent values;
+//! for i64, 16 chains of 64. Each chain's first difference is zero. Complete
+//! blocks' differences and exception positions are in UTL order, so patches
+//! precede lane sums; reconstructed values are returned in original order.
 
 use crate::encodings::fastlanes::FastLanesBitPacking;
 use crate::errors::{ParquetError, Result};
@@ -74,6 +81,21 @@ pub(crate) const PACKING_MODE_FOR_BIT_PACK: u8 = 0;
 /// is added, so both modes have the same encoded length and vector offsets.
 pub(crate) const PACKING_MODE_FASTLANES: u8 = 1;
 
+/// FastLanes packing with independent UTL delta chains. A differenced vector
+/// stores 128 bytes of lane starts per complete 1024-value block, followed by
+/// one scalar start if it has a tail. Complete blocks contain UTL differences;
+/// tails retain ordinary adjacent differences. Non-delta vectors match mode 1.
+pub(crate) const PACKING_MODE_FASTLANES_DELTA: u8 = 2;
+
+pub(crate) fn delta_start_count<T: PforInt>(packing_mode: u8, num_elements: usize) -> usize {
+    if packing_mode == PACKING_MODE_FASTLANES_DELTA {
+        num_elements / DEFAULT_VECTOR_SIZE * (DEFAULT_VECTOR_SIZE / T::MAX_BIT_WIDTH as usize)
+            + usize::from(!num_elements.is_multiple_of(DEFAULT_VECTOR_SIZE))
+    } else {
+        1
+    }
+}
+
 /// Mask selecting the bit width out of the info block's width byte.
 pub(crate) const BIT_WIDTH_MASK: u8 = 0x7F;
 
@@ -99,6 +121,20 @@ pub trait PforInt: Copy + Default + Ord + Send + std::fmt::Debug + FromBitpacked
     /// Unpack a complete FastLanes block, fusing the wrapping frame addition.
     #[doc(hidden)]
     fn unpack_fastlanes(width: usize, packed: &[u8], frame: Self, out: &mut [Self]);
+
+    /// Decode a complete UTL delta block without an intermediate serial sum.
+    #[doc(hidden)]
+    fn unpack_fastlanes_delta(
+        width: usize,
+        packed: &[u8],
+        frame: Self,
+        starts: &[u8],
+        out: &mut [Self],
+    );
+
+    /// Restore independent delta lanes after patching their differences.
+    #[doc(hidden)]
+    fn restore_fastlanes_delta(starts: &[u8], out: &mut [Self]);
 
     /// Width of one value on the wire, in bytes: 4 for INT32, 8 for INT64.
     const BYTE_WIDTH: usize;
@@ -143,6 +179,27 @@ pub trait PforInt: Copy + Default + Ord + Send + std::fmt::Debug + FromBitpacked
 }
 
 impl PforInt for i32 {
+    fn unpack_fastlanes_delta(
+        width: usize,
+        packed: &[u8],
+        frame: Self,
+        starts: &[u8],
+        out: &mut [Self],
+    ) {
+        // SAFETY: i32/u32 have identical layout, all bit patterns are valid, and
+        // the mutable borrow remains exclusive for the call.
+        let out =
+            unsafe { std::slice::from_raw_parts_mut(out.as_mut_ptr().cast::<u32>(), out.len()) };
+        u32::unpack_delta_bytes(width, packed, frame as u32, starts, out);
+    }
+
+    fn restore_fastlanes_delta(starts: &[u8], out: &mut [Self]) {
+        // SAFETY: same layout and exclusive borrow as above.
+        let out =
+            unsafe { std::slice::from_raw_parts_mut(out.as_mut_ptr().cast::<u32>(), out.len()) };
+        u32::restore_delta(starts, out);
+    }
+
     fn pack_fastlanes(width: usize, residuals: &[u64], out: &mut Vec<u8>) {
         assert_eq!(residuals.len(), DEFAULT_VECTOR_SIZE);
         let input: [u32; DEFAULT_VECTOR_SIZE] = std::array::from_fn(|i| residuals[i] as u32);
@@ -182,6 +239,27 @@ impl PforInt for i32 {
 }
 
 impl PforInt for i64 {
+    fn unpack_fastlanes_delta(
+        width: usize,
+        packed: &[u8],
+        frame: Self,
+        starts: &[u8],
+        out: &mut [Self],
+    ) {
+        // SAFETY: i64/u64 have identical layout, all bit patterns are valid, and
+        // the mutable borrow remains exclusive for the call.
+        let out =
+            unsafe { std::slice::from_raw_parts_mut(out.as_mut_ptr().cast::<u64>(), out.len()) };
+        u64::unpack_delta_bytes(width, packed, frame as u64, starts, out);
+    }
+
+    fn restore_fastlanes_delta(starts: &[u8], out: &mut [Self]) {
+        // SAFETY: same layout and exclusive borrow as above.
+        let out =
+            unsafe { std::slice::from_raw_parts_mut(out.as_mut_ptr().cast::<u64>(), out.len()) };
+        u64::restore_delta(starts, out);
+    }
+
     fn pack_fastlanes(width: usize, residuals: &[u64], out: &mut Vec<u8>) {
         u64::pack_bytes(width, residuals, out);
     }
@@ -306,7 +384,7 @@ impl PforHeader {
         };
         if !matches!(
             header.packing_mode,
-            PACKING_MODE_FOR_BIT_PACK | PACKING_MODE_FASTLANES
+            PACKING_MODE_FOR_BIT_PACK | PACKING_MODE_FASTLANES | PACKING_MODE_FASTLANES_DELTA
         ) {
             return Err(general_err!(
                 "PFOR unsupported packing mode: {}",
@@ -349,7 +427,8 @@ impl PforHeader {
 /// The width byte holds the bit width in bits 0..6 and the differencing flag in bit 7. A vector
 /// with the flag set packs the backward differences of its values rather than the values, and
 /// carries one extra full-width field after this block -- the vector's first value -- so that it
-/// still decodes without reading the vector before it.
+/// still decodes without reading the vector before it. Mode 2 instead carries
+/// the lane starts described by [`delta_start_count`].
 ///
 /// Seven bits for the width, not six: the range is 0..64 inclusive, and 64 does not fit in six. A
 /// six-bit field stored an INT64 vector whose differences need the full 64 bits as width 0, and
@@ -371,7 +450,9 @@ pub(crate) struct PforVectorInfo<T> {
 }
 
 impl<T: PforInt> PforVectorInfo<T> {
-    /// Bytes this info occupies on the wire, start value included.
+    /// Bytes this info occupies in modes 0 and 1, start value included.
+    /// Mode 2 must additionally account for its lane starts using
+    /// [`delta_start_count`].
     ///
     /// Not a constant: the start value is only present on a differenced vector. Paying for it
     /// unconditionally would be free at a 1024-value vector and ruinous at the smallest one the
@@ -611,7 +692,7 @@ mod tests {
 
         // A packing mode this implementation does not have.
         let mut buf = bytes(&good);
-        buf[0] = 2;
+        buf[0] = 3;
         assert!(PforHeader::read::<i32>(&buf).is_err());
 
         // An INT64 page read as INT32.


### PR DESCRIPTION
# Which issue does this PR close?

None. Experimental follow-up stacked on #10977, based on its head `f6e19d07a3a574b4c83ff32559f2f91332fc6281`. This draft includes that PR's commits.

Incremental commits: [byte-oriented FastLanes packing](https://github.com/sdf-jkl/arrow-rs/commit/f0ece7446b527ab255c25be4cf034c2acb08a606) and [independent UTL delta chains](https://github.com/sdf-jkl/arrow-rs/commit/67bff48a94769dc24b939d7e8f85dff4e7375e0b).

# Rationale for this change

The PFOR implementation in #10977 unpacks residuals sequentially, adds the frame in another pass, and reconstructs delta vectors with one serial prefix sum. This experiment adds two opt-in FastLanes modes and measures their costs, including returning decoded integers in original order.

# What changes are included in this PR?

- Mode 1: byte-oriented FastLanes packing with fused wrapping frame addition. It retains ordinary adjacent delta encoding and its serial reconstruction. Complete 1,024-value blocks use FastLanes; tails use sequential packing. Encoded sizes match mode 0.
- Mode 2: FastLanes with independent UTL delta chains, enabled by `with_fastlanes_delta_enabled(true)`. Each complete block has 32 chains of 32 consecutive values for i32, or 16 chains of 64 for i64. Each chain starts with a zero difference and carries its first value separately: 128 bytes of starts per full block. Tails retain scalar delta with one start.
- Unpatched mode-2 blocks fuse unpacking, frame addition, and lane accumulation into a UTL buffer. A separate, fully unrolled 1,024-value permutation restores original output order, following the actual FastLanes and Vortex implementations. Patched blocks apply exceptions before the lane sums and use the same permutation. This replaces the earlier scatter-based output path.
- The per-vector planner includes all lane-start bytes in its cost. Mode 2 may fall back to raw PFOR; delta remains optional. Its encoded size can differ from ordinary delta.
- Kernels use unaligned little-endian byte loads/stores, adapted from the earlier local ALP experiment, with the UTL sum/output strategy taken from the FastLanes and Vortex references. Mode 2 retains its existing i32 lane numbering; the fully unrolled permutation accounts for that difference. `fastlanes = 0.5.0` is a dev-only bitpacking oracle, not a runtime dependency.
- Benchmark arms retain the original and mode-1 variants and add `PFOR_FASTLANES+UTL_DELTA`. Untimed checks compare every decoded integer with the original. Benchmark logs now report exact encoded sizes, actual delta-vector counts, UTL-block counts, and patch counts.

# Are these changes tested?

Passed on the final implementation:

```text
cargo test -p parquet --lib --offline encodings::  # 200 passed
cargo clippy -p parquet --features experimental --lib --tests --bench pfor --offline -- -D warnings
cargo fmt --all --check
rustfmt --edition 2024 --check <the five changed Rust files>
git diff --check
```

Tests include all bit widths for both integer types against independently packed oracle data, byte alignments 0–7, wrapping arithmetic, running sums and output permutation checked against the upstream `Delta::undelta` and `Transpose::untranspose` implementations, fused and patched lane reconstruction, literal wire data with a lane-local patch and a scalar tail, truncated start arrays, all supported vector sizes, and streaming reads/skips across lanes, blocks, vectors, and tails. Existing mode-0/mode-1 roundtrips remain covered. These are codec-level checks, not an end-to-end Arrow roundtrip with mode 2.

## Native benchmark results

Measured implementation: `67bff48a94769dc24b939d7e8f85dff4e7375e0b` (fully unrolled transpose). Main comparison is **original PFOR + delta versus FastLanes + UTL delta**. The transitional FastLanes + serial-delta arm is omitted from the reported comparison; its measurements remain in the raw logs for reference.

AMD Ryzen AI 9 HX PRO 470, pinned logical CPU 2, Rust 1.97.1 / LLVM 22.1.6, `-C target-cpu=native`. The comparison covers 33 synthetic i32 and four synthetic i64 datasets, each with 102,400 values: 74 encode/decode pairs. Criterion uses 60 samples, 0.3 s warmup, and 1 s target measurement per case. Throughput below is decimal GB/s of uncompressed output, with geometric means across datasets. Exact integer readback checks passed.

### All workloads, delta allowed

| Type | Operation | Datasets | Original PFOR GB/s | FastLanes UTL GB/s | Speedup |
|---|---|---:|---:|---:|---:|
| int32 | encode | 33 | 0.96 | 1.07 | 1.11× |
| int32 | decode | 33 | 19.20 | 37.28 | 1.94× |
| int64 | encode | 4 | 1.33 | 1.48 | 1.12× |
| int64 | decode | 4 | 20.61 | 32.42 | 1.57× |

### Actual UTL-selected workloads

| Type | Operation | Datasets | Original PFOR GB/s | FastLanes UTL GB/s | Speedup |
|---|---|---:|---:|---:|---:|
| int32 | encode | 5 | 0.48 | 0.54 | 1.14× |
| int32 | decode | 5 | 12.05 | 12.84 | 1.07× |
| int64 | encode | 1 | 0.89 | 0.93 | 1.05× |
| int64 | decode | 1 | 15.55 | 19.64 | 1.26× |

### UTL-selected decode cases

| Type | Dataset | Original GB/s | UTL GB/s | Speedup | Original bytes | UTL bytes |
|---|---|---:|---:|---:|---:|---:|
| int32 | CounterID | 10.58 | 12.79 | 1.21× | 27707 | 52307 |
| int32 | MonotoneRowId | 15.42 | 13.35 | 0.87× | 2107 | 26707 |
| int32 | NearSortedUnixTime | 10.60 | 11.36 | 1.07× | 65561 | 77247 |
| int32 | SortedKeyDups | 12.53 | 13.28 | 1.06× | 14307 | 26707 |
| int32 | SortedUnixTime | 11.75 | 13.57 | 1.15× | 39907 | 52307 |
| int64 | SortedUnixTime | 15.55 | 19.64 | 1.26× | 296707 | 308707 |

Most datasets do not select delta at all. The overall 1.94× i32 / 1.57× i64 decode improvements therefore include faster raw bitpacking and must not be described as delta-specific improvements. On the five i32 datasets that select UTL delta, the decode improvement is 1.07×; on the single selected i64 dataset it is 1.26×. MonotoneRowId regresses, and its extra lane starts/zero differences increase encoded size substantially. The current codec does not achieve a 2× improvement on these actual delta-selected workloads.

### Independent larger-working-set check

A standalone wall-clock probe uses synthetic i32 positive steps with occasional large jumps. Every vector is asserted to select delta; full output equality is checked. Two rounds reverse implementation order. The latest probe was rebuilt against this implementation's native library.

| Working set | Original PFOR delta GB/s | FastLanes UTL delta GB/s |
|---|---:|---:|
| One hot page | 10.01–10.42 | 12.55–12.66 |
| 256 distinct pages (~119 MB original / ~125 MB UTL input+output) | 10.16–10.26 | 10.70–10.76 |

These are codec measurements, not full Parquet scan or file-I/O throughput.

### Machine conditions

Temperature and host counters were sampled each second, with 30 seconds of preflight telemetry. AC was connected throughout; powersave governor / balance_performance EPP were unchanged. Preflight temperature averaged 48.5°C. During Criterion it averaged 87.1°C and peaked at 95°C; CPU 2 reported frequency averaged 5.07 GHz. The SMT sibling averaged 6.1% busy with a brief one-second peak of 85.9%. This was a monitored desktop run, not an isolated host. Frequency snapshots do not establish absence of throttling, and small differences should be treated cautiously.

Reproduce the two-way comparison:

```sh
RUSTFLAGS='-C target-cpu=native' taskset -c 2 cargo bench \
  -p parquet --features experimental --bench pfor -- \
  'int(32|64)/(encode|decode)/(PFOR\+DELTA|PFOR_FASTLANES\+UTL_DELTA)/' \
  --sample-size 60 --warm-up-time 0.3 --measurement-time 1.0 --noplot
```

Reference implementations inspected: [Vortex FastLanes transpose](https://github.com/spiraldb/fastlanes/blob/cad8dd9/src/transpose.rs), [Vortex delta decompression](https://github.com/vortex-data/vortex/blob/3226d32/encodings/fastlanes/src/delta/array/delta_decompress.rs), and the local FastLanes generated `rsum` / `untranspose_i` kernels.

# Are there any user-facing changes?

Mode 0 remains the default. The decoder reads modes 0, 1, and 2. Opt-in modes 1 and 2 require their respective decoder extensions; older decoders reject them. These are experimental PFOR wire-format extensions, not changes to existing standard Parquet encodings. UTL delta remains opt-in given its compression overhead and the mixed performance results above.
