### PR TITLE
refactor(schema): use REE field name constants

### DIFF
--- a/arrow-schema/src/datatype_parse.rs
+++ b/arrow-schema/src/datatype_parse.rs
@@ -1249,27 +1249,55 @@ mod test {
                 true,
             ),
             DataType::RunEndEncoded(
-                Arc::new(Field::new("run_ends", DataType::UInt32, false)),
-                Arc::new(Field::new("values", DataType::Int32, true)),
+                Arc::new(Field::new(
+                    Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
+                    DataType::UInt32,
+                    false,
+                )),
+                Arc::new(Field::new(
+                    Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                    DataType::Int32,
+                    true,
+                )),
             ),
             DataType::RunEndEncoded(
                 Arc::new(Field::new(
-                    "run_ends",
+                    Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
                     DataType::RunEndEncoded(
-                        Arc::new(Field::new("run_ends", DataType::UInt32, false)),
-                        Arc::new(Field::new("values", DataType::Int32, true)),
+                        Arc::new(Field::new(
+                            Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
+                            DataType::UInt32,
+                            false,
+                        )),
+                        Arc::new(Field::new(
+                            Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                            DataType::Int32,
+                            true,
+                        )),
                     ),
                     false,
                 )),
-                Arc::new(Field::new("values", DataType::Int32, true)),
+                Arc::new(Field::new(
+                    Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                    DataType::Int32,
+                    true,
+                )),
             ),
             // non-default field names trigger verbose display form
             DataType::RunEndEncoded(
                 Arc::new(Field::new(
-                    "run_ends",
+                    Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
                     DataType::RunEndEncoded(
-                        Arc::new(Field::new("run_ends", DataType::UInt32, false)),
-                        Arc::new(Field::new("values", DataType::Int32, true)),
+                        Arc::new(Field::new(
+                            Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
+                            DataType::UInt32,
+                            false,
+                        )),
+                        Arc::new(Field::new(
+                            Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                            DataType::Int32,
+                            true,
+                        )),
                     ),
                     false,
                 )),
@@ -1278,10 +1306,18 @@ mod test {
             // verbose form with non-null inner values
             DataType::RunEndEncoded(
                 Arc::new(Field::new(
-                    "run_ends",
+                    Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
                     DataType::RunEndEncoded(
-                        Arc::new(Field::new("run_ends", DataType::UInt32, false)),
-                        Arc::new(Field::new("values", DataType::Int32, false)),
+                        Arc::new(Field::new(
+                            Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
+                            DataType::UInt32,
+                            false,
+                        )),
+                        Arc::new(Field::new(
+                            Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                            DataType::Int32,
+                            false,
+                        )),
                     ),
                     false,
                 )),

--- a/arrow-schema/src/extension/canonical/timestamp_with_offset.rs
+++ b/arrow-schema/src/extension/canonical/timestamp_with_offset.rs
@@ -207,8 +207,16 @@ mod tests {
                 Field::new(
                     OFFSET_FIELD_NAME,
                     DataType::RunEndEncoded(
-                        Arc::new(Field::new("run_ends", run_ends_type, false)),
-                        Arc::new(Field::new("values", DataType::Int16, false)),
+                        Arc::new(Field::new(
+                            Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
+                            run_ends_type,
+                            false,
+                        )),
+                        Arc::new(Field::new(
+                            Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                            DataType::Int16,
+                            false,
+                        )),
                     ),
                     false,
                 ),
@@ -411,8 +419,16 @@ mod tests {
             Field::new(
                 OFFSET_FIELD_NAME,
                 DataType::RunEndEncoded(
-                    Arc::new(Field::new("run_ends", DataType::Boolean, false)),
-                    Arc::new(Field::new("values", DataType::Int16, false)),
+                    Arc::new(Field::new(
+                        Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
+                        DataType::Boolean,
+                        false,
+                    )),
+                    Arc::new(Field::new(
+                        Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                        DataType::Int16,
+                        false,
+                    )),
                 ),
                 false,
             ),
@@ -434,8 +450,16 @@ mod tests {
             Field::new(
                 OFFSET_FIELD_NAME,
                 DataType::RunEndEncoded(
-                    Arc::new(Field::new("run_ends", DataType::UInt16, false)),
-                    Arc::new(Field::new("values", DataType::Int32, false)),
+                    Arc::new(Field::new(
+                        Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
+                        DataType::UInt16,
+                        false,
+                    )),
+                    Arc::new(Field::new(
+                        Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                        DataType::Int32,
+                        false,
+                    )),
                 ),
                 false,
             ),

--- a/arrow-schema/src/ffi.rs
+++ b/arrow-schema/src/ffi.rs
@@ -1003,8 +1003,16 @@ mod tests {
             true,
         )])));
         round_trip_type(DataType::RunEndEncoded(
-            Arc::new(Field::new("run_ends", DataType::Int32, false)),
-            Arc::new(Field::new("values", DataType::Binary, true)),
+            Arc::new(Field::new(
+                Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
+                DataType::Int32,
+                false,
+            )),
+            Arc::new(Field::new(
+                Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                DataType::Binary,
+                true,
+            )),
         ));
     }
 

--- a/arrow-schema/src/fields.rs
+++ b/arrow-schema/src/fields.rs
@@ -695,8 +695,16 @@ mod tests {
             Field::new(
                 "i",
                 DataType::RunEndEncoded(
-                    Arc::new(Field::new("run_ends", DataType::Int32, false)),
-                    Arc::new(Field::new("values", DataType::Struct(floats.clone()), true)),
+                    Arc::new(Field::new(
+                        Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
+                        DataType::Int32,
+                        false,
+                    )),
+                    Arc::new(Field::new(
+                        Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                        DataType::Struct(floats.clone()),
+                        true,
+                    )),
                 ),
                 false,
             ),
@@ -726,8 +734,16 @@ mod tests {
             &Field::new(
                 "i",
                 DataType::RunEndEncoded(
-                    Arc::new(Field::new("run_ends", DataType::Int32, false)),
-                    Arc::new(Field::new("values", floats_a.clone(), true)),
+                    Arc::new(Field::new(
+                        Field::REE_RUN_ENDS_FIELD_DEFAULT_NAME,
+                        DataType::Int32,
+                        false
+                    )),
+                    Arc::new(Field::new(
+                        Field::REE_VALUES_FIELD_DEFAULT_NAME,
+                        floats_a.clone(),
+                        true
+                    )),
                 ),
                 false,
             )


### PR DESCRIPTION
Closes #11035

Assisted-by: Codex

## Summary

Use the existing REE default field-name constants wherever `arrow-schema` constructs fields with the default `run_ends` and `values` names. Intentional custom `named_values` parsing and display cases remain unchanged.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p arrow-schema` — 108 unit tests and 41 doctests passed.
- `cargo test -p arrow-schema --all-features` — 179 unit tests and 43 doctests passed.
- `cargo clippy -p arrow-schema --all-targets --all-features -- -D warnings`
- Manually exercised display/parse round trips for both the default REE schema and a custom `named_values` schema; each parsed back to the original data type.

## User-facing changes

None.

AI assistance was used to identify and apply the mechanical substitutions. I reviewed every changed construction and confirmed custom-name cases remain explicit.
