### PR TITLE
Support RunEndEncoded arrays in numeric kernels

### DIFF
--- a/arrow-arith/Cargo.toml
+++ b/arrow-arith/Cargo.toml
@@ -50,5 +50,9 @@ criterion = { workspace = true }
 name = "decimal_arithmetic"
 harness = false
 
+[[bench]]
+name = "run_arithmetic"
+harness = false
+
 [lints]
 workspace = true

--- a/arrow-arith/benches/run_arithmetic.rs
+++ b/arrow-arith/benches/run_arithmetic.rs
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::hint;
+
+use arrow_arith::numeric::add;
+use arrow_array::types::Int32Type;
+use arrow_array::{Int32Array, Int64Array, RunArray};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+
+const SIZE: usize = 1_000_000;
+
+fn input(run_length: usize, first_run_length: usize) -> (RunArray<Int32Type>, Int64Array) {
+    let mut run_ends = Vec::new();
+    let mut values = Vec::new();
+    let mut dense = Vec::with_capacity(SIZE);
+    let mut previous = 0;
+    let mut end = first_run_length.min(run_length).clamp(1, SIZE);
+
+    loop {
+        let value = 1 + (run_ends.len() % 100) as i64;
+        run_ends.push(end as i32);
+        values.push(value);
+        dense.extend(std::iter::repeat_n(value, end - previous));
+        if end == SIZE {
+            break;
+        }
+        previous = end;
+        end = (end + run_length).min(SIZE);
+    }
+
+    let run_array =
+        RunArray::try_new(&Int32Array::from(run_ends), &Int64Array::from(values)).unwrap();
+    (run_array, Int64Array::from(dense))
+}
+
+fn run_arithmetic(c: &mut Criterion) {
+    for run_length in [8, 128, 4096] {
+        let (left, left_dense) = input(run_length, run_length);
+        let (right, right_dense) = input(run_length, run_length.div_ceil(2));
+        let scalar = Int64Array::new_scalar(2);
+        let mut group = c.benchmark_group(format!("run_arithmetic/{run_length}"));
+        group.throughput(Throughput::Elements(SIZE as u64));
+
+        group.bench_function("ree_scalar", |b| {
+            b.iter(|| hint::black_box(add(hint::black_box(&left), &scalar).unwrap()))
+        });
+        group.bench_function("dense_scalar", |b| {
+            b.iter(|| hint::black_box(add(hint::black_box(&left_dense), &scalar).unwrap()))
+        });
+        group.bench_function("ree_aligned", |b| {
+            b.iter(|| hint::black_box(add(hint::black_box(&left), &left).unwrap()))
+        });
+        group.bench_function("dense_aligned", |b| {
+            b.iter(|| hint::black_box(add(hint::black_box(&left_dense), &left_dense).unwrap()))
+        });
+        group.bench_function("ree_staggered", |b| {
+            b.iter(|| hint::black_box(add(hint::black_box(&left), &right).unwrap()))
+        });
+        group.bench_function("dense_staggered", |b| {
+            b.iter(|| hint::black_box(add(hint::black_box(&left_dense), &right_dense).unwrap()))
+        });
+        group.finish();
+    }
+}
+
+criterion_group!(benches, run_arithmetic);
+criterion_main!(benches);

--- a/arrow-arith/src/numeric.rs
+++ b/arrow-arith/src/numeric.rs
@@ -15,7 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines numeric arithmetic kernels on [`PrimitiveArray`], such as [`add`]
+//! Defines numeric arithmetic kernels on [`PrimitiveArray`] and [`RunArray`], such as [`add`].
+//!
+//! Run-end encoded inputs retain their encoding when the other operand is a scalar
+//! or another run-end encoded array. Two encoded operands use the union of their
+//! run boundaries and the wider run-end integer type. Adjacent equal results are
+//! not coalesced. Mixing an encoded input with a non-scalar unencoded array is not
+//! supported. Arithmetic is applied only to values in the logical slice, with the
+//! same null, overflow, decimal and temporal semantics as primitive inputs.
+
+mod run;
 
 use std::cmp::Ordering;
 use std::fmt::Formatter;
@@ -106,6 +115,7 @@ pub fn neg(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
     use TimeUnit::*;
 
     match array.data_type() {
+        RunEndEncoded(_, _) => run::unary(array, neg),
         Int8 => neg_checked!(Int8Type, array),
         Int16 => neg_checked!(Int16Type, array),
         Int32 => neg_checked!(Int32Type, array),
@@ -179,6 +189,9 @@ pub fn neg(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
 
 /// Negates each element of  `array`, wrapping on overflow for [`DataType::is_integer`]
 pub fn neg_wrapping(array: &dyn Array) -> Result<ArrayRef, ArrowError> {
+    if matches!(array.data_type(), DataType::RunEndEncoded(_, _)) {
+        return run::unary(array, neg_wrapping);
+    }
     downcast_integer! {
         array.data_type() => (neg_wrapping, array),
         _ => neg(array),
@@ -235,6 +248,10 @@ fn arithmetic_op(op: Op, lhs: &dyn Datum, rhs: &dyn Datum) -> Result<ArrayRef, A
 
     let (l, l_scalar) = lhs.get();
     let (r, r_scalar) = rhs.get();
+    if matches!(l.data_type(), RunEndEncoded(_, _)) || matches!(r.data_type(), RunEndEncoded(_, _))
+    {
+        return run::binary(l, l_scalar, r, r_scalar, |l, r| arithmetic_op(op, l, r));
+    }
     downcast_integer! {
         l.data_type(), r.data_type() => (integer_helper, op, l, l_scalar, r, r_scalar),
         (Float16, Float16) => float_op::<Float16Type>(op, l, l_scalar, r, r_scalar),

--- a/arrow-arith/src/numeric/run.rs
+++ b/arrow-arith/src/numeric/run.rs
@@ -1,0 +1,202 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow_array::types::{Int16Type, Int32Type, Int64Type, RunEndIndexType};
+use arrow_array::{
+    Array, ArrayRef, Datum, PrimitiveArray, RunArray, Scalar, downcast_run_array, make_array,
+};
+use arrow_buffer::ArrowNativeType;
+use arrow_data::transform::MutableArrayData;
+use arrow_schema::{ArrowError, DataType};
+
+/// Values and (logical end, physical value index) pairs for an operand.
+/// Primitive arrays have one run per row.
+struct Operand<'a> {
+    values: &'a dyn Array,
+    runs: Box<dyn Iterator<Item = (usize, usize)> + 'a>,
+}
+
+fn next_run(runs: &mut dyn Iterator<Item = (usize, usize)>) -> Result<(usize, usize), ArrowError> {
+    runs.next().ok_or_else(|| {
+        ArrowError::ComputeError(
+            "Run-end encoded operand has no run for a non-empty logical array".to_owned(),
+        )
+    })
+}
+
+impl<'a> Operand<'a> {
+    fn new(array: &'a dyn Array) -> Self {
+        let len = array.len();
+        downcast_run_array!(array => {
+            let values = array.values().as_ref();
+            let start = array.get_start_physical_index();
+            let count = if array.is_empty() {
+                0
+            } else {
+                array.get_end_physical_index() - start + 1
+            };
+            let offset = array.offset();
+            let runs = Box::new(array.run_ends().values().iter().enumerate().skip(start).take(count)
+                .map(move |(index, end)| ((end.as_usize() - offset).min(len), index)));
+            Self { values, runs }
+        }, _ => {
+            let runs = Box::new((0..len).map(|index| (index + 1, index)));
+            Self { values: array, runs }
+        })
+    }
+}
+
+fn values_slice(array: &dyn Array) -> ArrayRef {
+    downcast_run_array!(array => array.values_slice(), _ => array.slice(0, array.len()))
+}
+
+fn run_end_type(array: &dyn Array) -> Option<&DataType> {
+    match array.data_type() {
+        DataType::RunEndEncoded(ends, _) => Some(ends.data_type()),
+        _ => None,
+    }
+}
+
+fn encode<R: RunEndIndexType>(
+    ends: Vec<usize>,
+    values: &dyn Array,
+) -> Result<ArrayRef, ArrowError> {
+    let ends = ends
+        .into_iter()
+        .map(|end| {
+            R::Native::from_usize(end).ok_or_else(|| {
+                ArrowError::ComputeError(format!("Run end {end} exceeds {}", R::DATA_TYPE))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let ends = PrimitiveArray::<R>::new(ends.into(), None);
+    Ok(Arc::new(RunArray::<R>::try_new(&ends, values)?))
+}
+
+fn finish(
+    ends: Vec<usize>,
+    values: ArrayRef,
+    data_type: &DataType,
+) -> Result<ArrayRef, ArrowError> {
+    match data_type {
+        DataType::Int16 => encode::<Int16Type>(ends, values.as_ref()),
+        DataType::Int32 => encode::<Int32Type>(ends, values.as_ref()),
+        DataType::Int64 => encode::<Int64Type>(ends, values.as_ref()),
+        _ => unreachable!("run ends must be Int16, Int32 or Int64"),
+    }
+}
+
+pub(super) fn unary(
+    array: &dyn Array,
+    op: impl Fn(&dyn Array) -> Result<ArrayRef, ArrowError>,
+) -> Result<ArrayRef, ArrowError> {
+    downcast_run_array!(array => {
+        let operand = Operand::new(array);
+        let ends = operand.runs.map(|(end, _)| end).collect();
+        let values = op(array.values_slice().as_ref())?;
+        finish(ends, values, array.run_ends_field().data_type())
+    }, _ => unreachable!("expected a run array"))
+}
+
+pub(super) fn binary(
+    left: &dyn Array,
+    left_scalar: bool,
+    right: &dyn Array,
+    right_scalar: bool,
+    op: impl Fn(&dyn Datum, &dyn Datum) -> Result<ArrayRef, ArrowError>,
+) -> Result<ArrayRef, ArrowError> {
+    let len = match (left_scalar, right_scalar) {
+        (true, false) => right.len(),
+        (false, true) => left.len(),
+        _ if left.len() == right.len() => left.len(),
+        _ => {
+            return Err(ArrowError::ComputeError(
+                "Cannot perform arithmetic operation on arrays of different length".to_owned(),
+            ));
+        }
+    };
+    let left_type = run_end_type(left);
+    let right_type = run_end_type(right);
+    if (left_type.is_none() && !left_scalar) || (right_type.is_none() && !right_scalar) {
+        return Err(ArrowError::InvalidArgumentError(
+            "Run-end encoded arithmetic requires the other operand to be a scalar or run-end encoded array".to_owned(),
+        ));
+    }
+    let result_type = match (left_type, right_type) {
+        (Some(DataType::Int64), _) | (_, Some(DataType::Int64)) => DataType::Int64,
+        (Some(DataType::Int32), _) | (_, Some(DataType::Int32)) => DataType::Int32,
+        _ => DataType::Int16,
+    };
+    // A scalar does not split runs: evaluate the visible physical values directly,
+    // without gathering or expanding the scalar to one value per run.
+    if left_scalar || right_scalar {
+        let left_values = values_slice(left);
+        let right_values = values_slice(right);
+        let values = match (left_scalar, right_scalar) {
+            (true, true) => op(&Scalar::new(left_values), &Scalar::new(right_values))?,
+            (true, false) => op(&Scalar::new(left_values), &right_values)?,
+            (false, true) => op(&left_values, &Scalar::new(right_values))?,
+            _ => unreachable!(),
+        };
+        let array = if left_scalar { right } else { left };
+        let ends = Operand::new(array).runs.map(|(end, _)| end).collect();
+        return finish(ends, values, &result_type);
+    }
+
+    let left_ends: Vec<_> = Operand::new(left).runs.map(|(end, _)| end).collect();
+    let right_ends: Vec<_> = Operand::new(right).runs.map(|(end, _)| end).collect();
+    if left_ends == right_ends {
+        let values = op(&values_slice(left), &values_slice(right))?;
+        return finish(left_ends, values, &result_type);
+    }
+    let mut left = Operand::new(left);
+    let mut right = Operand::new(right);
+
+    // Validate value types before gathering.
+    op(&left.values.slice(0, 0), &right.values.slice(0, 0))?;
+
+    let left_data = left.values.to_data();
+    let right_data = right.values.to_data();
+    let capacity = left_ends.len() + right_ends.len();
+    let mut left_values = MutableArrayData::try_new(vec![&left_data], false, capacity)?;
+    let mut right_values = MutableArrayData::try_new(vec![&right_data], false, capacity)?;
+    let mut ends = Vec::with_capacity(capacity);
+    let mut l = next_run(left.runs.as_mut())?;
+    let mut r = next_run(right.runs.as_mut())?;
+    loop {
+        let end = l.0.min(r.0);
+        left_values.try_extend(0, l.1, l.1 + 1)?;
+        right_values.try_extend(0, r.1, r.1 + 1)?;
+        ends.push(end);
+        if end == len {
+            break;
+        }
+        if l.0 == end {
+            l = next_run(left.runs.as_mut())?;
+        }
+        if r.0 == end {
+            r = next_run(right.runs.as_mut())?;
+        }
+    }
+    let values = op(
+        &make_array(left_values.freeze()),
+        &make_array(right_values.freeze()),
+    )?;
+    finish(ends, values, &result_type)
+}

--- a/arrow-arith/tests/run_numeric.rs
+++ b/arrow-arith/tests/run_numeric.rs
@@ -1,0 +1,399 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_arith::numeric::*;
+use arrow_array::builder::PrimitiveRunBuilder;
+use arrow_array::cast::AsArray;
+use arrow_array::types::*;
+use arrow_array::*;
+use arrow_buffer::ArrowNativeType;
+use arrow_schema::{ArrowError, DataType, TimeUnit};
+
+type BinaryOp = fn(&dyn Datum, &dyn Datum) -> Result<ArrayRef, ArrowError>;
+
+const OPS: [BinaryOp; 8] = [
+    add,
+    add_wrapping,
+    sub,
+    sub_wrapping,
+    mul,
+    mul_wrapping,
+    div,
+    rem,
+];
+
+fn encode<R: RunEndIndexType>(values: &[Option<i64>]) -> RunArray<R> {
+    let mut builder = PrimitiveRunBuilder::<R, Int64Type>::new();
+    builder.extend(values.iter().copied());
+    builder.finish()
+}
+
+fn decode(array: &dyn Array) -> Int64Array {
+    downcast_run_array!(array => {
+        array.downcast::<Int64Array>().unwrap().into_iter().collect()
+    }, _ => array.as_primitive::<Int64Type>().clone())
+}
+
+#[test]
+fn run_scalar_arithmetic() {
+    let array = RunArray::<Int32Type>::try_new(
+        &Int32Array::from(vec![2, 5, 7]),
+        &Int64Array::from(vec![Some(10), None, Some(30)]),
+    )
+    .unwrap();
+    let result = add(&array, &Int64Array::new_scalar(2)).unwrap();
+    let result = result.as_run::<Int32Type>();
+    assert_eq!(result.run_ends().values(), &[2, 5, 7]);
+    assert_eq!(
+        result.values().as_primitive::<Int64Type>(),
+        &Int64Array::from(vec![Some(12), None, Some(32)])
+    );
+}
+
+#[test]
+fn run_run_arithmetic() {
+    let left = RunArray::<Int16Type>::try_new(
+        &Int16Array::from(vec![2, 5]),
+        &Int64Array::from(vec![10, 20]),
+    )
+    .unwrap();
+    let right = RunArray::<Int64Type>::try_new(
+        &Int64Array::from(vec![1, 4, 5]),
+        &Int64Array::from(vec![1, 2, 3]),
+    )
+    .unwrap();
+    let result = sub(&left, &right).unwrap();
+    let result = result.as_run::<Int64Type>();
+    assert_eq!(result.run_ends().values(), &[1, 2, 4, 5]);
+    assert_eq!(
+        result.values().as_primitive::<Int64Type>(),
+        &Int64Array::from(vec![9, 8, 18, 17])
+    );
+}
+
+#[test]
+fn run_slice_does_not_evaluate_hidden_overflow() {
+    let array = RunArray::<Int32Type>::try_new(
+        &Int32Array::from(vec![2, 5, 7]),
+        &Int64Array::from(vec![i64::MAX, 10, i64::MAX]),
+    )
+    .unwrap()
+    .slice(3, 2);
+    let result = add(&array, &Int64Array::new_scalar(1)).unwrap();
+    let result = result.as_run::<Int32Type>();
+    assert_eq!(result.run_ends().values(), &[2]);
+    assert_eq!(
+        result.values().as_primitive::<Int64Type>(),
+        &Int64Array::from(vec![11])
+    );
+}
+
+fn check_slices<L: RunEndIndexType, R: RunEndIndexType>() {
+    let l: Vec<_> = (0..19)
+        .map(|i| if i % 7 == 0 { None } else { Some(1 + i / 3) })
+        .collect();
+    let r: Vec<_> = (0..23)
+        .map(|i| if i % 11 < 2 { None } else { Some(1 + i / 4) })
+        .collect();
+    let left = encode::<L>(&l);
+    let right = encode::<R>(&r);
+    let left_flat = Int64Array::from(l);
+    let right_flat = Int64Array::from(r);
+    for len in 0..=12 {
+        for l_offset in 0..=left.len() - len {
+            for r_offset in 0..=right.len() - len {
+                let l = left.slice(l_offset, len);
+                let r = right.slice(r_offset, len);
+                let l_flat = left_flat.slice(l_offset, len);
+                let r_flat = right_flat.slice(r_offset, len);
+                for op in OPS {
+                    let expected = op(&l_flat, &r_flat).unwrap();
+                    let result = op(&l, &r).unwrap();
+                    result.to_data().validate_full().unwrap();
+                    assert_eq!(
+                        &decode(result.as_ref()),
+                        expected.as_primitive::<Int64Type>()
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn run_arithmetic_matches_flat_for_slices_and_nulls() {
+    check_slices::<Int16Type, Int32Type>();
+    check_slices::<Int64Type, Int16Type>();
+}
+
+#[test]
+fn run_scalar_both_directions_and_encoded_scalars() {
+    let array = encode::<Int16Type>(&[Some(4), Some(4), None, Some(8), Some(8)]).slice(1, 3);
+    let scalar_array = encode::<Int64Type>(&[Some(i64::MAX), Some(2), Some(i64::MAX)]).slice(1, 1);
+    let encoded_scalar = Scalar::new(scalar_array);
+    let plain_scalar = Int64Array::new_scalar(2);
+    let flat = decode(&array);
+    for op in OPS {
+        for scalar in [&plain_scalar as &dyn Datum, &encoded_scalar as &dyn Datum] {
+            let result = op(&array, scalar).unwrap();
+            let expected = op(&flat, &plain_scalar).unwrap();
+            assert_eq!(
+                &decode(result.as_ref()),
+                expected.as_primitive::<Int64Type>()
+            );
+            let result = op(scalar, &array).unwrap();
+            let expected = op(&plain_scalar, &flat).unwrap();
+            assert_eq!(
+                &decode(result.as_ref()),
+                expected.as_primitive::<Int64Type>()
+            );
+            let result = op(&encoded_scalar, scalar).unwrap();
+            assert_eq!(result.len(), 1);
+            let expected = op(&plain_scalar, &plain_scalar).unwrap();
+            assert_eq!(
+                &decode(result.as_ref()),
+                expected.as_primitive::<Int64Type>()
+            );
+        }
+        assert!(op(&encoded_scalar, &flat).is_err());
+        assert!(op(&flat, &encoded_scalar).is_err());
+    }
+}
+
+#[test]
+fn run_null_scalar_and_empty_inputs() {
+    let array = encode::<Int32Type>(&[Some(i64::MIN), Some(0), Some(i64::MAX)]);
+    let null = Scalar::new(Int64Array::new_null(1));
+    let encoded_null = Scalar::new(encode::<Int16Type>(&[None]));
+    for op in OPS {
+        for scalar in [&null as &dyn Datum, &encoded_null as &dyn Datum] {
+            for result in [op(&array, scalar), op(scalar, &array)] {
+                assert_eq!(decode(result.unwrap().as_ref()), Int64Array::new_null(3));
+            }
+        }
+        for empty in [
+            array.slice(1, 0),
+            array.slice(array.len(), 0),
+            encode::<Int32Type>(&[]),
+        ] {
+            for scalar in [Int64Array::new_scalar(0), Int64Array::new_scalar(-1)] {
+                let result = op(&empty, &scalar).unwrap();
+                assert_eq!(result.as_run::<Int32Type>().values().len(), 0);
+                assert_eq!(result.len(), 0);
+                let result = op(&scalar, &empty).unwrap();
+                assert_eq!(result.len(), 0);
+            }
+        }
+    }
+}
+
+#[test]
+fn run_checked_and_wrapping_errors_match_flat() {
+    for (l, r) in [(i64::MAX, 1), (i64::MIN, -1), (i64::MIN, 0), (i64::MAX, 2)] {
+        let left = encode::<Int32Type>(&[Some(l), Some(l)]);
+        let right = encode::<Int16Type>(&[Some(r), Some(r)]);
+        let flat_left = decode(&left);
+        let flat_right = decode(&right);
+        for op in OPS {
+            let expected = op(&flat_left, &flat_right);
+            let actual = op(&left, &right);
+            match (actual, expected) {
+                (Ok(actual), Ok(expected)) => assert_eq!(
+                    &decode(actual.as_ref()),
+                    expected.as_primitive::<Int64Type>()
+                ),
+                (Err(actual), Err(expected)) => {
+                    assert_eq!(actual.to_string(), expected.to_string())
+                }
+                (actual, expected) => panic!("different outcomes: {actual:?}, {expected:?}"),
+            }
+        }
+    }
+    let left = encode::<Int32Type>(&[None, Some(6)]);
+    let right = encode::<Int32Type>(&[Some(0), Some(2)]);
+    assert_eq!(
+        decode(div(&left, &right).unwrap().as_ref()),
+        Int64Array::from(vec![None, Some(3)])
+    );
+}
+
+#[test]
+fn run_negation_uses_visible_values() {
+    let array = encode::<Int16Type>(&[Some(i64::MIN), Some(4), Some(4), None, Some(i64::MIN)]);
+    assert!(neg(&array).is_err());
+    let slice = array.slice(2, 2);
+    assert_eq!(
+        decode(neg(&slice).unwrap().as_ref()),
+        Int64Array::from(vec![Some(-4), None])
+    );
+    let result = neg_wrapping(&array).unwrap();
+    assert_eq!(
+        &decode(result.as_ref()),
+        neg_wrapping(&decode(&array))
+            .unwrap()
+            .as_primitive::<Int64Type>()
+    );
+    assert_eq!(neg(&array.slice(5, 0)).unwrap().len(), 0);
+
+    let unsigned =
+        RunArray::<Int32Type>::try_new(&Int32Array::from(vec![3]), &UInt32Array::from(vec![1]))
+            .unwrap();
+    assert!(neg(&unsigned).is_err());
+    assert_eq!(
+        neg_wrapping(&unsigned)
+            .unwrap()
+            .as_run::<Int32Type>()
+            .values()
+            .as_primitive::<UInt32Type>(),
+        &UInt32Array::from(vec![u32::MAX])
+    );
+}
+
+#[test]
+fn run_numeric_value_types() {
+    macro_rules! check {
+        ($t:ty) => {{
+            let values = PrimitiveArray::<$t>::from_iter_values([
+                <$t as ArrowPrimitiveType>::Native::usize_as(4),
+                <$t as ArrowPrimitiveType>::Native::usize_as(2),
+            ]);
+            let array =
+                RunArray::<Int32Type>::try_new(&Int32Array::from(vec![2, 5]), &values).unwrap();
+            for op in OPS {
+                let result = op(&array, &array).unwrap();
+                let result = result.as_run::<Int32Type>();
+                assert_eq!(result.run_ends().values(), &[2, 5]);
+                assert_eq!(
+                    result.values().to_data(),
+                    op(&values, &values).unwrap().to_data()
+                );
+            }
+        }};
+    }
+    check!(Int8Type);
+    check!(Int16Type);
+    check!(Int32Type);
+    check!(Int64Type);
+    check!(UInt8Type);
+    check!(UInt16Type);
+    check!(UInt32Type);
+    check!(UInt64Type);
+    check!(Float16Type);
+    check!(Float32Type);
+    check!(Float64Type);
+}
+
+#[test]
+fn run_float_ieee_semantics() {
+    let values = Float64Array::from(vec![Some(f64::NAN), Some(f64::INFINITY), Some(-0.0), None]);
+    let array =
+        RunArray::<Int64Type>::try_new(&Int64Array::from(vec![2, 5, 7, 9]), &values).unwrap();
+    let scalar = Float64Array::new_scalar(0.0);
+    for op in OPS {
+        let result = op(&array, &scalar).unwrap();
+        assert_eq!(
+            result.as_run::<Int64Type>().values().to_data(),
+            op(&values, &scalar).unwrap().to_data()
+        );
+    }
+}
+
+#[test]
+fn run_decimal_and_temporal_result_types() {
+    let values = Decimal128Array::from(vec![Some(1234), None, Some(-5678)])
+        .with_precision_and_scale(12, 2)
+        .unwrap();
+    let array = RunArray::<Int32Type>::try_new(&Int32Array::from(vec![2, 3, 5]), &values).unwrap();
+    let scalar = Scalar::new(
+        Decimal128Array::from(vec![200])
+            .with_precision_and_scale(8, 3)
+            .unwrap(),
+    );
+    for op in OPS {
+        let result = op(&array, &scalar).unwrap();
+        assert_eq!(
+            result.as_run::<Int32Type>().values().to_data(),
+            op(&values, &scalar).unwrap().to_data()
+        );
+    }
+    let values =
+        TimestampSecondArray::from(vec![Some(60), None, Some(120)]).with_timezone("+05:30");
+    let timestamps =
+        RunArray::<Int16Type>::try_new(&Int16Array::from(vec![2, 3, 5]), &values).unwrap();
+    let result = sub(&timestamps, &TimestampSecondArray::new_scalar(10)).unwrap();
+    assert_eq!(
+        result.as_run::<Int16Type>().values().data_type(),
+        &DataType::Duration(TimeUnit::Second)
+    );
+    assert_eq!(
+        result.as_run::<Int16Type>().values().to_data(),
+        sub(&values, &TimestampSecondArray::new_scalar(10))
+            .unwrap()
+            .to_data()
+    );
+    let delta = DurationSecondArray::new_scalar(5);
+    for result in [
+        add(&timestamps, &delta).unwrap(),
+        add(&delta, &timestamps).unwrap(),
+    ] {
+        assert_eq!(
+            result.as_run::<Int16Type>().values().to_data(),
+            add(&values, &delta).unwrap().to_data()
+        );
+    }
+    let result = sub(&timestamps.slice(5, 0), &timestamps.slice(0, 0)).unwrap();
+    assert_eq!(
+        result.as_run::<Int16Type>().values().data_type(),
+        &DataType::Duration(TimeUnit::Second)
+    );
+}
+
+#[test]
+fn run_errors_for_mismatched_lengths_and_types() {
+    let array = encode::<Int32Type>(&[Some(1), Some(1)]);
+    assert!(add(&array, &Int64Array::from(vec![1])).is_err());
+    assert!(add(&array, &encode::<Int32Type>(&[Some(1)])).is_err());
+    assert!(add(&array, &Float64Array::new_scalar(1.0)).is_err());
+    let strings =
+        RunArray::<Int32Type>::try_new(&Int32Array::from(vec![2]), &StringArray::from(vec!["x"]))
+            .unwrap();
+    assert!(add(&strings, &array).is_err());
+    assert!(neg(&strings).is_err());
+}
+
+#[test]
+fn run_large_logical_length_stays_compressed() {
+    let left = RunArray::<Int64Type>::try_new(
+        &Int64Array::from(vec![1_000_000_000]),
+        &Int64Array::from(vec![10]),
+    )
+    .unwrap();
+    let right = RunArray::<Int32Type>::try_new(
+        &Int32Array::from(vec![500_000_000, 1_000_000_000]),
+        &Int64Array::from(vec![1, 2]),
+    )
+    .unwrap();
+    let result = add(&left, &right).unwrap();
+    let result = result.as_run::<Int64Type>();
+    assert_eq!(result.len(), 1_000_000_000);
+    assert_eq!(result.values().len(), 2);
+    assert_eq!(
+        result.values().as_primitive::<Int64Type>(),
+        &Int64Array::from(vec![11, 12])
+    );
+    assert!(result.get_array_memory_size() < 4096);
+}

--- a/arrow-arith/tests/run_numeric.rs
+++ b/arrow-arith/tests/run_numeric.rs
@@ -305,10 +305,30 @@ fn run_float_ieee_semantics() {
     let scalar = Float64Array::new_scalar(0.0);
     for op in OPS {
         let result = op(&array, &scalar).unwrap();
-        assert_eq!(
-            result.as_run::<Int64Type>().values().to_data(),
-            op(&values, &scalar).unwrap().to_data()
-        );
+        let result = result.as_run::<Int64Type>();
+        assert_eq!(result.run_ends().values(), &[2, 5, 7, 9]);
+
+        let actual = result.values().as_primitive::<Float64Type>();
+        let expected = op(&values, &scalar).unwrap();
+        let expected = expected.as_primitive::<Float64Type>();
+        assert_eq!(actual.len(), expected.len());
+        assert_eq!(actual.nulls(), expected.nulls());
+        for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+            match (actual, expected) {
+                (Some(actual), Some(expected)) if expected.is_nan() => {
+                    assert!(actual.is_nan(), "value at index {index} is not NaN");
+                }
+                (Some(actual), Some(expected)) => {
+                    assert_eq!(
+                        actual.to_bits(),
+                        expected.to_bits(),
+                        "value at index {index}"
+                    );
+                }
+                (None, None) => {}
+                _ => unreachable!("null buffers were verified above"),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

- Closes #10891.

# Rationale for this change

Numeric kernels currently reject run-end encoded inputs. This prevents consumers such as DataFusion from applying arithmetic to compressed ordering columns without decoding them first.

# What changes are included in this PR?

- Route the checked, wrapping, division, remainder, and negation numeric entry points through a shared REE implementation.
- Preserve run boundaries for scalar operations and use the union of boundaries for two REE operands. Aligned inputs avoid gathering their physical values.
- Normalize sliced run ends, preserve primitive null/overflow/decimal/temporal semantics, and select the wider run-end integer type for two differently encoded operands.
- Return an explicit error for a REE array combined with a non-scalar unencoded array. That case would require expansion to produce a dense result and is outside this compression-preserving path. Direct arrow-arith numeric kernels also do not currently accept Dictionary arrays; encoded-type policy is under discussion.

# Are these changes tested?

Yes. The new differential tests compare decoded REE results with the existing primitive kernels across all public numeric operations, all run-end integer widths, integer/float/decimal/timestamp values, nulls, checked and wrapping overflow, division errors, unequal run boundaries, every slice offset in a deterministic matrix, empty inputs, and both scalar directions. A billion-row logical array test verifies work and result storage remain proportional to physical runs.

Local validation:

- `cargo test -p arrow-arith --all-features`: 239 unit tests, 13 integration tests, and 16 doctests passed.
- `cargo test --lib --tests --release -p arrow-arith`: 239 unit tests and 13 integration tests passed.
- `cargo test -p arrow --features=force_validate,prettyprint,ipc_compression,ffi,chrono-tz`: passed.
- `cargo clippy -p arrow-arith --all-targets --all-features -- -D warnings`: passed.
- `cargo +stable fmt --all -- --check`: passed.
- `cargo bench -p arrow-arith --bench run_arithmetic -- --quick`: passed.

The committed Criterion benchmark compares scalar, aligned-boundary, and staggered-boundary REE arithmetic with arithmetic over already-resident dense arrays at one million logical rows. On this machine, runs of 128 rows were 2.5x-13.7x faster and runs of 4096 rows were 68x-295x faster. Runs of 8 rows were 13%-6.5x slower, so this PR does not claim REE is beneficial for low-compression data. The billion-row test covers the non-expansion property deterministically.

The same integration test file was also run against the unmodified base: 12 of 13 tests failed because REE numeric operations were unsupported; only the invalid-input test passed.

# Are there any user-facing changes?

Yes. Numeric arithmetic and negation can now operate directly on REE arrays when the other operand is a scalar or REE array. The result remains run-end encoded. There are no public API signature changes.

AI disclosure: Codex assisted with repository research, implementation, test generation, performance analysis, and self-review. I reviewed the resulting behavior through differential tests, negative controls against the base revision, release-mode tests, strict Clippy, and the compression benchmark. The PR has not yet received a separate independent review from another human.

