### PR TITLE
fix(arrow-array): deprecate FixedSizeListArray::value_offset, which wraps past i32::MAX

### DIFF
--- a/arrow-array/src/array/fixed_size_list_array.rs
+++ b/arrow-array/src/array/fixed_size_list_array.rs
@@ -371,9 +371,14 @@ impl FixedSizeListArray {
     /// Returns the offset for value at index `i`.
     ///
     /// Note this doesn't do any bound checking, for performance reason.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the offset exceeds `i32::MAX`.
+    #[deprecated(since = "60.1.0", note = "Use i * value_length() as usize instead")]
     #[inline]
     pub fn value_offset(&self, i: usize) -> i32 {
-        self.value_offset_at(i) as i32
+        i32::try_from(self.value_offset_at(i)).expect("offset overflow")
     }
 
     /// Returns the length for an element.
@@ -662,7 +667,6 @@ mod tests {
         assert_eq!(DataType::Int32, list_array.value_type());
         assert_eq!(3, list_array.len());
         assert_eq!(0, list_array.null_count());
-        assert_eq!(6, list_array.value_offset(2));
         assert_eq!(3, list_array.value_length());
         assert_eq!(0, list_array.value(0).as_primitive::<Int32Type>().value(0));
         for i in 0..3 {
@@ -684,7 +688,6 @@ mod tests {
         assert_eq!(2, list_array.len());
         assert_eq!(0, list_array.null_count());
         assert_eq!(3, list_array.value(0).as_primitive::<Int32Type>().value(0));
-        assert_eq!(3, list_array.value_offset(1));
         assert_eq!(3, list_array.value_length());
     }
 
@@ -745,7 +748,6 @@ mod tests {
         assert_eq!(DataType::Int32, list_array.value_type());
         assert_eq!(5, list_array.len());
         assert_eq!(2, list_array.null_count());
-        assert_eq!(6, list_array.value_offset(3));
         assert_eq!(2, list_array.value_length());
 
         let sliced_array = list_array.slice(1, 4);
@@ -760,14 +762,26 @@ mod tests {
             }
         }
 
-        // Check offset and length for each non-null value.
+        // Check where each non-null value starts, and its length.
         let sliced_list_array = sliced_array
             .as_any()
             .downcast_ref::<FixedSizeListArray>()
             .unwrap();
         assert_eq!(2, sliced_list_array.value_length());
-        assert_eq!(4, sliced_list_array.value_offset(2));
-        assert_eq!(6, sliced_list_array.value_offset(3));
+        assert_eq!(
+            6,
+            sliced_list_array
+                .value(2)
+                .as_primitive::<Int32Type>()
+                .value(0)
+        );
+        assert_eq!(
+            8,
+            sliced_list_array
+                .value(3)
+                .as_primitive::<Int32Type>()
+                .value(0)
+        );
     }
 
     #[test]

--- a/arrow-array/src/builder/fixed_size_list_builder.rs
+++ b/arrow-array/src/builder/fixed_size_list_builder.rs
@@ -310,7 +310,6 @@ mod tests {
         assert_eq!(DataType::Int32, list_array.value_type());
         assert_eq!(4, list_array.len());
         assert_eq!(1, list_array.null_count());
-        assert_eq!(6, list_array.value_offset(2));
         assert_eq!(3, list_array.value_length());
     }
 
@@ -323,7 +322,6 @@ mod tests {
         assert_eq!(DataType::Int32, list_array.value_type());
         assert_eq!(4, list_array.len());
         assert_eq!(0, list_array.null_count());
-        assert_eq!(6, list_array.value_offset(2));
         assert_eq!(3, list_array.value_length());
     }
 
@@ -336,7 +334,6 @@ mod tests {
         assert_eq!(DataType::Int32, list_array.value_type());
         assert_eq!(4, list_array.len());
         assert_eq!(1, list_array.null_count());
-        assert_eq!(6, list_array.value_offset(2));
         assert_eq!(3, list_array.value_length());
     }
 
@@ -383,7 +380,6 @@ mod tests {
         assert_eq!(DataType::Int32, list_array.value_type());
         assert_eq!(4, list_array.len());
         assert_eq!(1, list_array.null_count());
-        assert_eq!(6, list_array.value_offset(2));
         assert_eq!(3, list_array.value_length());
     }
 
@@ -405,7 +401,6 @@ mod tests {
         assert_eq!(DataType::Int32, list_array.value_type());
         assert_eq!(4, list_array.len());
         assert_eq!(1, list_array.null_count());
-        assert_eq!(6, list_array.value_offset(2));
         assert_eq!(3, list_array.value_length());
     }
 
@@ -442,7 +437,6 @@ mod tests {
         assert_eq!(DataType::Int32, list_array.value_type());
         assert_eq!(6, list_array.len());
         assert_eq!(2, list_array.null_count());
-        assert_eq!(6, list_array.value_offset(2));
         assert_eq!(3, list_array.value_length());
     }
 

--- a/arrow-avro/src/writer/encoder.rs
+++ b/arrow-avro/src/writer/encoder.rs
@@ -2100,7 +2100,6 @@ impl<'a, O: OffsetSizeTrait> ListViewEncoder<'a, O> {
 
 /// FixedSizeList encoder.
 struct FixedSizeListEncoder<'a> {
-    list: &'a FixedSizeListArray,
     values: FieldEncoder<'a>,
     values_offset: usize,
     elem_len: usize,
@@ -2113,7 +2112,6 @@ impl<'a> FixedSizeListEncoder<'a> {
         item_plan: &FieldPlan,
     ) -> Result<Self, AvroError> {
         Ok(Self {
-            list,
             values: FieldEncoder::make_encoder(
                 list.values().as_ref(),
                 item_plan,
@@ -2126,7 +2124,7 @@ impl<'a> FixedSizeListEncoder<'a> {
 
     fn encode<W: Write + ?Sized>(&mut self, out: &mut W, idx: usize) -> Result<(), AvroError> {
         // Starting index is relative to values() start
-        let rel = self.list.value_offset(idx) as usize;
+        let rel = idx * self.elem_len;
         let start = self.values_offset + rel;
         let end = start + self.elem_len;
         encode_blocked_range(out, start, end, |out, row| {
@@ -2551,6 +2549,34 @@ mod tests {
         expected.extend(avro_long_bytes(1));
         expected.extend(avro_long_bytes(3));
         expected.extend(avro_long_bytes(0));
+
+        let plan = FieldPlan::List {
+            items_nullability: None,
+            item_plan: Box::new(FieldPlan::Scalar),
+        };
+        let got = encode_all(&list, &plan, None);
+        assert_bytes_eq(&got, &expected);
+    }
+
+    #[test]
+    fn fixed_size_list_encoder_int32_sliced() {
+        // [[1, 2], [3, 4], [5, 6]] sliced to [[3, 4], [5, 6]]
+        let values = Int32Array::from(vec![1, 2, 3, 4, 5, 6]);
+        let list = FixedSizeListArray::new(
+            Field::new("item", DataType::Int32, true).into(),
+            2,
+            Arc::new(values) as ArrayRef,
+            None,
+        )
+        .slice(1, 2);
+        let mut expected = Vec::new();
+        for row in [[3, 4], [5, 6]] {
+            expected.extend(avro_long_bytes(2));
+            for value in row {
+                expected.extend(avro_long_bytes(value));
+            }
+            expected.extend(avro_long_bytes(0));
+        }
 
         let plan = FieldPlan::List {
             items_nullability: None,

--- a/arrow-select/src/take.rs
+++ b/arrow-select/src/take.rs
@@ -1467,7 +1467,9 @@ where
                 .value(i)
                 .to_usize()
                 .ok_or_else(|| ArrowError::ComputeError("Cast to usize failed".to_string()))?;
-            let start = list.value_offset(index) as <UInt32Type as ArrowPrimitiveType>::Native;
+            let start = u32::try_from(index * list.value_length() as usize).map_err(|_| {
+                ArrowError::ComputeError("FixedSizeList offset overflows u32".to_string())
+            })?;
 
             // Safety: Range always has known length.
             unsafe {


### PR DESCRIPTION
### Which issue does this PR close?

- Closes #11059.

### Rationale for this change

FixedSizeListArray::value_offset casts a usize offset to i32, so once a row starts past i32::MAX child values it returns a negative number. the avro FixedSizeList encoder cast that back to usize and panicked writing the batch.

### What changes are included in this PR?

- deprecate value_offset in favour of i * value_length() as usize, same as FixedSizeBinaryArray::value_offset in #9910, and panic instead of wrapping
- the avro encoder uses idx * elem_len instead
- take_value_indices_from_fixed_size_list computes the offset in usize and returns an error when it doesn't fit u32
- the value_offset asserts come out of the tests, and the slice test checks row values instead

### Are these changes tested?

yes. fixed_size_list_encoder_int32_sliced is new and covers the avro change. the overflow itself needs 384 MiB so it isn't a unit test, but the repro from the issue panics on 59.3.0 and writes the batch on this branch. arrow-array 972, arrow-select 446 and arrow-avro 515 tests pass, and clippy is clean.

### Are there any user-facing changes?

FixedSizeListArray::value_offset is deprecated and panics past i32::MAX. take on a FixedSizeList returns an error past u32::MAX instead of wrapping.
