### PR TITLE
perf(filter): batch bitmap extraction for auto-vectorization

### DIFF
--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -677,11 +677,8 @@ where
     RunArray::try_new(&run_ends, &values)
 }
 
-/// Extract bits from `src` at positions where `filter` has a 1, packed densely.
-///
-/// Processes 64 filter bits per iteration: one u64 load from each buffer, then
-/// software PEXT to scatter the selected source bits. This reduces source reads
-/// from O(selected_count) byte loads to O(filter_len/64) u64 loads.
+/// Extract bits from `src` at positions where `filter` has a 1, packed densely,
+/// processing 64 filter bits at a time
 fn gather_bits(src: &BooleanBuffer, filter: &BooleanBuffer, count: usize) -> Buffer {
     let filter_chunks = filter.bit_chunks();
     let src_chunks = BitChunks::new(src.values(), src.offset(), filter.len());
@@ -689,24 +686,22 @@ fn gather_bits(src: &BooleanBuffer, filter: &BooleanBuffer, count: usize) -> Buf
     let out_u64s = bit_util::ceil(count, 64);
     let mut out: Vec<u64> = Vec::with_capacity(out_u64s);
     let mut current_word = 0u64;
-    let mut bits_filled = 0usize; // bits written into `current_word` so far (0..=63)
+    let mut bits_filled = 0usize;
 
     // Appends `bits_selected` densely-packed bits from `selected_bits` into the output word stream.
     let mut push_chunk = |selected_bits: u64, bits_selected: usize| {
         let bits_remaining = 64 - bits_filled;
-        if bits_selected <= bits_remaining {
-            current_word |= selected_bits << bits_filled;
+        current_word |= selected_bits << bits_filled;
+        if bits_selected < bits_remaining {
             bits_filled += bits_selected;
-            if bits_filled == 64 {
-                out.push(current_word);
-                current_word = 0;
-                bits_filled = 0;
-            }
         } else {
-            // Fill the current word with the lower `bits_remaining` bits, then start the next word.
-            current_word |= selected_bits << bits_filled; // upper bits of selected_bits shift off; kept in >> below
+            // Current word is full; carry the overflow into the next word.
             out.push(current_word);
-            current_word = selected_bits >> bits_remaining;
+            current_word = if bits_selected == bits_remaining {
+                0
+            } else {
+                selected_bits >> bits_remaining
+            };
             bits_filled = bits_selected - bits_remaining;
         }
     };

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -26,6 +26,7 @@ use arrow_array::types::{
     ArrowDictionaryKeyType, ArrowPrimitiveType, ByteArrayType, ByteViewType, RunEndIndexType,
 };
 use arrow_array::*;
+use arrow_buffer::bit_chunk_iterator::BitChunks;
 use arrow_buffer::{
     ArrowNativeType, BooleanBuffer, NullBuffer, OffsetBuffer, RunEndBuffer, ScalarBuffer, bit_util,
 };
@@ -676,6 +677,79 @@ where
     RunArray::try_new(&run_ends, &values)
 }
 
+/// Extract bits from `src` at positions where `filter` has a 1, packed densely.
+///
+/// Processes 64 filter bits per iteration: one u64 load from each buffer, then
+/// software PEXT to scatter the selected source bits. This reduces source reads
+/// from O(selected_count) byte loads to O(filter_len/64) u64 loads.
+fn gather_bits(src: &BooleanBuffer, filter: &BooleanBuffer, count: usize) -> Buffer {
+    let filter_chunks = filter.bit_chunks();
+    let src_chunks = BitChunks::new(src.values(), src.offset(), filter.len());
+
+    let out_u64s = bit_util::ceil(count, 64);
+    let mut out: Vec<u64> = Vec::with_capacity(out_u64s);
+    let mut out_word = 0u64;
+    let mut out_bits = 0usize; // bits written into `out_word` so far (0..=63)
+
+    macro_rules! push_chunk {
+        ($compressed:expr, $n_set:expr) => {{
+            let free = 64 - out_bits;
+            if $n_set <= free {
+                out_word |= $compressed << out_bits;
+                out_bits += $n_set;
+                if out_bits == 64 {
+                    out.push(out_word);
+                    out_word = 0;
+                    out_bits = 0;
+                }
+            } else {
+                // Fill the current word with the lower `free` bits, then start the next word.
+                out_word |= $compressed << out_bits; // upper bits of compressed shift off; kept in >> below
+                out.push(out_word);
+                out_word = $compressed >> free;
+                out_bits = $n_set - free;
+            }
+        }};
+    }
+
+    for (filter_word, src_word) in filter_chunks.iter().zip(src_chunks.iter()) {
+        if filter_word == 0 {
+            continue;
+        }
+        let n_set = filter_word.count_ones() as usize;
+        push_chunk!(pext64(src_word, filter_word), n_set);
+    }
+
+    let rem_filter = filter_chunks.remainder_bits();
+    if rem_filter != 0 {
+        let n_set = rem_filter.count_ones() as usize;
+        push_chunk!(pext64(src_chunks.remainder_bits(), rem_filter), n_set);
+    }
+
+    if out_bits > 0 {
+        out.push(out_word);
+    }
+
+    let mut buf: MutableBuffer = out.into();
+    buf.truncate(bit_util::ceil(count, 8));
+    buf.into()
+}
+
+/// Software parallel-bits-extract (PEXT): pack the bits of `val` at positions
+/// where `mask` has a 1 into the low bits of the result, in LSB-first order.
+#[inline(always)]
+fn pext64(val: u64, mut mask: u64) -> u64 {
+    let mut result = 0u64;
+    let mut dst = 0u32;
+    while mask != 0 {
+        let bit = mask.trailing_zeros();
+        result |= ((val >> bit) & 1) << dst;
+        dst += 1;
+        mask &= mask - 1;
+    }
+    result
+}
+
 /// Filter the packed bitmask `buffer`, with `predicate` starting at bit offset `offset`
 fn filter_bits(buffer: &BooleanBuffer, predicate: &FilterPredicate) -> Buffer {
     let src = buffer.values();
@@ -684,22 +758,20 @@ fn filter_bits(buffer: &BooleanBuffer, predicate: &FilterPredicate) -> Buffer {
 
     match &predicate.strategy {
         IterationStrategy::IndexIterator => {
-            let bits =
-                // SAFETY: IndexIterator uses the filter predicate to derive indices
-                IndexIterator::new(&predicate.filter, predicate.count).map(|src_idx| unsafe {
-                    bit_util::get_bit_raw(buffer.values().as_ptr(), src_idx + offset)
-                });
-
-            // SAFETY: `IndexIterator` reports its size correctly
-            unsafe { MutableBuffer::from_trusted_len_iter_bool(bits).into() }
+            gather_bits(buffer, predicate.filter.values(), predicate.count)
         }
         IterationStrategy::Indices(indices) => {
-            // SAFETY: indices were derived from the filter predicate
-            let bits = indices.iter().map(|src_idx| unsafe {
-                bit_util::get_bit_raw(buffer.values().as_ptr(), *src_idx + offset)
-            });
-            // SAFETY: `Vec::iter()` reports its size correctly
-            unsafe { MutableBuffer::from_trusted_len_iter_bool(bits).into() }
+            // gather_bits scans every filter chunk (filter_len/64 u64 loads).
+            // For very sparse selections the precomputed Vec is smaller and cheaper to walk.
+            // Threshold: switch when the selected count exceeds one u64 per filter chunk.
+            if predicate.count.saturating_mul(64) >= predicate.filter.len() {
+                gather_bits(buffer, predicate.filter.values(), predicate.count)
+            } else {
+                let bits = indices.iter().map(|src_idx| unsafe {
+                    bit_util::get_bit_raw(buffer.values().as_ptr(), *src_idx + offset)
+                });
+                unsafe { MutableBuffer::from_trusted_len_iter_bool(bits).into() }
+            }
         }
         IterationStrategy::SlicesIterator => {
             let mut builder = BooleanBufferBuilder::new(predicate.count);

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -734,19 +734,20 @@ fn gather_bits(src: &BooleanBuffer, filter: &BooleanBuffer, count: usize) -> Buf
     buf.into()
 }
 
-/// Software parallel-bits-extract (PEXT): pack the bits of `val` at positions
-/// where `mask` has a 1 into the low bits of the result, in LSB-first order.
+/// Collects the bits of `val` wherever `mask` is 1, packed into the low bits of the result.
 #[inline(always)]
 fn pext64(val: u64, mut mask: u64) -> u64 {
-    let mut result = 0u64;
-    let mut dst = 0u32;
+    let mut packed = 0u64;
+    let mut out_bit = 0u32;
+    // Each iteration finds the lowest set bit in mask, copies the corresponding bit from val
+    // into the next output position, then clears that mask bit to advance to the next one.
     while mask != 0 {
-        let bit = mask.trailing_zeros();
-        result |= ((val >> bit) & 1) << dst;
-        dst += 1;
+        let src_bit = mask.trailing_zeros();
+        packed |= ((val >> src_bit) & 1) << out_bit;
+        out_bit += 1;
         mask &= mask - 1;
     }
-    result
+    packed
 }
 
 /// Filter the packed bitmask `buffer`, with `predicate` starting at bit offset `offset`

--- a/arrow-select/src/filter.rs
+++ b/arrow-select/src/filter.rs
@@ -688,46 +688,45 @@ fn gather_bits(src: &BooleanBuffer, filter: &BooleanBuffer, count: usize) -> Buf
 
     let out_u64s = bit_util::ceil(count, 64);
     let mut out: Vec<u64> = Vec::with_capacity(out_u64s);
-    let mut out_word = 0u64;
-    let mut out_bits = 0usize; // bits written into `out_word` so far (0..=63)
+    let mut current_word = 0u64;
+    let mut bits_filled = 0usize; // bits written into `current_word` so far (0..=63)
 
-    macro_rules! push_chunk {
-        ($compressed:expr, $n_set:expr) => {{
-            let free = 64 - out_bits;
-            if $n_set <= free {
-                out_word |= $compressed << out_bits;
-                out_bits += $n_set;
-                if out_bits == 64 {
-                    out.push(out_word);
-                    out_word = 0;
-                    out_bits = 0;
-                }
-            } else {
-                // Fill the current word with the lower `free` bits, then start the next word.
-                out_word |= $compressed << out_bits; // upper bits of compressed shift off; kept in >> below
-                out.push(out_word);
-                out_word = $compressed >> free;
-                out_bits = $n_set - free;
+    // Appends `bits_selected` densely-packed bits from `selected_bits` into the output word stream.
+    let mut push_chunk = |selected_bits: u64, bits_selected: usize| {
+        let bits_remaining = 64 - bits_filled;
+        if bits_selected <= bits_remaining {
+            current_word |= selected_bits << bits_filled;
+            bits_filled += bits_selected;
+            if bits_filled == 64 {
+                out.push(current_word);
+                current_word = 0;
+                bits_filled = 0;
             }
-        }};
-    }
+        } else {
+            // Fill the current word with the lower `bits_remaining` bits, then start the next word.
+            current_word |= selected_bits << bits_filled; // upper bits of selected_bits shift off; kept in >> below
+            out.push(current_word);
+            current_word = selected_bits >> bits_remaining;
+            bits_filled = bits_selected - bits_remaining;
+        }
+    };
 
     for (filter_word, src_word) in filter_chunks.iter().zip(src_chunks.iter()) {
         if filter_word == 0 {
             continue;
         }
         let n_set = filter_word.count_ones() as usize;
-        push_chunk!(pext64(src_word, filter_word), n_set);
+        push_chunk(pext64(src_word, filter_word), n_set);
     }
 
     let rem_filter = filter_chunks.remainder_bits();
     if rem_filter != 0 {
         let n_set = rem_filter.count_ones() as usize;
-        push_chunk!(pext64(src_chunks.remainder_bits(), rem_filter), n_set);
+        push_chunk(pext64(src_chunks.remainder_bits(), rem_filter), n_set);
     }
 
-    if out_bits > 0 {
-        out.push(out_word);
+    if bits_filled > 0 {
+        out.push(current_word);
     }
 
     let mut buf: MutableBuffer = out.into();
@@ -761,9 +760,6 @@ fn filter_bits(buffer: &BooleanBuffer, predicate: &FilterPredicate) -> Buffer {
             gather_bits(buffer, predicate.filter.values(), predicate.count)
         }
         IterationStrategy::Indices(indices) => {
-            // gather_bits scans every filter chunk (filter_len/64 u64 loads).
-            // For very sparse selections the precomputed Vec is smaller and cheaper to walk.
-            // Threshold: switch when the selected count exceeds one u64 per filter chunk.
             if predicate.count.saturating_mul(64) >= predicate.filter.len() {
                 gather_bits(buffer, predicate.filter.values(), predicate.count)
             } else {


### PR DESCRIPTION
# Which issue does this PR close?

Related to #11055. This draft builds on Richard's changes at `4727e6a654d28f6371a9fd352a34d8a77af9c0e8` and includes those commits. The measurements below compare against that PR head, not against `main`.

# Rationale for this change

Filtering a bitmap requires gathering the selected bits from each input word and concatenating the resulting fragments. Finishing one word's variable-length extraction loop before starting the next leaves this work scalar in the inspected builds.

This draft processes eight words together, advancing one selected bit per active lane per iteration. It exposes independent operations across words to LLVM's vectorizer while keeping the implementation in stable, portable Rust. A batch runs until its largest mask population count is exhausted, so shorter lanes can do idle work; the sparse tradeoff still needs evaluation.

# What changes are included in this PR?

- Extract eight independent `u64` fragments by testing each mask's lowest set bit and conditionally OR-ing a shared destination bit into the lane's result. Empty masks naturally contribute zero.
- Pack each batch immediately using stack arrays and the masks' population counts. There is no input-sized fragment allocation.
- Preallocate the output, write the current partial word, and advance its index when it fills. Handle carry shifts without shifting by 64 and store words in little-endian byte order.
- Retain the original scalar `pext64` for leftover words and the final partial word.
- Cover differing lane lengths, empty/full masks, zero-valued fragments, unaligned buffers, longer sources, and word/batch boundaries.

The batch helper is kept as a separate optimization unit with `#[inline(never)]`. There are no ISA intrinsics, CPU-feature dispatch branches, or unstable Rust APIs.

# Are these changes tested?

- `cargo test -p arrow-select --lib --release --offline`: all 432 tests passed.
- Separate generic/native boundary checks passed 15,300 variant/oracle comparisons per build. Benchmark inputs were also checked before timing.
- Formatting and `git diff --check` passed.

Local exploratory measurements of full Boolean filtering, 65,536 rows, in microseconds (lower is better):

| Build | Selected | Filter reuse | #11055 | This draft |
|---|---:|---|---:|---:|
| Generic x86-64 | 10% | repeated | 3.76 | 5.94 |
| Generic x86-64 | 10% | cycling | 9.78 | 6.31 |
| Generic x86-64 | 50% | repeated | 18.54 | 17.05 |
| Generic x86-64 | 50% | cycling | 20.56 | 17.23 |
| Generic x86-64 | 79% | repeated | 28.92 | 24.02 |
| Generic x86-64 | 79% | cycling | 29.27 | 24.08 |
| Native Ryzen | 10% | repeated | 4.01 | 3.34 |
| Native Ryzen | 10% | cycling | 8.94 | 3.93 |
| Native Ryzen | 50% | repeated | 23.33 | 8.60 |
| Native Ryzen | 50% | cycling | 25.53 | 9.19 |
| Native Ryzen | 79% | repeated | 41.16 | 11.97 |
| Native Ryzen | 79% | cycling | 41.39 | 12.08 |

Ryzen AI 9 HX PRO 470; rustc 1.98.1 / LLVM 22.1.8. The native build uses `RUSTFLAGS="-C target-cpu=native"` for the harness and dependencies; the generic build has no CPU override. Each build compares the implementations in one executable, pinned to CPU 2, with rotated order over 21 rounds and approximately 3 ms per variant per round. Numbers are median thread CPU time, including allocation and excluding input/predicate construction. Repeated reuses one bitmap; cycling uses 64 prebuilt bitmaps. These are exploratory harness results, not Criterion confidence intervals, and thread CPU time does not eliminate clock/cache interference.

The generic repeated 10% case regresses. Very sparse direct-gather cases also remain a concern; optimized sparse filtering may bypass this kernel.

Inspection of the extraction loop found scalar conditional moves in the final generic x86 build and ZMM SIMD in the native build. Standalone Rust probes produce YMM SIMD with `target-cpu=x86-64-v3` and NEON for both generic AArch64 and `target-cpu=neoverse-v2`. ARM results are code-generation checks only: no ARM performance measurements or inspection of the bot's compiled binary yet.

# Are there any user-facing changes?

Filtering results and public APIs are unchanged. This draft changes performance and needs further evaluation, particularly on the ARM benchmark runner and sparse workloads.
